### PR TITLE
chore: absorb secure-agent-kali into agent-images

### DIFF
--- a/docs/findings/2026-04-18-remote-control-shutdown.md
+++ b/docs/findings/2026-04-18-remote-control-shutdown.md
@@ -1,0 +1,198 @@
+# Remote-Control Shutdown — Findings
+
+Phase 0 spike for the `persistent-agent-reliability` plan. Goal: determine
+whether the `claude` CLI offers a clean way to disconnect a remote-control
+session so the persistent agent stops accumulating phantom sessions in
+claude.ai.
+
+Investigation environment: `claude` 2.1.114 inside the agent pod
+(`/home/claude/.local/share/claude/versions/2.1.114`, 236 MB statically
+linked binary).
+
+## CLI surface
+
+`claude --help` and `claude remote-control --help` were inspected. Relevant
+remote-control flags exist on the `claude` top level and on the subcommand:
+
+```
+--remote-control-session-name-prefix <prefix>
+    Prefix for auto-generated Remote Control session names
+    (default: hostname; env: CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX)
+```
+
+`claude remote-control --help` documents only `--name`, `--spawn`,
+`--capacity`, `--permission-mode`, `--debug-file`, `--verbose`, and
+`--[no-]create-session-in-dir`. **No subcommand for `list`, `close`,
+`disconnect`, `stop`, or `rm` exists**:
+
+```
+$ claude remote-control list
+Error: Unknown argument: list
+$ claude remote-control close
+Error: Unknown argument: close
+```
+
+`claude auth` only exposes `login`, `logout`, `status` — nothing
+session-aware.
+
+In short: **no public CLI affordance for remotely closing a specific
+remote-control session by name or id.**
+
+## State dir
+
+`~/.claude/` contains the expected layout. The two interesting
+subdirectories:
+
+- `~/.claude/sessions/<pid>.json` — one entry per *currently running* CLI
+  process. Schema:
+  `{pid, sessionId (uuid), cwd, startedAt, version, kind, entrypoint}`.
+  This is purely an in-process registry — restarts of the agent leave no
+  stale entries here.
+- `~/.claude/session-env/<uuid>/` — **1 123 empty directories** on the
+  inspected pod. These are per-session scratch dirs that the CLI creates
+  when a session starts but never removes on exit. They do not contain the
+  remote `environment_id` returned by the bridge API; they are local
+  bookkeeping only.
+
+The bridge environment id is *not* persisted to a stable file the operator
+can grep for. The CLI writes a `bridge-pointer.json` under
+`~/.claude/projects/<encoded-cwd>/bridge-pointer.json` while a bridge is
+active (encoder logic: `kD$.join(s8(), "projects", IJ(cwd))`). On the
+inspected pod no such file exists — the agent's bridge sessions had
+already exited by the time we looked. The pointer is removed by the CLI's
+own graceful-shutdown handler (`clearBridgePointer(dir)`), so it is
+present only while the bridge process is alive.
+
+The 1 123 empty `session-env/` dirs are a separate accumulation bug
+(per-session scratch space that is never cleaned up). They are local
+disk noise but not the cause of the phantom claude.ai sessions.
+
+## Server endpoint
+
+A clean disconnect endpoint **does exist**, even though it is not surfaced
+on the CLI. Strings extracted from the binary include the bridge HTTP
+client:
+
+```
+[bridge:api] POST   /v1/environments/bridge        (registerBridgeEnvironment)
+[bridge:api] DELETE /v1/environments/bridge/<env_id>   (deregisterEnvironment)
+[bridge:api] POST   /v1/sessions/<id>/archive          (archiveSession)
+[bridge:api] POST   /v1/environments/<env>/work/<id>/stop  (stopWork)
+```
+
+The CLI's own shutdown path uses these. Decompiled inline from the binary
+(string-extracted, formatting cleaned up):
+
+```js
+[bridge:shutdown] Shutting down ${D.size} active session(s)
+[bridge:shutdown] Sending SIGTERM to sessionId=${e}
+[bridge:shutdown] Force-killing stuck sessionId=${e}
+[bridge:shutdown] Cleaning up ${e.length} worktree(s)
+…
+await K.deregisterEnvironment($)
+[bridge:shutdown] Environment deregistered, bridge offline
+await clearBridgePointer(H.dir)
+```
+
+The handler is wired to `SIGTERM` at top level:
+
+```js
+process.on("SIGTERM", () => {
+    A8("info","shutdown_signal",{signal:"SIGTERM"});
+    w7(143);
+});
+```
+
+Where `w7(143)` is the graceful exit path that drains `bridge:shutdown`
+above — i.e. **a SIGTERM delivered to the `claude remote-control` process
+itself triggers `DELETE /v1/environments/bridge/<env_id>` against the
+Anthropic API and removes the local pointer.**
+
+Auth headers used by `deregisterEnvironment` are the same OAuth bearer
+already cached in `~/.claude/.credentials.json`, plus
+`x-organization-uuid`. There is no separate setup the agent needs.
+
+Bottom line: the *capability* is there. The *bug* is that the agent never
+gets to invoke it — the supervisor wrapper hides the right PID and the pod
+shutdown path doesn't deliver SIGTERM to claude.
+
+## Signal behavior
+
+Live SIGTERM/SIGINT testing was deferred — running a real
+`claude remote-control` from the spike pod would create a real environment
+in claude.ai (the user's account), and if the signal handler reasoning
+below is wrong the test itself would leave a phantom. The static evidence
+above is sufficient to decide Phase 1's direction; Phase 1 verifies
+empirically when implementing `shutdown.sh`.
+
+The relevant structural problem is in the existing supervisor.
+`scripts/session-manager.sh` starts each bridge as:
+
+```bash
+nohup bash -c "echo y | claude remote-control --name '$SESSION_NAME'" \
+  >> "...session-${SESSION_NAME}.log" 2>&1 &
+echo $! > "$PIDFILE"
+```
+
+The PID written to `$PIDFILE` is the wrapper `bash -c`, not `claude`.
+On `kill -TERM "$(cat $PIDFILE)"`:
+
+- `bash` receives SIGTERM. It does not forward signals to children of a
+  pipeline by default. `bash -c '<pipeline>'` exits, the pipeline is left
+  to finish or get reaped, and `claude`'s own SIGTERM handler is
+  **not** invoked by our kill.
+- Even if claude eventually exits, it exits because its stdin/stdout
+  closed, not because of SIGTERM — that path goes through process exit
+  cleanup, not the documented `bridge:shutdown` handler. The remote
+  bridge is not deregistered.
+- On pod termination, Kubernetes sends SIGTERM to PID 1 (here:
+  vibe-kanban or supercronic depending on context); orphaned `claude`
+  processes get SIGKILL after the grace period — also no clean shutdown.
+
+This matches the symptom: phantoms accumulate one-per-restart in
+claude.ai.
+
+The fix has two parts:
+
+1. **Make the tracked PID == claude's PID.** Replace the wrapper with
+   `exec`, e.g.
+   `nohup bash -c "exec claude remote-control --name '$SESSION_NAME' < <(echo y)" …`
+   so `bash` is replaced in-place by `claude`. Now `kill -TERM
+   "$(cat $PIDFILE)"` reaches the claude process directly and its
+   internal SIGTERM handler runs `bridge:shutdown` → DELETE
+   `/v1/environments/bridge/<env_id>`.
+2. **Add a pod-level shutdown hook** (`scripts/shutdown.sh`) that loops
+   over `$PIDDIR/*.pid` and sends SIGTERM, then waits up to ~30 s
+   (bridge:shutdown's `loop_grace_ms` default) before SIGKILL. Wire it as
+   a Kubernetes `preStop` hook on the agent deployment in
+   `derio-net/frank` so the pod actually gets a chance to deregister
+   before SIGKILL.
+
+The Frank deployment change is filed as a separate Issue against
+`derio-net/frank`, per the plan's architecture note — not part of this
+plan's PR chain.
+
+## Decision for Phase 1
+
+**Chosen: A (close API available).**
+
+Reason: The CLI bundles a working bridge-deregister code path
+(`DELETE /v1/environments/bridge/<env_id>` invoked from
+`[bridge:shutdown]`) and wires it to `SIGTERM`. We do not need to
+reverse-engineer or reimplement that endpoint. We need only deliver
+SIGTERM to the right PID and give the process time to drain. Concretely
+Phase 1 should:
+
+- Change `session-manager.sh` to launch claude via `exec` so `$PIDFILE`
+  records claude's PID (not bash's).
+- Add `scripts/shutdown.sh` that iterates the PID dir, sends SIGTERM,
+  waits ≤30 s per process, then SIGKILL as fallback.
+- File a separate Issue against `derio-net/frank` to wire `shutdown.sh`
+  as a `preStop` hook with a `terminationGracePeriodSeconds` ≥ 35.
+- Independent cleanup for the 1 123 stale `~/.claude/session-env/<uuid>/`
+  dirs (cron job that prunes empty ones older than N hours) belongs in
+  the housekeeping batch — it is unrelated to phantoms in claude.ai.
+- Verify empirically during Phase 1 implementation: start a bridge,
+  capture the claude PID directly, send SIGTERM, confirm the
+  `claude.ai/code` UI shows the session disappear within 30 s and that
+  `bridge-pointer.json` is removed.

--- a/docs/superpowers/archived-plans/2026-04-14-bridge-fail-loud-and-blocker-preamble.md
+++ b/docs/superpowers/archived-plans/2026-04-14-bridge-fail-loud-and-blocker-preamble.md
@@ -1,0 +1,518 @@
+# Bridge Fail Loud And Blocker Preamble Implementation Plan
+
+> **For VK agents:** Use vk-execute to implement assigned phases.
+> **For local execution:** Use subagent-driven-development or executing-plans.
+> **For dispatch:** Use vk-dispatch to create Issues from this plan.
+
+**Spec:** `docs/superpowers/specs/2026-04-14-archive-and-unified-descriptions-design.md` (in derio-net/superpowers-for-vk)
+**Status:** Not Started
+
+**Goal:** Remove silent failure paths in `vk-issue-bridge.py` so parse/check errors fail loudly with actionable messages, and add a blocker-verification preamble to the workspace starting prompt so spawned agents refuse to duplicate upstream work.
+**Architecture:** All changes live in `scripts/vk-issue-bridge.py`. This plan bootstraps a minimal `tests/test_vk_issue_bridge.py` harness. After merge, the cron-managed copy at `/opt/scripts/vk-issue-bridge.py` is redeployed in Phase 3.
+**Tech Stack:** Python 3.11+, pytest
+
+---
+
+## Phase 0: Test bootstrap and fail-loud parse_dependencies [agentic]
+<!-- Tracking: https://github.com/derio-net/secure-agent-kali/issues/8 -->
+
+### Task 1: Bootstrap test harness for the bridge
+
+**Files:**
+- Create: `tests/test_vk_issue_bridge.py`
+- Create: `tests/__init__.py` (if missing)
+
+- [ ] **Step 1: Confirm test layout**
+
+```bash
+ls tests/ 2>&1
+```
+
+If missing:
+
+```bash
+mkdir -p tests && touch tests/__init__.py
+```
+
+Verify pytest:
+
+```bash
+python -m pytest --version 2>&1
+```
+
+If missing, install via the project's normal path (e.g. `uv pip install pytest` or equivalent).
+
+- [ ] **Step 2: Write initial import test**
+
+Create `tests/test_vk_issue_bridge.py`:
+
+```python
+"""Tests for vk-issue-bridge.py fail-loud behavior."""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+BRIDGE_PATH = Path(__file__).parent.parent / "scripts" / "vk-issue-bridge.py"
+
+
+def _load_bridge():
+    """Load vk-issue-bridge.py as a module named 'vk_issue_bridge'."""
+    os.environ.setdefault("VK_ORG_ID", "test")
+    os.environ.setdefault("VK_DERIO_OPS_PROJECT_ID", "test")
+    spec = importlib.util.spec_from_file_location("vk_issue_bridge", BRIDGE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["vk_issue_bridge"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_bridge_module_loads():
+    mod = _load_bridge()
+    assert hasattr(mod, "parse_dependencies")
+    assert hasattr(mod, "check_blockers")
+    assert hasattr(mod, "build_prompt")
+```
+
+Run: `python -m pytest tests/test_vk_issue_bridge.py -x 2>&1 | tail -10`. Expected: pass.
+
+### Task 2: Fail loud when phase>0 has no parseable dependencies
+
+**Files:**
+- Modify: `scripts/vk-issue-bridge.py`
+- Modify: `tests/test_vk_issue_bridge.py`
+
+- [ ] **Step 1: Failing test — parse_dependencies gates on phase_number**
+
+Append:
+
+```python
+class TestParseDependenciesFailLoud:
+    def test_empty_deps_for_phase_zero_is_fine(self):
+        mod = _load_bridge()
+        assert mod.parse_dependencies(
+            "## Dependencies\n\nNone — no blocking phases.\n",
+            phase_number=0,
+        ) == []
+
+    def test_empty_deps_for_phase_n_raises(self):
+        mod = _load_bridge()
+        body = "## Dependencies\n\nSome prose without a dash-Blocked-by line.\n"
+        with pytest.raises(ValueError, match="no parseable"):
+            mod.parse_dependencies(body, phase_number=2)
+
+    def test_missing_dependencies_section_for_phase_n_raises(self):
+        mod = _load_bridge()
+        with pytest.raises(ValueError, match="Dependencies"):
+            mod.parse_dependencies("## Instruction\n\nDo stuff.\n", phase_number=1)
+
+    def test_valid_dash_blocker_for_phase_n_parses(self):
+        mod = _load_bridge()
+        assert mod.parse_dependencies(
+            "## Dependencies\n\n- Blocked by #42\n",
+            phase_number=1,
+        ) == [(None, 42)]
+```
+
+Run: expected TypeError (`parse_dependencies` takes one arg).
+
+- [ ] **Step 2: Add phase_number parameter with fail-loud logic**
+
+Replace `parse_dependencies` (scripts/vk-issue-bridge.py lines 169–192) with:
+
+```python
+def parse_dependencies(
+    body: str,
+    phase_number: int | None = None,
+) -> list[tuple[str | None, int]]:
+    """Extract issue references from the ## Dependencies section.
+
+    Matches '- Blocked by #N' (same-repo) or '- Blocked by owner/repo#N' (cross-repo).
+
+    Fail-loud: when ``phase_number`` is > 0 and no parseable dep line is found,
+    raises ValueError. The bridge cannot gate work safely without parseable deps
+    (see superpowers-for-vk spec 2026-04-14-archive-and-unified-descriptions-design.md).
+    """
+    deps: list[tuple[str | None, int]] = []
+    in_deps = False
+    saw_deps_section = False
+    dep_re = re.compile(r"-\s+Blocked by (?:(?P<repo>[\w.-]+/[\w.-]+))?#(?P<num>\d+)")
+    for line in body.splitlines():
+        stripped = line.strip()
+        if stripped == "## Dependencies":
+            in_deps = True
+            saw_deps_section = True
+            continue
+        if in_deps and (stripped.startswith("## ") or stripped == "---"):
+            break
+        if in_deps:
+            m = dep_re.match(stripped)
+            if m:
+                deps.append((m.group("repo"), int(m.group("num"))))
+
+    if phase_number is not None and phase_number > 0 and not deps:
+        missing_section = "" if saw_deps_section else " No ## Dependencies section found."
+        raise ValueError(
+            f"Issue body for phase {phase_number} has no parseable "
+            f"'- Blocked by #N' line in ## Dependencies.{missing_section} "
+            f"Fix: run 'vk dispatch migrate <plan>' or re-dispatch. "
+            f"The bridge cannot safely gate work without parseable deps."
+        )
+    return deps
+```
+
+Run the four tests; expect pass.
+
+- [ ] **Step 3: Extend GhIssue with labels, update gh_list_ready_issues**
+
+`GhIssue` (lines 73–83) does not carry labels. Add:
+
+```python
+@dataclass
+class GhIssue:
+    number: int
+    title: str
+    body: str
+    html_url: str
+    repo: str
+    labels: tuple[str, ...] = ()
+
+    @property
+    def repo_name(self) -> str:
+        return self.repo.split("/", 1)[1]
+```
+
+In `gh_list_ready_issues` (lines 362–372) populate labels from gh JSON:
+
+```python
+issues.append(GhIssue(
+    number=raw["number"],
+    title=raw["title"],
+    body=raw.get("body") or "",
+    html_url=raw["url"],
+    repo=repo,
+    labels=tuple(l["name"] for l in raw.get("labels", [])),
+))
+```
+
+Add a test:
+
+```python
+def test_ghissue_has_labels_default(self):
+    mod = _load_bridge()
+    i = mod.GhIssue(number=1, title="t", body="b",
+                   html_url="u", repo="o/r")
+    assert i.labels == ()
+```
+
+Run; expect pass.
+
+- [ ] **Step 4: Thread phase_number into main() parse_dependencies call**
+
+In `main()` (scripts/vk-issue-bridge.py around line 543), replace:
+
+```python
+deps = parse_dependencies(i.body)
+```
+
+with:
+
+```python
+phase_number: int | None = None
+for lbl in i.labels:
+    if lbl.startswith("phase:"):
+        try:
+            phase_number = int(lbl.split(":", 1)[1])
+        except ValueError:
+            pass
+        break
+
+try:
+    deps = parse_dependencies(i.body, phase_number=phase_number)
+except ValueError as exc:
+    log(f"  x {i.repo}#{i.number}: PARSE ERROR — {exc}")
+    push_failure_metric(str(i.number), "deps_parse_failed")
+    failed += 1
+    continue
+```
+
+Run `python -m pytest tests/ 2>&1 | tail -10`. Expected: pass.
+
+---
+
+## Phase 1: Fail-loud check_blockers [agentic]
+<!-- Tracking: https://github.com/derio-net/secure-agent-kali/issues/9 -->
+
+### Task 1: Remove fail-open on gh errors
+
+**Files:**
+- Modify: `scripts/vk-issue-bridge.py`
+- Modify: `tests/test_vk_issue_bridge.py`
+
+- [ ] **Step 1: Failing tests — check_blockers raises on gh error**
+
+Append:
+
+```python
+class TestCheckBlockersFailLoud:
+    def test_check_blockers_raises_on_gh_error(self, monkeypatch):
+        mod = _load_bridge()
+        import subprocess
+        def fake_run(*a, **kw):
+            raise subprocess.CalledProcessError(1, "gh", stderr="auth required")
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError, match="unreachable"):
+            mod.check_blockers("org/repo", [(None, 42)])
+
+    def test_check_blockers_returns_open_list_on_success(self, monkeypatch):
+        mod = _load_bridge()
+        import subprocess, json
+        class _R: stdout = json.dumps({"state": "OPEN"})
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _R())
+        assert mod.check_blockers("org/repo", [(None, 42)]) == ["#42"]
+
+    def test_check_blockers_skips_closed(self, monkeypatch):
+        mod = _load_bridge()
+        import subprocess, json
+        class _R: stdout = json.dumps({"state": "CLOSED"})
+        monkeypatch.setattr(subprocess, "run", lambda *a, **kw: _R())
+        assert mod.check_blockers("org/repo", [(None, 42)]) == []
+```
+
+Run; expect failure (current code fails open).
+
+- [ ] **Step 2: Rewrite check_blockers fail-loud**
+
+Replace lines 195–219 of `scripts/vk-issue-bridge.py`:
+
+```python
+def check_blockers(repo: str, deps: list[tuple[str | None, int]]) -> list[str]:
+    """Return list of open blockers as human-readable strings.
+
+    Fail-loud: any gh error or timeout raises RuntimeError. The previous
+    fail-open behavior silently bypassed dependency gating when gh was
+    misconfigured, which led to duplicate-work incidents.
+    """
+    open_blockers: list[str] = []
+    for dep_repo, num in deps:
+        check_repo = dep_repo if dep_repo else repo
+        display = f"{dep_repo}#{num}" if dep_repo else f"#{num}"
+        try:
+            out = subprocess.run(
+                ["gh", "issue", "view", str(num),
+                 "--repo", check_repo, "--json", "state"],
+                check=True, capture_output=True, text=True, timeout=10,
+            ).stdout
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
+                FileNotFoundError) as exc:
+            raise RuntimeError(
+                f"Blocker {display} in {check_repo} unreachable — cannot gate "
+                f"safely. Fix: check gh auth, network, or that the Issue exists. "
+                f"Underlying error: {exc}"
+            ) from exc
+        try:
+            state = json.loads(out).get("state", "").upper()
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"Blocker {display}: gh returned non-JSON. Output: {out[:200]!r}"
+            ) from exc
+        if state != "CLOSED":
+            open_blockers.append(display)
+    return open_blockers
+```
+
+Run tests; expect pass.
+
+- [ ] **Step 3: Handle RuntimeError at call site**
+
+In `main()` around line 545:
+
+```python
+if deps:
+    try:
+        open_blockers = check_blockers(i.repo, deps)
+    except RuntimeError as exc:
+        log(f"  x {i.repo}#{i.number}: BLOCKER CHECK FAILED — {exc}")
+        push_failure_metric(str(i.number), "blocker_check_failed")
+        failed += 1
+        continue
+    if open_blockers:
+        blocker_str = ", ".join(open_blockers)
+        log(f"  p {i.repo}#{i.number}: blocked by {blocker_str}")
+        deferred += 1
+        continue
+```
+
+Run full suite; expect pass.
+
+---
+
+## Phase 2: Blocker preamble in build_prompt [agentic]
+<!-- Tracking: https://github.com/derio-net/secure-agent-kali/issues/10 -->
+
+### Task 1: Prepend preamble when deps present
+
+**Files:**
+- Modify: `scripts/vk-issue-bridge.py`
+- Modify: `tests/test_vk_issue_bridge.py`
+
+- [ ] **Step 1: Failing tests — preamble presence contract**
+
+Append:
+
+```python
+class TestBuildPromptBlockerPreamble:
+    def _issue(self, mod):
+        return mod.GhIssue(
+            number=77, title="Phase 2", body="body",
+            html_url="https://gh/org/r/issues/77", repo="org/r",
+            labels=(),
+        )
+
+    def _parsed(self, mod):
+        return mod.ParsedBody(skill="vk-execute", repos=["r"], raw_instruction="x")
+
+    def test_no_preamble_when_no_deps(self):
+        mod = _load_bridge()
+        p = mod.build_prompt(self._issue(mod), self._parsed(mod), deps=[])
+        assert "BEFORE YOU BEGIN" not in p
+
+    def test_preamble_when_deps_present(self):
+        mod = _load_bridge()
+        deps = [(None, 42), ("other/repo", 7)]
+        p = mod.build_prompt(self._issue(mod), self._parsed(mod), deps=deps)
+        assert "BEFORE YOU BEGIN" in p
+        assert "#42" in p
+        assert "other/repo#7" in p
+        assert "STOP" in p
+        assert "do not duplicate" in p.lower()
+```
+
+Run; expect TypeError.
+
+- [ ] **Step 2: Extend build_prompt signature**
+
+Replace lines 378–388:
+
+```python
+def build_prompt(
+    issue: GhIssue,
+    parsed: ParsedBody,
+    deps: list[tuple[str | None, int]] | None = None,
+) -> str:
+    preamble = ""
+    if deps:
+        dep_refs = ", ".join(
+            f"{r}#{n}" if r else f"#{n}" for r, n in deps
+        )
+        preamble = (
+            f"BEFORE YOU BEGIN: This Issue declares dependencies: {dep_refs}.\n"
+            f"Verify each is CLOSED via "
+            f"`gh issue view <n> --repo <owner/repo> --json state`.\n"
+            f"If any is OPEN:\n"
+            f"  - STOP. Do not start work.\n"
+            f"  - Do not duplicate the upstream work.\n"
+            f"  - Do not start 'parts that don't depend on it'.\n"
+            f"  - Exit with message: 'Blocked on <open_blocker>, not starting.'\n"
+            f"The bridge should have deferred this workspace if a blocker were "
+            f"open — if you see this and blockers are open, report it to the "
+            f"operator.\n\n"
+            f"---\n\n"
+        )
+    return (
+        preamble
+        + f"You are a VK-spawned agent working on GitHub Issue gh#{issue.number}:\n"
+        f"{issue.title}\n\n"
+        f"The Issue is at: {issue.html_url}\n"
+        f"Repo: {parsed.repos[0]}\n\n"
+        f"Use superpowers-for-vk:{parsed.skill} to implement this task.\n\n"
+        "The full task description is in the GitHub Issue body — read it before "
+        "starting. When you finish, open a PR. The lifecycle board will reflect "
+        "your progress automatically."
+    )
+```
+
+Run; expect pass.
+
+- [ ] **Step 3: Thread deps into sync_issue call**
+
+Update `sync_issue` signature (line 391):
+
+```python
+def sync_issue(
+    issue: GhIssue,
+    parsed: ParsedBody,
+    deps: list[tuple[str | None, int]],
+    client: VkMcpClient,
+) -> bool:
+```
+
+Update its `build_prompt` call (line 455) to pass `deps=deps`.
+
+In `main()` (around line 579), change:
+
+```python
+if sync_issue(i, parsed, client):
+```
+
+to:
+
+```python
+if sync_issue(i, parsed, deps, client):
+```
+
+Note: blocked Issues are already deferred earlier in the loop, so in practice `deps` here describes deps whose blockers are all CLOSED. The preamble still runs as defense-in-depth — if the bridge misfires or a human manually labels an Issue, the agent refuses.
+
+Run full suite `python -m pytest tests/ 2>&1 | tail -10`. Expect pass.
+
+---
+
+## Phase 3: Deploy bridge to production [manual]
+<!-- Tracking: https://github.com/derio-net/secure-agent-kali/issues/11 -->
+
+### Task 1: Review, merge, deploy
+
+- [ ] **Step 1: Create PR and merge**
+
+Open a PR with the changes from Phases 0–2. Get review. Merge to main. No regressions for phase-0 Issues (no deps → no preamble, existing sync flow unchanged).
+
+- [ ] **Step 2: Deploy updated script**
+
+Follow the existing deployment path for `vk-issue-bridge.py`. Depending on infrastructure:
+
+```bash
+# Direct copy (if pod mounts source dir):
+cp /home/claude/repos/secure-agent-kali/scripts/vk-issue-bridge.py /opt/scripts/vk-issue-bridge.py
+chmod +x /opt/scripts/vk-issue-bridge.py
+```
+
+Or trigger the image rebuild + pod restart via whatever pipeline is standard.
+
+- [ ] **Step 3: Smoke test next cron tick**
+
+Wait ≤ 2 minutes:
+
+```bash
+ssh secure-agent-pod 'tail -40 /var/log/supercronic/vk-issue-bridge.log'
+```
+
+Expected: `[bridge] starting — dry_run=False` and a clean run. If Python traceback appears, roll back immediately by restoring the previous `/opt/scripts/vk-issue-bridge.py`.
+
+- [ ] **Step 4: Verify deferral behavior on a live blocked Issue**
+
+Find an Issue with a `phase:N` label where `N > 0` and whose `- Blocked by #M` blocker (`#M`) is still OPEN. In the next bridge tick, confirm the log shows:
+
+```
+  p derio-net/<repo>#<N>: blocked by #<M>
+```
+
+If instead the bridge spawned a workspace for it, ordering or label propagation is broken — investigate before proceeding.
+
+- [ ] **Step 5: Notify superpowers-for-vk Phase 5 to proceed**
+
+Once smoke test passes, the operational migration (Phase 5 of the superpowers-for-vk plan) can run. Leave a comment on the corresponding Phase 5 tracking Issue confirming bridge deployment. Mark this plan's Status as `Complete`.

--- a/docs/superpowers/plan-config.yaml
+++ b/docs/superpowers/plan-config.yaml
@@ -1,0 +1,21 @@
+plan:
+  filename: "YYYY-MM-DD-{name}.md"
+  save_to: docs/superpowers/plans/
+
+header:
+  required:
+    - Spec
+    - Status
+  status_values:
+    - Not Started
+    - In Progress
+    - Complete
+
+dispatch:
+  target: github-issues
+  owner: derio-net
+  project_board: "Derio Ops"
+  default_repo: derio-net/agent-images
+  labels:
+    agentic: vk-ready
+    manual: manual

--- a/docs/superpowers/plans/2026-04-18-persistent-agent-reliability.md
+++ b/docs/superpowers/plans/2026-04-18-persistent-agent-reliability.md
@@ -1,0 +1,779 @@
+# Persistent Agent Reliability Implementation Plan
+
+> **For VK agents:** Use vk-execute to implement assigned phases.
+> **For local execution:** Use subagent-driven-development or executing-plans.
+> **For dispatch:** Use vk-dispatch to create Issues from this plan.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-persistent-agent-reliability-design.md`
+**Status:** Not Started; K8s preStop deployment change tracked in `derio-net/frank#108`
+
+**Goal:** Fix the reliability and observability issues in the Willikins persistent agent surfaced by the 2026-04-18 triage: phantom sessions accumulating in claude.ai, silently-broken audit pipeline, unrotated 332 MB session log, and vk-bridge warning spam.
+
+**Architecture:** Changes concentrated in `scripts/session-manager.sh`, `scripts/guardrails-hook.py`, and `scripts/vk-issue-bridge.py`. A new `scripts/shutdown.sh` and a new `scripts/logrotate.conf` are added, plus a new supercronic entry for rotation. If Phase 0 determines a K8s preStop hook is needed, the deployment change is filed as a separate Issue against `derio-net/frank` — not included in this plan's PR chain.
+
+**Tech Stack:** Bash, Python 3.11+, pytest, supercronic, logrotate.
+
+---
+
+## Phase 0: Remote-control close/list spike [agentic]
+<!-- Tracking: https://github.com/derio-net/secure-agent-kali/issues/15 -->
+
+### Task 1: Investigate Claude CLI for session/env management
+
+**Files:**
+- Create: `docs/findings/2026-04-18-remote-control-shutdown.md`
+
+- [ ] **Step 1: Survey `claude` CLI surface**
+
+```bash
+claude --version 2>&1
+claude --help 2>&1 | tail -60
+claude remote-control --help 2>&1
+```
+
+Capture output verbatim. Look specifically for subcommands named `list`, `close`, `disconnect`, `stop`, `rm`, `logout`, or flags like `--session-id`, `--env-id`.
+
+- [ ] **Step 2: Inspect Claude state dir for env/session bookkeeping**
+
+```bash
+ls -la ~/.claude/ 2>&1
+find ~/.claude -type f \( -name '*.json' -o -name '*.jsonl' \) 2>&1 | head -30
+```
+
+If state files mention `env_`, `session_`, or `remote_control`, `jq` the relevant ones to understand the schema. Do not modify anything — read-only inspection.
+
+- [ ] **Step 3: Probe for a server-side disconnect endpoint**
+
+Check whether Claude Code's HTTP client (node bundle) exposes a disconnect RPC. Grep the installed bundle:
+
+```bash
+which claude
+realpath "$(which claude)" 2>&1
+CLAUDE_BIN="$(realpath "$(which claude)")"
+# Find adjacent node modules or source
+ls -la "$(dirname "$CLAUDE_BIN")/../lib" 2>&1 | head
+grep -l "remote[-_]control" "$(dirname "$CLAUDE_BIN")/../lib/node_modules" -r 2>&1 | head -5 || true
+```
+
+Grep any hits for URL patterns like `/api/remote_control`, `disconnect`, `close_environment`. Do not call any endpoint — this is reconnaissance only.
+
+- [ ] **Step 4: Test SIGTERM/SIGINT behavior in a sandbox**
+
+On the pod (not in production), start a short-lived remote-control session and observe what signals do:
+
+```bash
+# In a separate shell on the pod:
+nohup bash -c "echo y | claude remote-control --name spike-test" \
+  > /tmp/spike.log 2>&1 &
+SPIKE_PID=$!
+sleep 10
+# See child tree
+pstree -p "$SPIKE_PID" 2>&1 || ps --ppid "$SPIKE_PID" 2>&1
+# Test SIGTERM propagation
+kill -TERM "$SPIKE_PID"
+sleep 5
+# Did anything in ~/.claude change? Does the session still show in claude.ai?
+tail -30 /tmp/spike.log
+```
+
+Capture: does SIGTERM reach the child? Does it write any "disconnecting" log line? Does the session disappear from claude.ai UI, or linger?
+
+Repeat with SIGINT.
+
+- [ ] **Step 5: Write findings doc and commit**
+
+Create `docs/findings/2026-04-18-remote-control-shutdown.md` with four sections:
+
+```markdown
+# Remote-Control Shutdown — Findings
+
+## CLI surface
+[verbatim relevant output from Step 1]
+
+## State dir
+[what's stored locally; does anything help?]
+
+## Server endpoint
+[whether a disconnect RPC exists, with evidence]
+
+## Signal behavior
+[what SIGTERM / SIGINT actually do to a live session]
+
+## Decision for Phase 1
+
+One of:
+- **A (close API available):** call `claude remote-control close <name>` / HTTP endpoint in shutdown.sh.
+- **B (signal-only):** SIGTERM → wait → SIGKILL fallback; document that phantoms will still accumulate at a reduced rate.
+- **C (no clean shutdown possible):** document limitation, file upstream feature request, ship only SIGTERM trap + audit/rotation fixes.
+
+**Chosen:** <A|B|C>. Reason: <one paragraph>.
+```
+
+Commit:
+
+```bash
+git add docs/findings/2026-04-18-remote-control-shutdown.md
+git commit -m "docs: remote-control shutdown findings (Phase 0)"
+```
+
+Phase 1 implementer reads this file before starting.
+
+---
+
+## Phase 1: Housekeeping batch [agentic]
+<!-- Tracking: https://github.com/derio-net/secure-agent-kali/issues/16 -->
+
+> **Note on phase ordering:** Housekeeping is logically independent of the Phase 0 spike, but placed at Phase 1 for strict linear dispatch ordering. It still blocks on Phase 0 only in the dispatch graph sense, not semantically.
+
+### Task 1: Failing test — audit hook writes to audit.jsonl
+
+**Files:**
+- Modify: `tests/test_guardrails_hook.py` (create if missing)
+
+- [ ] **Step 1: Confirm test layout**
+
+```bash
+ls tests/test_guardrails_hook.py 2>&1 || echo "missing — will create"
+python -m pytest --version 2>&1
+```
+
+- [ ] **Step 2: Write failing test for PostToolUse Bash audit write**
+
+Create or extend `tests/test_guardrails_hook.py`:
+
+```python
+"""Tests for guardrails-hook.py — PostToolUse audit write path."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+HOOK = Path(__file__).parent.parent / "scripts" / "guardrails-hook.py"
+
+
+def _run_hook(payload: dict, env_overrides: dict[str, str]) -> subprocess.CompletedProcess:
+    env = {**os.environ, **env_overrides}
+    return subprocess.run(
+        ["python3", str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=10,
+    )
+
+
+def test_posttooluse_bash_writes_audit_line(tmp_path, monkeypatch):
+    audit_log = tmp_path / "audit.jsonl"
+    # Hook expands ~ — point HOME so AUDIT_LOG lands in tmp_path
+    fake_home = tmp_path
+    (fake_home / ".willikins-agent").mkdir(parents=True, exist_ok=True)
+    expected_log = fake_home / ".willikins-agent" / "audit.jsonl"
+
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "ls -la"},
+        "tool_response": {"exit_code": 0},
+        "session_id": "test-session-42",
+    }
+
+    result = _run_hook(payload, {"HOME": str(fake_home)})
+    assert result.returncode == 0, f"hook exited non-zero: {result.stderr}"
+
+    assert expected_log.exists(), (
+        f"audit.jsonl was not created at {expected_log}. "
+        f"hook stderr: {result.stderr}"
+    )
+    lines = expected_log.read_text().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["command"] == "ls -la"
+    assert entry["exit_code"] == 0
+    assert entry["session"] == "test-session-42"
+
+
+def test_posttooluse_non_bash_no_write(tmp_path):
+    fake_home = tmp_path
+    (fake_home / ".willikins-agent").mkdir(parents=True, exist_ok=True)
+    expected_log = fake_home / ".willikins-agent" / "audit.jsonl"
+
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": "/etc/passwd"},
+        "tool_response": {},
+        "session_id": "t",
+    }
+    result = _run_hook(payload, {"HOME": str(fake_home)})
+    assert result.returncode == 0
+    assert not expected_log.exists()
+```
+
+Run:
+
+```bash
+python -m pytest tests/test_guardrails_hook.py -x 2>&1 | tail -20
+```
+
+Expected: `test_posttooluse_bash_writes_audit_line` FAILS because the hook reads `data.get("hook_type")` but Claude Code sends `hook_event_name` (verify by reading `scripts/guardrails-hook.py:205` and `:215`).
+
+### Task 2: Fix audit hook key mismatch
+
+**Files:**
+- Modify: `scripts/guardrails-hook.py`
+
+- [ ] **Step 1: Inspect current payload key usage**
+
+```bash
+grep -n 'hook_type\|hook_event_name' scripts/guardrails-hook.py
+```
+
+Expected: `hook_type` used in `main()` and nowhere does the hook accept `hook_event_name`.
+
+- [ ] **Step 2: Accept both keys, preferring the current one**
+
+In `scripts/guardrails-hook.py` `main()`, replace:
+
+```python
+    hook_type = data.get("hook_type", "")
+```
+
+with:
+
+```python
+    hook_type = data.get("hook_event_name") or data.get("hook_type", "")
+```
+
+Also update the `tool_output` key used by `handle_posttooluse`: Claude Code now sends `tool_response`. Change line 151:
+
+```python
+    exit_code = data.get("tool_output", {}).get("exit_code", None)
+```
+
+to:
+
+```python
+    tool_result = data.get("tool_response") or data.get("tool_output") or {}
+    exit_code = tool_result.get("exit_code", None)
+```
+
+- [ ] **Step 3: Re-run tests**
+
+```bash
+python -m pytest tests/test_guardrails_hook.py -x 2>&1 | tail -10
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 4: Smoke check against a real payload example**
+
+Capture (or reference) a real Claude Code hook payload from `session-willikins.log` if available; otherwise synthesize one matching the current documented schema. Confirm `test_posttooluse_bash_writes_audit_line` covers the current wire format.
+
+### Task 3: Log rotation for session-*.log
+
+**Files:**
+- Create: `scripts/logrotate.conf`
+- Create: `scripts/rotate-logs.sh`
+- Modify: `crontab.txt`
+
+- [ ] **Step 1: Write logrotate config**
+
+Create `scripts/logrotate.conf`:
+
+```
+/home/claude/.willikins-agent/session-*.log {
+    size 50M
+    rotate 5
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+    dateext
+    dateformat -%Y%m%d-%s
+}
+
+/home/claude/.willikins-agent/vk-bridge.log
+/home/claude/.willikins-agent/session-manager.log
+/home/claude/.willikins-agent/audit.jsonl
+{
+    size 20M
+    rotate 3
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}
+```
+
+`copytruncate` avoids corrupting a log file actively being written by `claude remote-control` (the process keeps its fd open).
+
+- [ ] **Step 2: Write wrapper script**
+
+Create `scripts/rotate-logs.sh`:
+
+```bash
+#!/usr/bin/env bash
+# rotate-logs.sh — invoke logrotate against willikins-agent log dir
+set -euo pipefail
+
+CONF="/opt/scripts/logrotate.conf"
+STATE="/home/claude/.willikins-agent/logrotate.state"
+
+if ! command -v logrotate >/dev/null 2>&1; then
+  echo "logrotate not installed — skipping" >&2
+  exit 0
+fi
+
+logrotate --state "$STATE" "$CONF"
+```
+
+```bash
+chmod +x scripts/rotate-logs.sh
+```
+
+- [ ] **Step 3: Verify logrotate is present in the image**
+
+```bash
+grep -nE 'logrotate' Dockerfile 2>&1 || echo "not found — need to add apt install"
+```
+
+If missing, add `logrotate` to the package install line in `Dockerfile`.
+
+- [ ] **Step 4: Add hourly cron entry**
+
+In `crontab.txt`, append before the "Audit digest" line:
+
+```
+# Log rotation (hourly)
+7 * * * * /opt/scripts/rotate-logs.sh >> /home/claude/.willikins-agent/logrotate.log 2>&1
+```
+
+- [ ] **Step 5: Dry-run test**
+
+```bash
+# Requires logrotate installed locally; otherwise skip and test in pod post-deploy
+mkdir -p /tmp/willtest/.willikins-agent
+printf 'x%.0s' {1..60000000} > /tmp/willtest/.willikins-agent/session-willikins.log
+sed 's|/home/claude|/tmp/willtest|g' scripts/logrotate.conf > /tmp/willtest/conf
+logrotate -d --state /tmp/willtest/state /tmp/willtest/conf 2>&1 | head -20
+```
+
+Expected: output shows `log needs rotating (log size is ... size threshold is ...)`.
+
+### Task 4: vk-bridge — skip repos with no GitHub remote-side presence
+
+**Files:**
+- Modify: `scripts/vk-issue-bridge.py`
+- Modify: `tests/test_vk_issue_bridge.py`
+
+- [ ] **Step 1: Read current behavior**
+
+```bash
+sed -n '350,390p' scripts/vk-issue-bridge.py
+```
+
+Confirm the flow: `discover_repos()` scans `~/repos/`, loop runs `gh issue list --repo derio-net/<name>` for each, logs `[warn] gh issue list failed for {repo}` on any error.
+
+- [ ] **Step 2: Failing test — 404 on a repo should be demoted from warn to debug-or-silent**
+
+Add to `tests/test_vk_issue_bridge.py`:
+
+```python
+class TestDiscoveryWarningFiltering:
+    def test_gh_404_is_not_a_warn(self, monkeypatch, capsys):
+        mod = _load_bridge()
+        import subprocess
+        def fake_run(*args, **kwargs):
+            raise subprocess.CalledProcessError(
+                1, "gh",
+                stderr="HTTP 404: Not Found (https://api.github.com/repos/derio-net/derio-profile/issues)",
+            )
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        # Call whatever the loop helper is — adjust to the real function name
+        # once the implementer identifies it. This is a placeholder contract.
+        issues = mod.gh_list_ready_issues("derio-net/derio-profile")
+        assert issues == []
+        # Assert the log line, if log() writes to stderr, does NOT include "[warn]"
+        captured = capsys.readouterr()
+        assert "[warn]" not in captured.err or "derio-profile" not in captured.err
+```
+
+Run:
+
+```bash
+python -m pytest tests/test_vk_issue_bridge.py::TestDiscoveryWarningFiltering -x 2>&1 | tail -10
+```
+
+Expected: FAIL (bridge currently emits `[warn]`).
+
+- [ ] **Step 3: Downgrade 404 to info, keep other errors as warn**
+
+In `gh_list_ready_issues` (around line 374), change the `except` branch to inspect stderr:
+
+```python
+        except subprocess.CalledProcessError as e:
+            stderr = (e.stderr or "").strip()
+            if "HTTP 404" in stderr or "Could not resolve" in stderr:
+                # Repo not present on GitHub (e.g., local-only mirror). Informational, not an alert.
+                log(f"[info] gh list skipped — {repo}: no GitHub remote ({stderr.splitlines()[0] if stderr else ''})")
+            else:
+                log(f"[warn] gh issue list failed for {repo}: {stderr}")
+            continue
+```
+
+- [ ] **Step 4: Re-run full bridge suite**
+
+```bash
+python -m pytest tests/ 2>&1 | tail -15
+```
+
+Expected: pass.
+
+### Task 5: Phase 1 PR
+
+- [ ] **Step 1: Open PR**
+
+```bash
+git checkout -b phase1/housekeeping
+git add scripts/guardrails-hook.py scripts/logrotate.conf scripts/rotate-logs.sh \
+        scripts/vk-issue-bridge.py crontab.txt tests/
+# Dockerfile edit only if logrotate was missing
+git status
+git commit -m "fix(agent): audit hook payload keys + log rotation + vk-bridge 404 demotion"
+```
+
+Push and open a PR. No production deploy yet — Phase 3 soaks the whole bundle together.
+
+---
+
+## Phase 2: Graceful shutdown [agentic]
+<!-- Tracking: https://github.com/derio-net/secure-agent-kali/issues/17 -->
+
+> **Semantic dependency:** Phase 0 findings doc must exist (`docs/findings/2026-04-18-remote-control-shutdown.md`). Phase 2 branches on its Decision section. Phase 2 also inherits the dispatch-graph `Blocked by` link to Phase 1 (housekeeping); in practice that's a no-op since the Phase 1 PR is unrelated.
+
+### Task 1: Write shutdown script
+
+**Files:**
+- Create: `scripts/shutdown.sh`
+- Create: `tests/test_shutdown.sh` (or extend an existing bash test harness)
+
+- [ ] **Step 1: Read Phase 0 decision**
+
+```bash
+cat docs/findings/2026-04-18-remote-control-shutdown.md
+```
+
+Identify chosen path (A / B / C). This determines whether `shutdown.sh` calls a close API, sends a specific signal sequence, or is a no-op wrapper that only cleans PID files.
+
+- [ ] **Step 2: Write shutdown.sh skeleton (signal-based baseline)**
+
+Create `scripts/shutdown.sh`:
+
+```bash
+#!/usr/bin/env bash
+# shutdown.sh — gracefully terminate all willikins-agent remote-control sessions
+# Invoked by K8s preStop hook OR by ad-hoc operator.
+set -euo pipefail
+
+LOGFILE="/home/claude/.willikins-agent/shutdown.log"
+PIDDIR="/home/claude/.willikins-agent/pids"
+mkdir -p "$(dirname "$LOGFILE")" "$PIDDIR"
+
+log() { echo "[$(date -u '+%Y-%m-%d %H:%M:%S')] $*" | tee -a "$LOGFILE" >&2; }
+
+if [[ ! -d "$PIDDIR" ]]; then
+  log "no PID dir — nothing to shut down"
+  exit 0
+fi
+
+shopt -s nullglob
+pids_seen=0
+for pidfile in "$PIDDIR"/*.pid; do
+  pids_seen=1
+  name="$(basename "$pidfile" .pid)"
+  pid="$(cat "$pidfile" 2>/dev/null || true)"
+  [[ -z "$pid" ]] && { log "empty pidfile $pidfile — skipping"; continue; }
+
+  if ! kill -0 "$pid" 2>/dev/null; then
+    log "session '$name' PID $pid already dead — cleaning"
+    rm -f "$pidfile"
+    continue
+  fi
+
+  # --- Phase 0 Decision injection point ---
+  # Path A: close via CLI or HTTP first
+  #   claude remote-control close --name "$name" || log "close returned nonzero"
+  # Path B/C: signal-only
+  log "sending SIGTERM to '$name' (PID $pid)"
+  kill -TERM "$pid" || log "SIGTERM to $pid returned nonzero"
+done
+
+if (( pids_seen == 0 )); then
+  log "no PID files present"
+  exit 0
+fi
+
+# Wait up to 20s for graceful exit, then SIGKILL stragglers
+deadline=$(( $(date +%s) + 20 ))
+while (( $(date +%s) < deadline )); do
+  alive=0
+  for pidfile in "$PIDDIR"/*.pid; do
+    pid="$(cat "$pidfile" 2>/dev/null || true)"
+    [[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null && alive=1
+  done
+  (( alive == 0 )) && break
+  sleep 1
+done
+
+for pidfile in "$PIDDIR"/*.pid; do
+  pid="$(cat "$pidfile" 2>/dev/null || true)"
+  [[ -z "$pid" ]] && continue
+  if kill -0 "$pid" 2>/dev/null; then
+    log "SIGKILL straggler $pid"
+    kill -KILL "$pid" || true
+  fi
+  rm -f "$pidfile"
+done
+
+log "shutdown complete"
+```
+
+```bash
+chmod +x scripts/shutdown.sh
+```
+
+If Phase 0 chose Path A, uncomment the `claude remote-control close` block and remove/adjust the comment marker. If Path C, replace the signal block with a `log "no clean shutdown available"` line.
+
+- [ ] **Step 3: Tests for shutdown.sh**
+
+Create `tests/test_shutdown.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+export HOME="$TMP"
+mkdir -p "$HOME/.willikins-agent/pids"
+
+# Start a sleep-forever child that handles SIGTERM
+bash -c 'trap "exit 0" TERM; sleep 300 &
+         echo $! > '"$HOME"'/.willikins-agent/pids/fake.pid; wait' &
+HARNESS_PID=$!
+sleep 1
+
+# Actually put the child's PID in the pidfile
+CHILD_PID="$(cat "$HOME/.willikins-agent/pids/fake.pid")"
+
+# Verify child is alive
+kill -0 "$CHILD_PID" || { echo "FAIL: harness child not running"; exit 1; }
+
+# Run shutdown.sh
+bash scripts/shutdown.sh
+
+# Child should be dead and pidfile gone
+if kill -0 "$CHILD_PID" 2>/dev/null; then
+  echo "FAIL: child $CHILD_PID still alive after shutdown.sh"
+  exit 1
+fi
+if [[ -f "$HOME/.willikins-agent/pids/fake.pid" ]]; then
+  echo "FAIL: pidfile not cleaned"
+  exit 1
+fi
+
+echo "OK"
+```
+
+```bash
+chmod +x tests/test_shutdown.sh
+bash tests/test_shutdown.sh 2>&1
+```
+
+Expected: `OK`.
+
+### Task 2: Wire shutdown into session-manager + supercronic exit
+
+**Files:**
+- Modify: `scripts/session-manager.sh`
+- Modify: `entrypoint.sh` (if it supervises supercronic)
+
+- [ ] **Step 1: Review entrypoint**
+
+```bash
+cat entrypoint.sh
+```
+
+Confirm whether it invokes `supercronic` in foreground or backgrounds it with `wait -n`. The goal: on container SIGTERM, entrypoint must run `shutdown.sh` before exiting.
+
+- [ ] **Step 2: Add trap in entrypoint.sh**
+
+If entrypoint.sh ends with `exec supercronic ...`, replace with:
+
+```bash
+# Trap SIGTERM to gracefully disconnect remote-control sessions before exit
+shutdown_handler() {
+  echo "[entrypoint] SIGTERM received — running shutdown.sh"
+  /opt/scripts/shutdown.sh || true
+  exit 0
+}
+trap shutdown_handler TERM INT
+
+supercronic /home/claude/.crontab &
+SUPERCRONIC_PID=$!
+wait "$SUPERCRONIC_PID"
+```
+
+If entrypoint already has a trap / supervisor loop, add the shutdown.sh call inside it.
+
+- [ ] **Step 3: Verify trap locally**
+
+Using a Docker smoke test (optional if not available locally):
+
+```bash
+docker build -t secure-agent-kali:test . 2>&1 | tail -5
+docker run -d --name sak-test secure-agent-kali:test
+sleep 15
+docker stop --time=30 sak-test
+docker logs sak-test 2>&1 | grep -i shutdown
+```
+
+Expected: log line `[entrypoint] SIGTERM received — running shutdown.sh` and subsequent lines from shutdown.sh.
+
+```bash
+docker rm -f sak-test 2>/dev/null || true
+```
+
+### Task 3: K8s preStop hook (frank-side) — filed as separate Issue
+
+**Files:**
+- None in this repo. Change lives in `derio-net/frank`.
+
+- [ ] **Step 1: Open a tracking Issue against derio-net/frank**
+
+```bash
+gh issue create --repo derio-net/frank \
+  --title "secure-agent-pod: add preStop hook for graceful session shutdown" \
+  --body "$(cat <<'EOF'
+Part of secure-agent-kali plan `2026-04-18-persistent-agent-reliability.md` Phase 1.
+
+Add a preStop hook to the `secure-agent-pod` Deployment pointing at `/opt/scripts/shutdown.sh`:
+
+```yaml
+lifecycle:
+  preStop:
+    exec:
+      command: ["/opt/scripts/shutdown.sh"]
+```
+
+And raise `terminationGracePeriodSeconds` to at least `45` (shutdown.sh allows 20s for SIGTERM + margin).
+
+Depends on: secure-agent-kali image including `shutdown.sh` (shipped in this plan's Phase 1/2 PRs).
+
+## Acceptance
+- Pod redeploy triggers preStop, `shutdown.sh` runs to completion, no orphaned `claude remote-control` processes on the new pod after rollout.
+EOF
+)"
+```
+
+- [ ] **Step 2: Link in the plan**
+
+Record the Issue number in this plan's header (manually edit the Status line to include `; frank#<N>`) so future readers can follow the cross-repo dependency.
+
+### Task 4: Phase 2 PR
+
+- [ ] **Step 1: Open PR**
+
+```bash
+git checkout -b phase2/graceful-shutdown
+git add scripts/shutdown.sh entrypoint.sh tests/test_shutdown.sh docs/findings/
+git commit -m "feat(agent): graceful shutdown for remote-control sessions"
+```
+
+PR body should reference the frank Issue created in Task 3. No deploy yet — Phase 3 handles.
+
+---
+
+## Phase 3: 24h soak [manual]
+<!-- Tracking: https://github.com/derio-net/secure-agent-kali/issues/18 -->
+
+### Task 1: Deploy
+
+- [ ] **Step 1: Merge Phase 1 and Phase 2 PRs**
+
+In any order; they touch different files.
+
+- [ ] **Step 2: Rebuild image and roll pod**
+
+```bash
+# Whatever the standard build path is for secure-agent-kali
+gh workflow run build.yml --repo derio-net/secure-agent-kali --ref main 2>&1
+# Once the new image tag lands, bump the frank deployment and merge the preStop PR
+```
+
+- [ ] **Step 3: Capture baseline**
+
+```bash
+START_TS=$(date -u +%FT%T)
+echo "$START_TS" > /tmp/soak-start.txt
+# Claude.ai phantom count (manual — open the app, count entries)
+# Session log size, audit line count
+kubectl exec -n secure-agent-pod deploy/secure-agent-pod -c kali -- \
+  bash -c 'stat -c "%s" ~/.willikins-agent/session-willikins.log 2>/dev/null;
+           wc -l ~/.willikins-agent/audit.jsonl 2>/dev/null;
+           ls ~/.willikins-agent/pids/'
+```
+
+### Task 2: Observe for 24h
+
+- [ ] **Step 1: Check at T+2h, T+8h, T+24h**
+
+At each checkpoint, record:
+
+```bash
+kubectl exec -n secure-agent-pod deploy/secure-agent-pod -c kali -- \
+  bash -c '
+    echo "== session-manager restarts =="
+    grep -c "Starting session" ~/.willikins-agent/session-manager.log
+    echo "== disconnect events =="
+    grep -c "Server unreachable" ~/.willikins-agent/session-willikins.log || true
+    echo "== audit lines =="
+    wc -l ~/.willikins-agent/audit.jsonl 2>/dev/null || echo "0 (still missing)"
+    echo "== log size =="
+    du -h ~/.willikins-agent/session-willikins.log
+    echo "== logrotate state =="
+    cat ~/.willikins-agent/logrotate.state 2>/dev/null | tail -5
+    echo "== vk-bridge warnings =="
+    grep -c "\[warn\]" ~/.willikins-agent/vk-bridge.log
+  '
+```
+
+- [ ] **Step 2: Manual phantom count in claude.ai**
+
+At T+24h, count remote-control environments in the claude.ai UI. Compare with the baseline and with the number of session-manager restarts during the window. If phantoms ≈ restarts: shutdown is not cleanly disconnecting (go back to Phase 0 with new signal/API evidence). If phantoms ≪ restarts: graceful shutdown is working.
+
+### Task 3: Outcome note and follow-up decisions
+
+- [ ] **Step 1: Write outcome note**
+
+Append a short entry to `../willikins/decisions/log.md` (via a separate commit in the willikins repo):
+
+```
+[2026-04-XX] DECISION: <reliability plan outcome> | REASONING: <phantom delta, audit state, disconnect count> | CONTEXT: persistent-agent-reliability plan (secure-agent-kali 2026-04-18)
+```
+
+- [ ] **Step 2: Open follow-up plans if needed**
+
+- If disconnect loops (`Server unreachable for 11 minutes`) persist at > 1/day: open a new plan **against derio-net/frank** for egress/Cilium investigation. Do not expand scope of this plan.
+- If phantoms still accumulate despite graceful shutdown: open an upstream feature request with Anthropic documenting the findings doc.
+- If audit.jsonl is still empty: the key-mismatch fix is not the whole problem — open a debug plan against secure-agent-kali.
+
+- [ ] **Step 3: Mark Status complete**
+
+Edit the `Status:` header of this plan to `Complete` and of the spec to `Complete`.

--- a/docs/superpowers/specs/2026-04-13-dynamic-repo-discovery-design.md
+++ b/docs/superpowers/specs/2026-04-13-dynamic-repo-discovery-design.md
@@ -1,0 +1,61 @@
+# Dynamic Repo Discovery for vk-issue-bridge
+
+**Date:** 2026-04-13
+**Status:** Approved
+
+## Problem
+
+`scripts/vk-issue-bridge.py` hardcodes a `KNOWN_REPOS` list on line 41. Adding a
+new repo requires editing the script and rebuilding the container image. Repos
+cloned to `~/repos` at runtime (on the PVC) are invisible to the bridge until
+the image is rebuilt.
+
+## Solution
+
+Replace the hardcoded `KNOWN_REPOS` list with a `discover_repos()` function that
+scans `~/repos` for git repositories at runtime. Every 2-minute cron invocation
+discovers the current set of repos automatically.
+
+## Design
+
+### `discover_repos(repos_dir)` function
+
+- Accepts a directory path (default from `REPOS_DIR` constant)
+- `REPOS_DIR` defaults to `/home/claude/repos`, overridable via `VK_REPOS_DIR`
+  env var
+- Scans first-level entries using `os.scandir(repos_dir)`
+- Includes an entry if it is a directory and contains a `.git` subdirectory
+- Returns a sorted list of directory names (e.g. `["frank", "kid-laptops", ...]`)
+- If `repos_dir` does not exist or is empty, returns `[]` and logs a warning
+
+### Integration into `gh_list_ready_issues()`
+
+- Calls `discover_repos()` at the top of the function instead of referencing the
+  module-level `KNOWN_REPOS` constant
+- The discovered list is logged for observability (similar to the existing VK
+  repos log on line 479)
+
+### What stays the same
+
+- The `derio-net/` GitHub org prefix remains hardcoded
+- All other logic (issue parsing, VK card creation, workspace management,
+  dependency gating, PR polling, metrics) is untouched
+- Cron schedule, permissions, and script location are unchanged
+
+### Testing
+
+- Unit test for `discover_repos()` using a temporary directory with a mix of
+  git dirs, non-git dirs, and files to verify correct filtering
+- Existing tests updated if they reference `KNOWN_REPOS`
+
+### Observability
+
+- The bridge logs the discovered repo list each run, e.g.
+  `[bridge] discovered repos: ['frank', 'kid-laptops', ...]`
+
+## Scope
+
+- **In scope:** Replace hardcoded list, add discovery function, add test, add
+  log line
+- **Out of scope:** Deriving GitHub org from remote URL, exclusion mechanisms,
+  config files

--- a/docs/superpowers/specs/2026-04-18-persistent-agent-reliability-design.md
+++ b/docs/superpowers/specs/2026-04-18-persistent-agent-reliability-design.md
@@ -1,0 +1,57 @@
+# Persistent Agent Reliability — Design
+
+*Date: 2026-04-18*
+*Status: In Progress*
+
+## Context
+
+The Willikins persistent agent runs on the `secure-agent-pod` as a per-repo `claude remote-control` session, watchdogged every 5 minutes by `scripts/session-manager.sh`. A 2026-04-18 triage of the pod surfaced six findings:
+
+| # | Finding | Severity |
+|---|---|---|
+| 1 | Phantom sessions accumulate in claude.ai — 39 environments, 43 sessions since 2026-03-31. Watchdog has restarted 40 times; each restart allocates a new server-side `env_…`/`session_…` that no graceful disconnect ever closes. | High (user-visible noise, +2/day steady state) |
+| 2 | `Server unreachable for 11 minutes, giving up.` disconnect loops — ~1/day average, bursts of 7 on bad days. Session dies, watchdog relaunches → new phantom (see #1). Root cause unknown (network? Anthropic side?). | Medium |
+| 3 | `/home/claude/.willikins-agent/audit.jsonl` does not exist. PostToolUse hook in `guardrails-hook.py` is silently not writing. Daily audit digest has reported "no log found" for 10+ days. | Medium (security-observability regression) |
+| 4 | `session-willikins.log` is 332 MB of ANSI escape sequences. No rotation. | Low (disk creep) |
+| 5 | `vk-issue-bridge.py` logs a `derio-net/derio-profile` not-found warning on every 2-min poll. Benign, but noise that masks real warnings. | Low |
+| 6 | Only one session is configured (`WILLIKINS_REPOS=/home/claude/repos/willikins:willikins`). Design intent per `WILLIKINS_REPOS` naming is multi-session. Deliberate for now — not addressed here. | N/A |
+
+## Decision
+
+Ship a bundle of targeted fixes in three agentic phases + one manual soak. Scope is deliberately narrow — investigation of the disconnect-loop root cause (#2) is deferred to the soak phase and promoted to a follow-up plan only if soak data implicates a fixable local cause.
+
+### Approach
+
+**Phase 0 — Spike:** determine whether `claude` CLI exposes a close/disconnect for remote-control environments. Output: findings doc. Gates Phase 1.
+
+**Phase 1 — Graceful shutdown:** SIGTERM trap in `session-manager.sh`, signal propagation to the `claude remote-control` child, and a disconnect action whose shape is chosen by Phase 0. If the fix requires a K8s preStop hook, the deployment change is filed as a separate Issue in `derio-net/frank` (one-plan-one-repo).
+
+**Phase 2 — Housekeeping batch:** audit hook write-path bug, log rotation config, vk-bridge warning patch. Independent from Phase 1, ships in parallel.
+
+**Phase 3 — 24h soak:** deploy, observe, record. If disconnect loops continue past the soak, a follow-up plan opens against the Frank network layer.
+
+### Non-goals
+
+- Root-causing the 11-min-unreachable loops (deferred to soak observation).
+- Multi-session configuration (`WILLIKINS_REPOS` with multiple repos) — separate initiative.
+- Retiring the audit pipeline — we fix it, not remove it, per the 2026-03-30 security design.
+- Any change to the Claude CLI itself. If Phase 0 finds no close API, we document the limitation and move on.
+
+## Threat model deltas
+
+None. No new capabilities, no loosened guardrails. The audit-hook fix restores a layer the 2026-03-30 design already specified.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Phase 0 finds no close API; phantoms continue to accumulate at a slower rate. | Document the limitation; file upstream issue / feature request with Anthropic. Graceful shutdown still helps for the common case (pod redeploy). |
+| SIGTERM trap breaks existing restart behavior. | TDD — test the trap in isolation before wiring it into the script. |
+| Log rotation truncates mid-write and corrupts an active session log. | Use `copytruncate` semantics (or size-capped tail) rather than rename+HUP. |
+| vk-bridge patch masks legitimate repo-discovery failures. | Patch the specific `derio-profile` case or make the warning levelled, not suppressed globally. |
+
+## Implementation Plans
+
+| Plan | Repo | File | Status | Depends on |
+|------|------|------|--------|------------|
+| Persistent Agent Reliability | derio-net/secure-agent-kali | `docs/superpowers/plans/2026-04-18-persistent-agent-reliability.md` | Not Started | — |

--- a/kali/Dockerfile
+++ b/kali/Dockerfile
@@ -18,9 +18,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get dist-upgrade -y \
     && rm -rf /var/lib/apt/lists/*
 
-# ── sshd + Kali tooling ──
+# ── sshd + Kali tooling + logrotate (for rotate-logs.sh) ──
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      openssh-server kali-tools-top10 nmap netcat-traditional \
+      openssh-server kali-tools-top10 nmap netcat-traditional logrotate \
     && mkdir -p /run/sshd /var/run/sshd \
     && rm -rf /var/lib/apt/lists/*
 

--- a/kali/config-templates/crontab.txt
+++ b/kali/config-templates/crontab.txt
@@ -25,5 +25,8 @@ PUSHGATEWAY_URL=http://pushgateway.monitoring.svc.cluster.local:9091
 # VK Issue Bridge — sync vk-ready GitHub Issues to VK workspaces (every 2 min)
 */2 * * * * /opt/scripts/vk-issue-bridge.py >> /home/claude/.willikins-agent/vk-bridge.log 2>&1
 
+# Log rotation (hourly)
+7 * * * * /opt/scripts/rotate-logs.sh >> /home/claude/.willikins-agent/logrotate.log 2>&1
+
 # Audit digest — daily summary of all agent activity (21:00 UTC / 23:00 Berlin)
 0 21 * * * /opt/scripts/audit-digest.sh

--- a/kali/config-templates/settings.json
+++ b/kali/config-templates/settings.json
@@ -10,7 +10,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /opt/scripts/guardrails-hook.py"
+            "command": "python3 $CLAUDE_PROJECT_DIR/scripts/guardrails-hook.py"
           }
         ]
       }
