### PR TITLE
docs: Phase 3 deployment deviations + restore findings doc

### DIFF
--- a/docs/superpowers/plans/2026-04-18-persistent-agent-reliability.md
+++ b/docs/superpowers/plans/2026-04-18-persistent-agent-reliability.md
@@ -5,7 +5,7 @@
 > **For dispatch:** Use vk-dispatch to create Issues from this plan.
 
 **Spec:** `docs/superpowers/specs/2026-04-18-persistent-agent-reliability-design.md`
-**Status:** Not Started
+**Status:** Phase 3 soak reset (2026-04-20) — four deployment gaps found during monitoring; remediation PRs in flight. See "Deployment Deviations" below.
 
 **Goal:** Fix the reliability and observability issues in the Willikins persistent agent surfaced by the 2026-04-18 triage: phantom sessions accumulating in claude.ai, silently-broken audit pipeline, unrotated 332 MB session log, and vk-bridge warning spam.
 
@@ -777,3 +777,102 @@ Append a short entry to `../willikins/decisions/log.md` (via a separate commit i
 - [ ] **Step 3: Mark Status complete**
 
 Edit the `Status:` header of this plan to `Complete` and of the spec to `Complete`.
+
+---
+
+## Deployment Deviations (2026-04-20)
+
+Monitoring the pod from the Frank host (rather than from inside the agent) during what was meant to be the Phase 3 baseline revealed four gaps that meant the 24h soak could not validate what it was designed to validate. Documenting here; fixes tracked below.
+
+### D1 — Frank `preStop` hook never deployed
+
+**Symptom:** `apps/secure-agent-pod/manifests/deployment.yaml` has no `lifecycle:` block on the `kali` container; `terminationGracePeriodSeconds: 30` (plan called for ≥45). `derio-net/frank#108` was closed on 2026-04-19T20:03:37Z with zero comments and no linked PR.
+
+**Impact:** `shutdown.sh` never fires on pod drain. Phase 2's whole point — graceful SIGTERM → `bridge:shutdown` → `DELETE /v1/environments/bridge/<env_id>` → no phantom in claude.ai — is only reachable in theory. OOMKilled events (4× observed) bypass `preStop` entirely by design, so they produce phantoms regardless.
+
+**Remediation:** New PR against `derio-net/frank` (`fix/secure-agent-pod-prestop`) adds the `lifecycle.preStop.exec.command: ["/opt/scripts/shutdown.sh"]` and raises grace to `45`.
+
+### D2 — Live `~/.crontab` is stale (PVC-first-boot-only seeding)
+
+**Symptom:** The image at `ghcr.io/derio-net/secure-agent-kali:b3b0899...` ships `/opt/crontab` with the log-rotation entry, but the running pod's `~/.crontab` (on the PVC) lacks it. The `session-willikins.log` has grown to 359 MB without a single rotation.
+
+**Root cause:** `entrypoint.sh:9` seeds `~/.crontab` only when it doesn't exist (`[ -f … ] || cp …`). Once a PVC has a crontab, image updates to `config-templates/crontab.txt` never reach the pod. Same class of gotcha as the PVC-hides-image-files one documented in frank's `CLAUDE.md`.
+
+**Why not auto-reconcile in entrypoint:** the operator has legitimate customizations in `~/.crontab` (exercise reminders disabled on 2026-04-06 with documented rationale). Unconditional overwrite would clobber operator intent. A proper additive/marker-aware reseed deserves its own plan.
+
+**Remediation (this plan):** manual kubectl-exec op (recorded as a runbook entry below). Future plan: design reseed semantics for PVC-backed config templates.
+
+### D3 — Findings doc lost in monorepo absorption
+
+**Symptom:** `docs/findings/2026-04-18-remote-control-shutdown.md` — the Phase 0 deliverable — was not copied into `agent-images/` when `secure-agent-kali` was absorbed on 2026-04-19. `kali/scripts/shutdown.sh:4` still references it.
+
+**Remediation:** restored from archived `derio-net/secure-agent-kali` repo to `kali/docs/findings/2026-04-18-remote-control-shutdown.md` in this PR.
+
+### D4 — Pod OOMKilled 4× in last 170 minutes
+
+**Symptom:** Per `kubectl describe`, `kali` container OOMKilled once (Apr 19 22:26, 32Gi limit), `vk-local` OOMKilled 3× (Apr 20 ~08:12, 2Gi limit). OOMKills use SIGKILL → `preStop` cannot fire → any future `preStop` wiring won't help these paths.
+
+**Impact on soak:** the "phantoms ≈ restarts" vs "phantoms ≪ restarts" heuristic in Phase 3 Task 2 Step 2 implicitly assumes restarts flow through SIGTERM. OOMKill restarts are a separate population that graceful shutdown can't address — any observed phantom delta must be stratified by restart cause.
+
+**Remediation:** out of scope for this plan. If OOMKill frequency persists after the soak restarts cleanly, open a follow-up plan to profile memory use in both containers.
+
+### Remediation PRs
+
+- `derio-net/agent-images#?` — this PR: findings doc restored, deviations documented, Status line updated.
+- `derio-net/frank#?` — preStop hook + grace period on `secure-agent-pod` deployment.
+
+### Post-merge manual operation
+
+```yaml
+# manual-operation
+id: secure-agent-pod-crontab-reseed-2026-04-20
+layer: agent
+app: secure-agent-pod
+plan: 2026-04-18-persistent-agent-reliability
+when: once, after agent-images reliability PRs merge and new image is deployed
+why_manual: |
+  ~/.crontab lives on a PVC and is only seeded on first-boot. The running pod's
+  ~/.crontab is from the pre-Phase-1 image (no log rotation entry). Operator has
+  legitimate customizations (exercise reminders disabled 2026-04-06) that must
+  not be clobbered — so we surgically add the missing entry via kubectl exec
+  rather than overwriting.
+commands:
+  - |
+    source .env && kubectl exec -n secure-agent-pod deploy/secure-agent-pod -c kali -- bash -c '
+      if ! grep -qF "/opt/scripts/rotate-logs.sh" ~/.crontab; then
+        cat >> ~/.crontab <<'\''EOF'\''
+
+    # Log rotation (hourly) — added manually 2026-04-20 (D2)
+    7 * * * * /opt/scripts/rotate-logs.sh >> /home/claude/.willikins-agent/logrotate.log 2>&1
+    EOF
+        echo "added rotate-logs entry"
+      else
+        echo "rotate-logs entry already present"
+      fi
+    '
+  - |
+    # supercronic watches ~/.crontab and auto-reloads on change — no restart needed.
+    # But to exercise the preStop path at least once, roll the pod:
+    source .env && kubectl rollout restart deploy/secure-agent-pod -n secure-agent-pod
+verify:
+  - |
+    # Cron picks up the entry
+    source .env && kubectl exec -n secure-agent-pod deploy/secure-agent-pod -c kali -- grep rotate-logs ~/.crontab
+  - |
+    # Within an hour, logrotate.log shows activity and session-willikins.log size drops
+    source .env && kubectl exec -n secure-agent-pod deploy/secure-agent-pod -c kali -- bash -c '
+      ls -lh ~/.willikins-agent/logrotate.log ~/.willikins-agent/session-willikins.log ~/.willikins-agent/logrotate.state 2>&1
+    '
+  - |
+    # Pod respects preStop — watch for shutdown.log entries on next drain
+    source .env && kubectl exec -n secure-agent-pod deploy/secure-agent-pod -c kali -- ls -la ~/.willikins-agent/shutdown.log
+status: pending
+```
+
+### Phase 3 restart plan
+
+After both PRs merge and the kubectl reseed runs:
+
+1. Capture fresh baseline (`session-willikins.log` size post-rotation, `audit.jsonl` line count, `shutdown.log` existence, PID dir).
+2. Roll the pod once to exercise `preStop` → `shutdown.sh` → `bridge:shutdown` path. Verify `shutdown.log` shows entries and no orphaned `claude remote-control` on the new pod.
+3. Start 24h observation window per original Task 2; stratify restart-cause (SIGTERM-drained vs OOMKilled) when interpreting phantom delta.

--- a/kali/docs/findings/2026-04-18-remote-control-shutdown.md
+++ b/kali/docs/findings/2026-04-18-remote-control-shutdown.md
@@ -1,0 +1,198 @@
+# Remote-Control Shutdown — Findings
+
+Phase 0 spike for the `persistent-agent-reliability` plan. Goal: determine
+whether the `claude` CLI offers a clean way to disconnect a remote-control
+session so the persistent agent stops accumulating phantom sessions in
+claude.ai.
+
+Investigation environment: `claude` 2.1.114 inside the agent pod
+(`/home/claude/.local/share/claude/versions/2.1.114`, 236 MB statically
+linked binary).
+
+## CLI surface
+
+`claude --help` and `claude remote-control --help` were inspected. Relevant
+remote-control flags exist on the `claude` top level and on the subcommand:
+
+```
+--remote-control-session-name-prefix <prefix>
+    Prefix for auto-generated Remote Control session names
+    (default: hostname; env: CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX)
+```
+
+`claude remote-control --help` documents only `--name`, `--spawn`,
+`--capacity`, `--permission-mode`, `--debug-file`, `--verbose`, and
+`--[no-]create-session-in-dir`. **No subcommand for `list`, `close`,
+`disconnect`, `stop`, or `rm` exists**:
+
+```
+$ claude remote-control list
+Error: Unknown argument: list
+$ claude remote-control close
+Error: Unknown argument: close
+```
+
+`claude auth` only exposes `login`, `logout`, `status` — nothing
+session-aware.
+
+In short: **no public CLI affordance for remotely closing a specific
+remote-control session by name or id.**
+
+## State dir
+
+`~/.claude/` contains the expected layout. The two interesting
+subdirectories:
+
+- `~/.claude/sessions/<pid>.json` — one entry per *currently running* CLI
+  process. Schema:
+  `{pid, sessionId (uuid), cwd, startedAt, version, kind, entrypoint}`.
+  This is purely an in-process registry — restarts of the agent leave no
+  stale entries here.
+- `~/.claude/session-env/<uuid>/` — **1 123 empty directories** on the
+  inspected pod. These are per-session scratch dirs that the CLI creates
+  when a session starts but never removes on exit. They do not contain the
+  remote `environment_id` returned by the bridge API; they are local
+  bookkeeping only.
+
+The bridge environment id is *not* persisted to a stable file the operator
+can grep for. The CLI writes a `bridge-pointer.json` under
+`~/.claude/projects/<encoded-cwd>/bridge-pointer.json` while a bridge is
+active (encoder logic: `kD$.join(s8(), "projects", IJ(cwd))`). On the
+inspected pod no such file exists — the agent's bridge sessions had
+already exited by the time we looked. The pointer is removed by the CLI's
+own graceful-shutdown handler (`clearBridgePointer(dir)`), so it is
+present only while the bridge process is alive.
+
+The 1 123 empty `session-env/` dirs are a separate accumulation bug
+(per-session scratch space that is never cleaned up). They are local
+disk noise but not the cause of the phantom claude.ai sessions.
+
+## Server endpoint
+
+A clean disconnect endpoint **does exist**, even though it is not surfaced
+on the CLI. Strings extracted from the binary include the bridge HTTP
+client:
+
+```
+[bridge:api] POST   /v1/environments/bridge        (registerBridgeEnvironment)
+[bridge:api] DELETE /v1/environments/bridge/<env_id>   (deregisterEnvironment)
+[bridge:api] POST   /v1/sessions/<id>/archive          (archiveSession)
+[bridge:api] POST   /v1/environments/<env>/work/<id>/stop  (stopWork)
+```
+
+The CLI's own shutdown path uses these. Decompiled inline from the binary
+(string-extracted, formatting cleaned up):
+
+```js
+[bridge:shutdown] Shutting down ${D.size} active session(s)
+[bridge:shutdown] Sending SIGTERM to sessionId=${e}
+[bridge:shutdown] Force-killing stuck sessionId=${e}
+[bridge:shutdown] Cleaning up ${e.length} worktree(s)
+…
+await K.deregisterEnvironment($)
+[bridge:shutdown] Environment deregistered, bridge offline
+await clearBridgePointer(H.dir)
+```
+
+The handler is wired to `SIGTERM` at top level:
+
+```js
+process.on("SIGTERM", () => {
+    A8("info","shutdown_signal",{signal:"SIGTERM"});
+    w7(143);
+});
+```
+
+Where `w7(143)` is the graceful exit path that drains `bridge:shutdown`
+above — i.e. **a SIGTERM delivered to the `claude remote-control` process
+itself triggers `DELETE /v1/environments/bridge/<env_id>` against the
+Anthropic API and removes the local pointer.**
+
+Auth headers used by `deregisterEnvironment` are the same OAuth bearer
+already cached in `~/.claude/.credentials.json`, plus
+`x-organization-uuid`. There is no separate setup the agent needs.
+
+Bottom line: the *capability* is there. The *bug* is that the agent never
+gets to invoke it — the supervisor wrapper hides the right PID and the pod
+shutdown path doesn't deliver SIGTERM to claude.
+
+## Signal behavior
+
+Live SIGTERM/SIGINT testing was deferred — running a real
+`claude remote-control` from the spike pod would create a real environment
+in claude.ai (the user's account), and if the signal handler reasoning
+below is wrong the test itself would leave a phantom. The static evidence
+above is sufficient to decide Phase 1's direction; Phase 1 verifies
+empirically when implementing `shutdown.sh`.
+
+The relevant structural problem is in the existing supervisor.
+`scripts/session-manager.sh` starts each bridge as:
+
+```bash
+nohup bash -c "echo y | claude remote-control --name '$SESSION_NAME'" \
+  >> "...session-${SESSION_NAME}.log" 2>&1 &
+echo $! > "$PIDFILE"
+```
+
+The PID written to `$PIDFILE` is the wrapper `bash -c`, not `claude`.
+On `kill -TERM "$(cat $PIDFILE)"`:
+
+- `bash` receives SIGTERM. It does not forward signals to children of a
+  pipeline by default. `bash -c '<pipeline>'` exits, the pipeline is left
+  to finish or get reaped, and `claude`'s own SIGTERM handler is
+  **not** invoked by our kill.
+- Even if claude eventually exits, it exits because its stdin/stdout
+  closed, not because of SIGTERM — that path goes through process exit
+  cleanup, not the documented `bridge:shutdown` handler. The remote
+  bridge is not deregistered.
+- On pod termination, Kubernetes sends SIGTERM to PID 1 (here:
+  vibe-kanban or supercronic depending on context); orphaned `claude`
+  processes get SIGKILL after the grace period — also no clean shutdown.
+
+This matches the symptom: phantoms accumulate one-per-restart in
+claude.ai.
+
+The fix has two parts:
+
+1. **Make the tracked PID == claude's PID.** Replace the wrapper with
+   `exec`, e.g.
+   `nohup bash -c "exec claude remote-control --name '$SESSION_NAME' < <(echo y)" …`
+   so `bash` is replaced in-place by `claude`. Now `kill -TERM
+   "$(cat $PIDFILE)"` reaches the claude process directly and its
+   internal SIGTERM handler runs `bridge:shutdown` → DELETE
+   `/v1/environments/bridge/<env_id>`.
+2. **Add a pod-level shutdown hook** (`scripts/shutdown.sh`) that loops
+   over `$PIDDIR/*.pid` and sends SIGTERM, then waits up to ~30 s
+   (bridge:shutdown's `loop_grace_ms` default) before SIGKILL. Wire it as
+   a Kubernetes `preStop` hook on the agent deployment in
+   `derio-net/frank` so the pod actually gets a chance to deregister
+   before SIGKILL.
+
+The Frank deployment change is filed as a separate Issue against
+`derio-net/frank`, per the plan's architecture note — not part of this
+plan's PR chain.
+
+## Decision for Phase 1
+
+**Chosen: A (close API available).**
+
+Reason: The CLI bundles a working bridge-deregister code path
+(`DELETE /v1/environments/bridge/<env_id>` invoked from
+`[bridge:shutdown]`) and wires it to `SIGTERM`. We do not need to
+reverse-engineer or reimplement that endpoint. We need only deliver
+SIGTERM to the right PID and give the process time to drain. Concretely
+Phase 1 should:
+
+- Change `session-manager.sh` to launch claude via `exec` so `$PIDFILE`
+  records claude's PID (not bash's).
+- Add `scripts/shutdown.sh` that iterates the PID dir, sends SIGTERM,
+  waits ≤30 s per process, then SIGKILL as fallback.
+- File a separate Issue against `derio-net/frank` to wire `shutdown.sh`
+  as a `preStop` hook with a `terminationGracePeriodSeconds` ≥ 35.
+- Independent cleanup for the 1 123 stale `~/.claude/session-env/<uuid>/`
+  dirs (cron job that prunes empty ones older than N hours) belongs in
+  the housekeeping batch — it is unrelated to phantoms in claude.ai.
+- Verify empirically during Phase 1 implementation: start a bridge,
+  capture the claude PID directly, send SIGTERM, confirm the
+  `claude.ai/code` UI shows the session disappear within 30 s and that
+  `bridge-pointer.json` is removed.


### PR DESCRIPTION
## Summary

Phase 3 of the `persistent-agent-reliability` plan was meant to be a 24h soak validating graceful shutdown. Running the baseline check *from the Frank host* (rather than from inside the agent) immediately revealed four gaps that meant the soak couldn't validate what it was designed to:

| # | Gap | Fix |
|---|---|---|
| D1 | Frank deployment missing `preStop` hook; `frank#108` closed without a PR | **Separate PR** against `derio-net/frank` |
| D2 | `~/.crontab` on PVC is stale (no log-rotation entry); `entrypoint.sh` only seeds on first boot; operator has legitimate customizations that forbid unconditional overwrite | Manual kubectl reseed (runbook entry below) |
| D3 | Phase 0 findings doc lost in `secure-agent-kali` absorption; `shutdown.sh:4` references it | **This PR** — restored from archived repo |
| D4 | Pod OOMKilled 4× recently (kali 1×, vk-local 3×); these paths bypass `preStop` by design | Out of scope — follow-up plan if persistent |

## What's in this PR

1. `kali/docs/findings/2026-04-18-remote-control-shutdown.md` — restored from `derio-net/secure-agent-kali` (archived repo) via `gh api /repos/.../contents/...`. Now the Phase 2 shutdown.sh's opening comment (line 4) has a local anchor.
2. Plan file updated:
   - `Status:` line now describes the soak-reset state instead of "Not Started"
   - New "Deployment Deviations (2026-04-20)" section at the end with D1–D4 analysis
   - Runbook entry for the manual crontab reseed (tagged `# manual-operation` for `/sync-runbook`)
   - "Phase 3 restart plan" describing the fresh baseline + controlled pod roll + 24h observation window, with restart-cause stratification

## Why the crontab isn't auto-reconciled in `entrypoint.sh`

The operator has intentional customizations in the live `~/.crontab` (exercise reminders disabled 2026-04-06 with documented rationale). Unconditional overwrite on every boot would clobber that. A proper additive/marker-aware reseed pattern is its own design problem and deserves its own plan — logged as a follow-up in the deviations section.

## Companion PRs / refs

- `derio-net/frank` PR (forthcoming): preStop hook + `terminationGracePeriodSeconds: 45` on `apps/secure-agent-pod/manifests/deployment.yaml` — replaces the silently-closed `frank#108`.

## Test plan

- [x] `vk plan format` still returns `phased`
- [x] `vk plan self-review` passes
- [ ] After merge + frank PR merge + kubectl reseed: verify `logrotate.log` shows activity within the hour and `session-willikins.log` drops from 359 MB
- [ ] Roll pod once → confirm `~/.willikins-agent/shutdown.log` has entries (graceful shutdown path exercised)
- [ ] 24h soak restart with stratified observation