### PR TITLE
fix(kali): remove vibe-kanban invocation from entrypoint

### DIFF
--- a/kali/entrypoint.sh
+++ b/kali/entrypoint.sh
@@ -71,9 +71,6 @@ fi
 # ── Start supercronic (non-root cron) ──
 supercronic "$HOME/.crontab" &
 
-# ── Start VibeKanban in local mode (SQLite, port 8081) ──
-vibe-kanban &
-
 # Trap SIGTERM/SIGINT so K8s pod termination runs shutdown.sh before we exit.
 # shutdown.sh signals each claude remote-control PID, giving the CLI's own
 # bridge:shutdown handler a chance to deregister the environment in
@@ -91,7 +88,7 @@ shutdown_handler() {
 }
 trap shutdown_handler TERM INT
 
-echo "[agent] secure-agent-kali ready (sshd on :2222, supercronic active, vibe-kanban on :8081)"
+echo "[agent] secure-agent-kali ready (sshd on :2222, supercronic active — vibe-kanban served by vk-local sidecar on :8081)"
 
 # Wait for any child to exit — if sshd or supercronic dies, pod restarts.
 # `wait -n` returns early when a trap fires, so shutdown_handler runs on SIGTERM.


### PR DESCRIPTION
## Summary

- Remove `vibe-kanban &` and its heading comment from `kali/entrypoint.sh` (lines 74–75). The binary has never been installed in the agent-images lineage — `vk-local` owns it via the fork server artifact.
- Update the ready banner to accurately reflect the architecture: *\"vibe-kanban served by vk-local sidecar on :8081\"*.

## Why

PR #1 (`f636dca` — *absorb secure-agent-kali into agent-images*) intended to port `shutdown.sh` + SIGTERM trap + session-manager changes from the dying `secure-agent-kali` repo. It did that correctly, but inadvertently grabbed a pre-strip snapshot of the \`vibe-kanban &\` call and re-introduced it. The agent-images bootstrap (`bc6322c`) shipped without it, and builds `325b23e` → `95e364f` were correctly strip-compliant.

## Impact

Once the frank-cluster lockstep bumper merged the `f636dca` image, `secure-agent-pod` began crash-looping on every kali restart:

\`\`\`
[agent] secure-agent-kali ready (sshd on :2222, supercronic active, vibe-kanban on :8081)
/entrypoint.sh: line 75: vibe-kanban: command not found
\`\`\`

\`vk-local\` sidecar stays healthy (1/2 Ready) because it has its own binary. Only kali crashes.

## Test plan

- [x] `bash -n kali/entrypoint.sh` — syntax OK
- [x] Repo-wide grep confirms no other boot-path reference to the `vibe-kanban` binary in `kali/`
- [ ] Once merged, CI builds new `agent-images` SHA → frank-cluster lockstep bumper opens bump PR → after merge, `secure-agent-pod` reaches 2/2 Ready with no restarts; `pgrep vibe-kanban` in kali returns empty; `:8081 /api/health` served by sidecar

🤖 Generated with [Claude Code](https://claude.com/claude-code)