@@ -21,7 +21,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 /opt/scripts/guardrails-hook.py"
+            "command": "python3 $CLAUDE_PROJECT_DIR/scripts/guardrails-hook.py"
           }
         ]
       }

--- a/kali/entrypoint.sh
+++ b/kali/entrypoint.sh
@@ -71,7 +71,28 @@ fi
 # ── Start supercronic (non-root cron) ──
 supercronic "$HOME/.crontab" &
 
-echo "[agent] secure-agent-kali ready (sshd on :2222, supercronic active)"
+# ── Start VibeKanban in local mode (SQLite, port 8081) ──
+vibe-kanban &
 
-# Wait for any child to exit — if sshd or supercronic dies, pod restarts
+# Trap SIGTERM/SIGINT so K8s pod termination runs shutdown.sh before we exit.
+# shutdown.sh signals each claude remote-control PID, giving the CLI's own
+# bridge:shutdown handler a chance to deregister the environment in
+# claude.ai. Without this, pod restarts leak phantom sessions.
+shutdown_handler() {
+    trap - TERM INT
+    # Marker tells session-manager.sh to stop respawning while we drain.
+    # supercronic keeps running after PID 1 gets SIGTERM; without this
+    # guard the 5-min tick can race in and launch a fresh claude session
+    # after shutdown.sh has already killed the old one.
+    touch /tmp/willikins-shutting-down
+    echo "[entrypoint] received termination signal — running shutdown.sh"
+    /opt/scripts/shutdown.sh || echo "[entrypoint] shutdown.sh exited nonzero"
+    exit 0
+}
+trap shutdown_handler TERM INT
+
+echo "[agent] secure-agent-kali ready (sshd on :2222, supercronic active, vibe-kanban on :8081)"
+
+# Wait for any child to exit — if sshd or supercronic dies, pod restarts.
+# `wait -n` returns early when a trap fires, so shutdown_handler runs on SIGTERM.
 wait -n

--- a/kali/scripts/guardrails-hook.py
+++ b/kali/scripts/guardrails-hook.py
@@ -148,7 +148,15 @@ def handle_posttooluse(data: dict) -> None:
         return
 
     command = data.get("tool_input", {}).get("command", "")
-    exit_code = data.get("tool_output", {}).get("exit_code", None)
+    # Prefer current key (`tool_response`) over legacy (`tool_output`); treat
+    # missing (None) and empty-but-present ({}) as different: the first
+    # non-None wins, so an explicit `tool_response: {}` is respected and
+    # we don't fall through to legacy keys.
+    tool_result = next(
+        (x for x in (data.get("tool_response"), data.get("tool_output")) if x is not None),
+        {},
+    )
+    exit_code = tool_result.get("exit_code", None)
     session_id = data.get("session_id", "unknown")
 
     entry = {
@@ -202,7 +210,7 @@ def main() -> None:
         sys.exit(0)
 
     data = json.loads(raw)
-    hook_type = data.get("hook_type", "")
+    hook_type = data.get("hook_event_name") or data.get("hook_type", "")
     tool_name = data.get("tool_name", "")
     tool_input = data.get("tool_input", {})
 

--- a/kali/scripts/logrotate.conf
+++ b/kali/scripts/logrotate.conf
@@ -1,0 +1,29 @@
+# NOTE: copytruncate leaves a sparse file until the writer reopens its fd
+# (claude remote-control keeps its stdout fd open for the lifetime of the
+# session). Accepted quirk — see plan
+# docs/superpowers/plans/2026-04-18-persistent-agent-reliability.md Task 3.
+
+/home/claude/.willikins-agent/session-*.log {
+    size 50M
+    rotate 5
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+    dateext
+    dateformat -%Y%m%d-%s
+}
+
+/home/claude/.willikins-agent/vk-bridge.log
+/home/claude/.willikins-agent/session-manager.log
+/home/claude/.willikins-agent/audit.jsonl
+{
+    size 20M
+    rotate 3
+    compress
+    delaycompress
+    missingok
+    notifempty
+    copytruncate
+}

--- a/kali/scripts/rotate-logs.sh
+++ b/kali/scripts/rotate-logs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# rotate-logs.sh — invoke logrotate against willikins-agent log dir
+set -euo pipefail
+
+CONF="/opt/scripts/logrotate.conf"
+STATE="/home/claude/.willikins-agent/logrotate.state"
+
+# logrotate lives in /usr/sbin on Debian/Kali, which is not in the supercronic
+# PATH (see crontab.txt). Extend locally so `command -v` finds it without
+# broadening sbin exposure for other cron jobs.
+export PATH="$PATH:/usr/sbin"
+
+if ! command -v logrotate >/dev/null 2>&1; then
+  echo "logrotate not installed — skipping" >&2
+  exit 0
+fi
+
+# Ensure the state dir exists — first cron fire may run before any other
+# script has created ~/.willikins-agent.
+mkdir -p "$(dirname "$STATE")"
+
+logrotate --state "$STATE" "$CONF"

--- a/kali/scripts/session-manager.sh
+++ b/kali/scripts/session-manager.sh
@@ -11,9 +11,16 @@ set -euo pipefail
 
 LOGFILE="/home/claude/.willikins-agent/session-manager.log"
 PIDDIR="/home/claude/.willikins-agent/pids"
+SHUTDOWN_MARKER="/tmp/willikins-shutting-down"
 mkdir -p "$(dirname "$LOGFILE")" "$PIDDIR"
 
 log() { echo "[$(date -u '+%Y-%m-%d %H:%M:%S')] $*" >> "$LOGFILE"; }
+
+# Bail out when entrypoint.sh is draining the pod. Prevents supercronic's
+# 5-min tick from respawning claude after shutdown.sh has killed it.
+if [[ -f "$SHUTDOWN_MARKER" ]]; then
+  log "Shutdown in progress — skipping session check"; exit 0
+fi
 
 if [[ -z "${WILLIKINS_REPOS:-}" ]]; then
   log "ERROR: WILLIKINS_REPOS not set"; exit 1
@@ -40,7 +47,11 @@ for ((i=0; i<${#ENTRIES[@]}; i+=2)); do
 
   log "Starting session '$SESSION_NAME' in $REPO_PATH"
   cd "$REPO_PATH"
-  nohup bash -c "echo y | claude remote-control --name '$SESSION_NAME'" \
+  # `exec` replaces the bash wrapper in place, so $! below is claude's own
+  # PID — required for SIGTERM to reach the bridge:shutdown handler that
+  # calls DELETE /v1/environments/bridge/<env_id>. Using a process-
+  # substitution stdin avoids a pipeline (which would again fork).
+  nohup bash -c "exec claude remote-control --name '$SESSION_NAME' < <(echo y)" \
     >> "/home/claude/.willikins-agent/session-${SESSION_NAME}.log" 2>&1 &
   echo $! > "$PIDFILE"
   log "Session '$SESSION_NAME' started (PID $!)"

--- a/kali/scripts/shutdown.sh
+++ b/kali/scripts/shutdown.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# shutdown.sh — gracefully terminate willikins-agent remote-control sessions.
+#
+# Invoked by K8s preStop hook or by an operator during pod drain. Per
+# docs/findings/2026-04-18-remote-control-shutdown.md, the `claude` CLI's
+# SIGTERM handler calls DELETE /v1/environments/bridge/<env_id>, which is
+# how we avoid phantom sessions in claude.ai. We therefore rely on
+# session-manager.sh recording claude's own PID (not a bash wrapper's)
+# in each pidfile, send SIGTERM, and wait for the bridge:shutdown path
+# to drain (~30s per the CLI's loop_grace_ms default) before SIGKILL.
+set -euo pipefail
+
+AGENT_DIR="${WILLIKINS_AGENT_DIR:-$HOME/.willikins-agent}"
+LOGFILE="$AGENT_DIR/shutdown.log"
+PIDDIR="$AGENT_DIR/pids"
+GRACE_SECONDS="${SHUTDOWN_GRACE_SECONDS:-30}"
+
+if [[ ! "$GRACE_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "[shutdown] invalid SHUTDOWN_GRACE_SECONDS='$GRACE_SECONDS' — defaulting to 30" >&2
+  GRACE_SECONDS=30
+fi
+
+mkdir -p "$AGENT_DIR" "$PIDDIR"
+
+log() {
+  local msg="[$(date -u '+%Y-%m-%d %H:%M:%S')] $*"
+  echo "$msg" >&2
+  # Logfile is on a PVC that may be detaching during pod termination;
+  # a failed write must never abort the shutdown itself.
+  echo "$msg" >> "$LOGFILE" 2>/dev/null || true
+}
+
+read_pid() {
+  # Prints the PID stored in $1 and returns 0 iff it looks like a positive integer.
+  local pidfile="$1" pid
+  pid="$(cat "$pidfile" 2>/dev/null || true)"
+  [[ "$pid" =~ ^[1-9][0-9]*$ ]] || return 1
+  printf '%s' "$pid"
+}
+
+shopt -s nullglob
+pidfiles=( "$PIDDIR"/*.pid )
+
+if (( ${#pidfiles[@]} == 0 )); then
+  log "no PID files present — nothing to shut down"
+  exit 0
+fi
+
+tracked=()
+for pidfile in "${pidfiles[@]}"; do
+  name="$(basename "$pidfile" .pid)"
+  if ! pid="$(read_pid "$pidfile")"; then
+    log "session '$name' has empty or malformed pidfile — removing"
+    rm -f "$pidfile"
+    continue
+  fi
+
+  if ! kill -0 "$pid" 2>/dev/null; then
+    log "session '$name' PID $pid already dead — cleaning pidfile"
+    rm -f "$pidfile"
+    continue
+  fi
+
+  log "sending SIGTERM to '$name' (PID $pid)"
+  if ! kill -TERM "$pid" 2>/dev/null; then
+    log "SIGTERM to $pid failed — process may have just exited"
+    rm -f "$pidfile"
+    continue
+  fi
+  tracked+=( "$pidfile" )
+done
+
+if (( ${#tracked[@]} == 0 )); then
+  log "no live sessions needed signalling"
+  exit 0
+fi
+
+deadline=$(( $(date +%s) + GRACE_SECONDS ))
+while (( $(date +%s) < deadline )); do
+  alive=0
+  for pidfile in "${tracked[@]}"; do
+    [[ -f "$pidfile" ]] || continue
+    pid="$(read_pid "$pidfile")" || continue
+    if kill -0 "$pid" 2>/dev/null; then
+      alive=1
+      break
+    fi
+  done
+  (( alive == 0 )) && break
+  sleep 1
+done
+
+for pidfile in "${tracked[@]}"; do
+  [[ -f "$pidfile" ]] || continue
+  name="$(basename "$pidfile" .pid)"
+  pid="$(read_pid "$pidfile")" || { rm -f "$pidfile"; continue; }
+  if kill -0 "$pid" 2>/dev/null; then
+    log "SIGKILL straggler '$name' (PID $pid) after ${GRACE_SECONDS}s grace"
+    kill -KILL "$pid" 2>/dev/null || true
+  else
+    log "session '$name' (PID $pid) exited gracefully"
+  fi
+  rm -f "$pidfile"
+done
+
+log "shutdown complete"

--- a/kali/scripts/vk-issue-bridge.py
+++ b/kali/scripts/vk-issue-bridge.py
@@ -210,10 +210,9 @@ def parse_dependencies(
 def check_blockers(repo: str, deps: list[tuple[str | None, int]]) -> list[str]:
     """Return list of open blockers as human-readable strings.
 
-    For each (dep_repo, num) tuple, check the Issue state. Same-repo deps
-    (dep_repo is None) are checked in ``repo``; cross-repo deps use their
-    explicit repo. On any error (deleted issue, API failure), fail open —
-    omit that dep from blockers.
+    Fail-loud: any gh error or timeout raises RuntimeError. The previous
+    fail-open behavior silently bypassed dependency gating when gh was
+    misconfigured, which led to duplicate-work incidents.
     """
     open_blockers: list[str] = []
     for dep_repo, num in deps:
@@ -225,12 +224,21 @@ def check_blockers(repo: str, deps: list[tuple[str | None, int]]) -> list[str]:
                  "--repo", check_repo, "--json", "state"],
                 check=True, capture_output=True, text=True, timeout=10,
             ).stdout
-            state = json.loads(out).get("state", "").upper()
-            if state != "CLOSED":
-                open_blockers.append(display)
         except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
-                json.JSONDecodeError):
-            log(f"  ! could not check blocker {display} in {check_repo} — treating as resolved")
+                FileNotFoundError) as exc:
+            raise RuntimeError(
+                f"Blocker {display} in {check_repo} unreachable — cannot gate "
+                f"safely. Fix: check gh auth, network, or that the Issue exists. "
+                f"Underlying error: {exc}"
+            ) from exc
+        try:
+            state = json.loads(out).get("state", "").upper()
+        except json.JSONDecodeError as exc:
+            raise RuntimeError(
+                f"Blocker {display}: gh returned non-JSON. Output: {out[:200]!r}"
+            ) from exc
+        if state != "CLOSED":
+            open_blockers.append(display)
     return open_blockers
 
 
@@ -371,7 +379,12 @@ def gh_list_ready_issues() -> list[GhIssue]:
                 check=True, capture_output=True, text=True,
             ).stdout
         except subprocess.CalledProcessError as e:
-            log(f"[warn] gh issue list failed for {repo}: {e.stderr}")
+            stderr = (e.stderr or "").strip()
+            if re.search(r"\bHTTP 404\b", stderr) or "Could not resolve" in stderr:
+                first_line = stderr.splitlines()[0] if stderr else ""
+                log(f"[info] gh list skipped — {repo}: no GitHub remote ({first_line})")
+            else:
+                log(f"[warn] gh issue list failed for {repo}: {stderr}")
             continue
 
         for raw in json.loads(out):
@@ -391,9 +404,33 @@ def gh_list_ready_issues() -> list[GhIssue]:
 
 # --- Sync logic ---
 
-def build_prompt(issue: GhIssue, parsed: ParsedBody) -> str:
+def build_prompt(
+    issue: GhIssue,
+    parsed: ParsedBody,
+    deps: list[tuple[str | None, int]] | None = None,
+) -> str:
+    preamble = ""
+    if deps:
+        dep_refs = ", ".join(
+            f"{r}#{n}" if r else f"#{n}" for r, n in deps
+        )
+        preamble = (
+            f"BEFORE YOU BEGIN: This Issue declares dependencies: {dep_refs}.\n"
+            f"Verify each is CLOSED via "
+            f"`gh issue view <n> --repo <owner/repo> --json state`.\n"
+            f"If any is OPEN:\n"
+            f"  - STOP. Do not start work.\n"
+            f"  - Do not duplicate the upstream work.\n"
+            f"  - Do not start 'parts that don't depend on it'.\n"
+            f"  - Exit with message: 'Blocked on <open_blocker>, not starting.'\n"
+            f"The bridge should have deferred this workspace if a blocker were "
+            f"open — if you see this and blockers are open, report it to the "
+            f"operator.\n\n"
+            f"---\n\n"
+        )
     return (
-        f"You are a VK-spawned agent working on GitHub Issue gh#{issue.number}:\n"
+        preamble
+        + f"You are a VK-spawned agent working on GitHub Issue gh#{issue.number}:\n"
         f"{issue.title}\n\n"
         f"The Issue is at: {issue.html_url}\n"
         f"Repo: {parsed.repos[0]}\n\n"
@@ -404,7 +441,12 @@ def build_prompt(issue: GhIssue, parsed: ParsedBody) -> str:
     )
 
 
-def sync_issue(issue: GhIssue, parsed: ParsedBody, client: VkMcpClient) -> bool:
+def sync_issue(
+    issue: GhIssue,
+    parsed: ParsedBody,
+    deps: list[tuple[str | None, int]],
+    client: VkMcpClient,
+) -> bool:
     """Create VK card + workspace for one GitHub Issue. Returns True on success."""
     repo_name = parsed.repos[0]
 
@@ -468,7 +510,7 @@ def sync_issue(issue: GhIssue, parsed: ParsedBody, client: VkMcpClient) -> bool:
             name=f"{simple_id} -> gh#{issue.number}",
             executor="CLAUDE_CODE",
             repositories=[{"repo_id": repo_uuid, "branch": "main"}],
-            prompt=build_prompt(issue, parsed),
+            prompt=build_prompt(issue, parsed, deps=deps),
             issue_id=card_id,
         )
     except VkMcpError as e:
@@ -575,7 +617,13 @@ def main() -> int:
 
             # Dependency gating: skip if blockers are still open
             if deps:
-                open_blockers = check_blockers(i.repo, deps)
+                try:
+                    open_blockers = check_blockers(i.repo, deps)
+                except RuntimeError as exc:
+                    log(f"  x {i.repo}#{i.number}: BLOCKER CHECK FAILED — {exc}")
+                    push_failure_metric(str(i.number), "blocker_check_failed")
+                    failed += 1
+                    continue
                 if open_blockers:
                     blocker_str = ", ".join(open_blockers)
                     log(f"  p {i.repo}#{i.number}: blocked by {blocker_str}")
@@ -609,7 +657,7 @@ def main() -> int:
                 deferred += 1
                 continue
 
-            if sync_issue(i, parsed, client):
+            if sync_issue(i, parsed, deps, client):
                 synced += 1
                 slots -= 1
             else:

--- a/kali/tests/test_guardrails_hook.py
+++ b/kali/tests/test_guardrails_hook.py
@@ -1,0 +1,66 @@
+"""Tests for guardrails-hook.py — PostToolUse audit write path."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+HOOK = Path(__file__).parent.parent / "scripts" / "guardrails-hook.py"
+
+
+def _run_hook(payload: dict, env_overrides: dict[str, str]) -> subprocess.CompletedProcess:
+    env = {**os.environ, **env_overrides}
+    return subprocess.run(
+        ["python3", str(HOOK)],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        timeout=10,
+    )
+
+
+def test_posttooluse_bash_writes_audit_line(tmp_path):
+    fake_home = tmp_path
+    (fake_home / ".willikins-agent").mkdir(parents=True, exist_ok=True)
+    expected_log = fake_home / ".willikins-agent" / "audit.jsonl"
+
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": "ls -la"},
+        "tool_response": {"exit_code": 0},
+        "session_id": "test-session-42",
+    }
+
+    result = _run_hook(payload, {"HOME": str(fake_home)})
+    assert result.returncode == 0, f"hook exited non-zero: {result.stderr}"
+
+    assert expected_log.exists(), (
+        f"audit.jsonl was not created at {expected_log}. "
+        f"hook stderr: {result.stderr}"
+    )
+    lines = expected_log.read_text().splitlines()
+    assert len(lines) == 1
+    entry = json.loads(lines[0])
+    assert entry["command"] == "ls -la"
+    assert entry["exit_code"] == 0
+    assert entry["session"] == "test-session-42"
+
+
+def test_posttooluse_non_bash_no_write(tmp_path):
+    fake_home = tmp_path
+    (fake_home / ".willikins-agent").mkdir(parents=True, exist_ok=True)
+    expected_log = fake_home / ".willikins-agent" / "audit.jsonl"
+
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Read",
+        "tool_input": {"file_path": "/etc/passwd"},
+        "tool_response": {},
+        "session_id": "t",
+    }
+    result = _run_hook(payload, {"HOME": str(fake_home)})
+    assert result.returncode == 0
+    assert not expected_log.exists()

--- a/kali/tests/test_shutdown.sh
+++ b/kali/tests/test_shutdown.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Integration tests for scripts/shutdown.sh.
+#
+# Covers:
+#   1. SIGTERM-on-exit: a cooperating child receives SIGTERM, exits, pidfile removed.
+#   2. SIGKILL fallback: a child that ignores SIGTERM gets killed after the grace window.
+#   3. Stale pidfile: pidfile whose PID is already dead is cleaned without error.
+#   4. Empty PIDDIR: shutdown.sh is a no-op and exits 0.
+#   5. Malformed pidfile content is cleaned.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SHUTDOWN="$REPO_ROOT/scripts/shutdown.sh"
+
+[[ -x "$SHUTDOWN" ]] || { echo "FAIL: $SHUTDOWN missing or not executable"; exit 1; }
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+pass() { echo "PASS: $*"; }
+
+# Each test gets its own isolated WILLIKINS_AGENT_DIR.
+make_env() {
+    local dir
+    dir="$(mktemp -d)"
+    mkdir -p "$dir/pids"
+    printf '%s' "$dir"
+}
+
+# ── Test 1: cooperating child exits on SIGTERM ──────────────────────────────
+test_graceful_sigterm() {
+    local agent_dir
+    agent_dir="$(make_env)"
+
+    bash -c 'trap "exit 0" TERM; sleep 60 & wait $!' &
+    local pid=$!
+    echo "$pid" > "$agent_dir/pids/willikins.pid"
+    # Give bash a moment to install the trap.
+    sleep 0.2
+    kill -0 "$pid" || fail "graceful: child didn't start (pid $pid)"
+
+    WILLIKINS_AGENT_DIR="$agent_dir" SHUTDOWN_GRACE_SECONDS=5 \
+        bash "$SHUTDOWN" >/dev/null
+
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -KILL "$pid" 2>/dev/null || true
+        fail "graceful: child $pid still alive after shutdown.sh"
+    fi
+    [[ -f "$agent_dir/pids/willikins.pid" ]] && fail "graceful: pidfile not cleaned"
+    rm -rf "$agent_dir"
+    pass "graceful SIGTERM"
+}
+
+# ── Test 2: uncooperative child is SIGKILLed after the grace window ─────────
+test_sigkill_fallback() {
+    local agent_dir
+    agent_dir="$(make_env)"
+
+    # Ignore SIGTERM entirely so shutdown.sh must fall through to SIGKILL.
+    bash -c 'trap "" TERM; sleep 60 & wait $!' &
+    local pid=$!
+    echo "$pid" > "$agent_dir/pids/stuck.pid"
+    sleep 0.2
+    kill -0 "$pid" || fail "sigkill: child didn't start"
+
+    local start=$SECONDS
+    WILLIKINS_AGENT_DIR="$agent_dir" SHUTDOWN_GRACE_SECONDS=2 \
+        bash "$SHUTDOWN" >/dev/null
+    local elapsed=$((SECONDS - start))
+
+    if kill -0 "$pid" 2>/dev/null; then
+        kill -KILL "$pid" 2>/dev/null || true
+        fail "sigkill: child $pid still alive after grace period"
+    fi
+    (( elapsed >= 2 )) || fail "sigkill: returned too early (${elapsed}s, expected >=2)"
+    (( elapsed < 10 )) || fail "sigkill: hung (${elapsed}s)"
+    [[ -f "$agent_dir/pids/stuck.pid" ]] && fail "sigkill: pidfile not cleaned"
+    rm -rf "$agent_dir"
+    pass "SIGKILL fallback"
+}
+
+# ── Test 3: stale pidfile whose PID is already dead is cleaned ──────────────
+test_stale_pidfile() {
+    local agent_dir
+    agent_dir="$(make_env)"
+
+    # Start then immediately kill a child to get a pid that is recycle-safe
+    # enough for a fast test: shell's own dead children aren't reused while
+    # unreaped, but we're running under a parent that won't reap fast here.
+    # Use a very large unlikely PID instead.
+    echo "2147483600" > "$agent_dir/pids/ghost.pid"
+
+    WILLIKINS_AGENT_DIR="$agent_dir" SHUTDOWN_GRACE_SECONDS=2 \
+        bash "$SHUTDOWN" >/dev/null
+
+    [[ -f "$agent_dir/pids/ghost.pid" ]] && fail "stale: pidfile not cleaned"
+    rm -rf "$agent_dir"
+    pass "stale pidfile"
+}
+
+# ── Test 4: no pidfiles at all — clean exit ─────────────────────────────────
+test_no_pidfiles() {
+    local agent_dir
+    agent_dir="$(make_env)"
+    WILLIKINS_AGENT_DIR="$agent_dir" bash "$SHUTDOWN" >/dev/null
+    rm -rf "$agent_dir"
+    pass "no pidfiles"
+}
+
+# ── Test 5: malformed pidfile content is removed ────────────────────────────
+test_malformed_pidfile() {
+    local agent_dir
+    agent_dir="$(make_env)"
+    printf 'not-a-pid\n' > "$agent_dir/pids/junk.pid"
+    : > "$agent_dir/pids/empty.pid"
+
+    WILLIKINS_AGENT_DIR="$agent_dir" bash "$SHUTDOWN" >/dev/null
+
+    [[ -f "$agent_dir/pids/junk.pid" ]] && fail "malformed: junk pidfile not cleaned"
+    [[ -f "$agent_dir/pids/empty.pid" ]] && fail "malformed: empty pidfile not cleaned"
+    rm -rf "$agent_dir"
+    pass "malformed pidfile"
+}
+
+test_graceful_sigterm
+test_sigkill_fallback
+test_stale_pidfile
+test_no_pidfiles
+test_malformed_pidfile
+
+echo "ALL OK"

--- a/kali/tests/test_vk_issue_bridge.py
+++ b/kali/tests/test_vk_issue_bridge.py
@@ -1,6 +1,8 @@
 """Unit tests for vk-issue-bridge — parser + helpers, no I/O."""
 import importlib.util
+import json as _json
 import os
+import subprocess as _subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -246,7 +248,7 @@ def test_sync_creates_card_via_mcp(mock_run):
     client = _make_mock_client()
     mock_run.return_value = MagicMock(returncode=0)
 
-    result = sync_issue(issue, parsed, client)
+    result = sync_issue(issue, parsed, [], client)
 
     assert result is True
     # Card created via MCP
@@ -277,7 +279,7 @@ def test_sync_returns_true_even_when_label_fails(mock_run):
 
     mock_run.side_effect = run_side_effect
 
-    result = sync_issue(issue, parsed, client)
+    result = sync_issue(issue, parsed, [], client)
 
     # Must return True — workspace IS running regardless of label failure
     assert result is True
@@ -744,6 +746,152 @@ class TestParseDependenciesFailLoud:
         i = GhIssue(number=1, title="t", body="b",
                      html_url="u", repo="o/r")
         assert i.labels == ()
+
+
+# --- check_blockers fail-loud tests (Phase 1) ---
+
+
+class TestCheckBlockersFailLoud:
+    def test_check_blockers_raises_on_gh_error(self, monkeypatch):
+        def fake_run(*a, **kw):
+            raise _subprocess.CalledProcessError(1, "gh", stderr="auth required")
+        monkeypatch.setattr(_subprocess, "run", fake_run)
+        with pytest.raises(RuntimeError, match="unreachable"):
+            mod.check_blockers("org/repo", [(None, 42)])
+
+    def test_check_blockers_returns_open_list_on_success(self, monkeypatch):
+        class _R:
+            stdout = _json.dumps({"state": "OPEN"})
+        monkeypatch.setattr(_subprocess, "run", lambda *a, **kw: _R())
+        assert mod.check_blockers("org/repo", [(None, 42)]) == ["#42"]
+
+    def test_check_blockers_skips_closed(self, monkeypatch):
+        class _R:
+            stdout = _json.dumps({"state": "CLOSED"})
+        monkeypatch.setattr(_subprocess, "run", lambda *a, **kw: _R())
+        assert mod.check_blockers("org/repo", [(None, 42)]) == []
+
+    def test_check_blockers_raises_on_non_json_response(self, monkeypatch):
+        class _R:
+            stdout = "not json at all"
+        monkeypatch.setattr(_subprocess, "run", lambda *a, **kw: _R())
+        with pytest.raises(RuntimeError, match="non-JSON"):
+            mod.check_blockers("org/repo", [(None, 42)])
+
+
+# --- check_blockers integration test: RuntimeError in main() ---
+
+BODY_WITH_SINGLE_DEP = """## Instruction
+
+Use superpowers:executing-plans to implement this task.
+
+## Workspace
+
+Repos: content-factory
+
+## Dependencies
+
+- Blocked by #8
+
+---
+"""
+
+
+@patch.object(mod, "push_heartbeat")
+@patch.object(mod, "gh_list_ready_issues")
+def test_main_counts_blocker_check_failure(mock_issues, mock_hb):
+    """When check_blockers raises RuntimeError, main() increments failed
+    and does not call sync_issue."""
+    mock_client = _make_mock_client()
+    mock_client.list_workspaces.return_value = {"workspaces": []}
+    mock_client.list_issues.return_value = {"issues": []}
+
+    issue = _make_issue(number=20, title="Task 20")
+    issue.body = BODY_WITH_SINGLE_DEP
+    mock_issues.return_value = [issue]
+
+    with patch.object(mod, "check_blockers", side_effect=RuntimeError("gh auth broke")), \
+         patch.object(mod, "sync_issue") as mock_sync, \
+         patch.object(mod, "VkMcpClient", return_value=mock_client):
+        orig = mod.MAX_CONCURRENT
+        mod.MAX_CONCURRENT = 3
+        try:
+            mod.main()
+        finally:
+            mod.MAX_CONCURRENT = orig
+
+    # sync_issue must NOT be called — issue was skipped due to blocker check failure
+    mock_sync.assert_not_called()
+
+
+# --- Blocker preamble in build_prompt tests (Phase 2) ---
+
+build_prompt = mod.build_prompt
+
+
+class TestBuildPromptBlockerPreamble:
+    def _issue(self):
+        return GhIssue(
+            number=77, title="Phase 2", body="body",
+            html_url="https://gh/org/r/issues/77", repo="org/r",
+            labels=(),
+        )
+
+    def _parsed(self):
+        return ParsedBody(skill="vk-execute", repos=["r"], raw_instruction="x")
+
+    def test_no_preamble_when_no_deps(self):
+        p = build_prompt(self._issue(), self._parsed(), deps=[])
+        assert "BEFORE YOU BEGIN" not in p
+
+    def test_preamble_when_deps_present(self):
+        deps = [(None, 42), ("other/repo", 7)]
+        p = build_prompt(self._issue(), self._parsed(), deps=deps)
+        assert "BEFORE YOU BEGIN" in p
+        assert "#42" in p
+        assert "other/repo#7" in p
+        assert "STOP" in p
+        assert "do not duplicate" in p.lower()
+
+
+class TestDiscoveryWarningFiltering:
+    """Phase 1: 404s from local-only mirrors should not surface as warnings."""
+
+    def test_gh_404_is_info_not_warn(self, monkeypatch, capsys):
+        monkeypatch.setattr(mod, "discover_repos", lambda *a, **kw: ["derio-profile"])
+
+        def fake_run(*args, **kwargs):
+            raise _subprocess.CalledProcessError(
+                1, "gh",
+                stderr="HTTP 404: Not Found (https://api.github.com/repos/derio-net/derio-profile/issues)",
+            )
+        monkeypatch.setattr(_subprocess, "run", fake_run)
+
+        issues = mod.gh_list_ready_issues()
+        assert issues == []
+
+        captured = capsys.readouterr()
+        combined = captured.err + captured.out
+        assert "[warn]" not in combined
+        assert "[info]" in combined
+        assert "derio-profile" in combined
+
+    def test_gh_generic_error_still_warns(self, monkeypatch, capsys):
+        monkeypatch.setattr(mod, "discover_repos", lambda *a, **kw: ["willikins"])
+
+        def fake_run(*args, **kwargs):
+            raise _subprocess.CalledProcessError(
+                1, "gh", stderr="HTTP 500: Internal Server Error",
+            )
+        monkeypatch.setattr(_subprocess, "run", fake_run)
+
+        issues = mod.gh_list_ready_issues()
+        assert issues == []
+
+        captured = capsys.readouterr()
+        combined = captured.err + captured.out
+        assert "[warn]" in combined
+        assert "willikins" in combined
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Completes the absorption called for by the 2026-04-15 `agents--agent-images-and-vk-local-sidecar` design spec (Status: Deployed). Since this repo was bootstrapped, persistent-agent-reliability Phases 0–2 and bridge-fail-loud Phases 0–2 merged into the now-dead `derio-net/secure-agent-kali` standalone repo. Production images kept building from here, so those changes never reached the running pod.

## What's ported

**Bridge** (`vk-issue-bridge.py`): fail-loud `parse_dependencies`, fail-loud `check_blockers`, blocker preamble in `build_prompt`, 404 demotion (no more GraphQL warn spam).

**Agent scripts**: `shutdown.sh` (new, graceful drain via SIGTERM+grace+SIGKILL), `rotate-logs.sh` + `logrotate.conf` (new, hourly), `guardrails-hook.py` (portable path), `session-manager.sh` (shutdown-marker guard), `entrypoint.sh` (SIGTERM trap + marker).

**Dockerfile**: add `logrotate` to apt install.

**Config templates**: hourly `rotate-logs` cron, portable guardrails path in `settings.json`.

**Docs**: persistent-agent-reliability plan + spec + findings; dynamic-repo-discovery spec; bridge-fail-loud plan archived; `plan-config.yaml` → `default_repo: derio-net/agent-images`.

## Tests

- 5/5 bash shutdown tests pass
- 65/65 pytest tests pass (`VK_DERIO_OPS_PROJECT_ID=dummy pytest tests/`)

## Follow-ups (next commits, not this PR)

- File Phase 3 (24h soak) issue against `derio-net/agent-images`; close `secure-agent-kali#18` as "moved"
- Close stale `secure-agent-kali#11` (bridge-fail-loud manual Phase 3 — bridge already deployed and running)
- `gh repo archive derio-net/secure-agent-kali` — hard stop on further merges there
- Remove local `~/repos/secure-agent-kali` so the bridge stops polling it

🤖 Generated with [Claude Code](https://claude.com/claude-code)