### PR TITLE
fix(kali): narrow logrotate first block to session-willikins.log (D5)

### DIFF
--- a/docs/superpowers/plans/2026-04-18-persistent-agent-reliability.md
+++ b/docs/superpowers/plans/2026-04-18-persistent-agent-reliability.md
@@ -5,7 +5,7 @@
 > **For dispatch:** Use vk-dispatch to create Issues from this plan.
 
 **Spec:** `docs/superpowers/specs/2026-04-18-persistent-agent-reliability-design.md`
-**Status:** Phase 3 soak reset (2026-04-20) — four deployment gaps found during monitoring; remediation PRs in flight. See "Deployment Deviations" below.
+**Status:** Phase 3 soak running (2026-04-20 09:31 UTC). D1 + D3 landed in `derio-net/frank#114` and `derio-net/agent-images#4`; D2 resolved via kubectl reseed per runbook; D5 discovered during the first rotation and fixed here. 24h observation window active.
 
 **Goal:** Fix the reliability and observability issues in the Willikins persistent agent surfaced by the 2026-04-18 triage: phantom sessions accumulating in claude.ai, silently-broken audit pipeline, unrotated 332 MB session log, and vk-bridge warning spam.
 
@@ -807,6 +807,16 @@ Monitoring the pod from the Frank host (rather than from inside the agent) durin
 **Symptom:** `docs/findings/2026-04-18-remote-control-shutdown.md` — the Phase 0 deliverable — was not copied into `agent-images/` when `secure-agent-kali` was absorbed on 2026-04-19. `kali/scripts/shutdown.sh:4` still references it.
 
 **Remediation:** restored from archived `derio-net/secure-agent-kali` repo to `kali/docs/findings/2026-04-18-remote-control-shutdown.md` in this PR.
+
+### D5 — `logrotate.conf` duplicate-entry error (found during Phase 3 reseed)
+
+**Symptom:** First manual invocation of `rotate-logs.sh` after the reseed emitted `/opt/scripts/logrotate.conf:18 duplicate log entry for /home/claude/.willikins-agent/session-manager.log` — surfaced only because rotation had never actually run before. The heavy target (`session-willikins.log`) still rotated correctly (359M → 0 via `copytruncate`), but the duplicate error would block the cleaner execution expected under a real soak.
+
+**Root cause:** First block's `session-*.log` glob matches `session-manager.log`, and the second block also lists it explicitly. Logrotate correctly refuses to process the same file against two different policies. The original intent was for the first block to cover the heavy transcript log only (50 MB threshold, 5 rotations) and for the operational logs to use the second block (20 MB, 3 rotations).
+
+**Remediation:** one-line fix to `kali/scripts/logrotate.conf` in this PR — narrow the first block from `session-*.log` to `session-willikins.log`. Added a comment explaining why the glob must not be widened back.
+
+**Operational impact before fix:** near-zero today — `session-manager.log` was 512 KB, `vk-bridge.log` 4.8 MB, `audit.jsonl` 75 KB, all well under the 20 MB threshold. But future growth would hit the duplicate-entry error on every hourly cron run.
 
 ### D4 — Pod OOMKilled 4× in last 170 minutes
 

--- a/kali/scripts/logrotate.conf
+++ b/kali/scripts/logrotate.conf
@@ -3,7 +3,12 @@
 # session). Accepted quirk — see plan
 # docs/superpowers/plans/2026-04-18-persistent-agent-reliability.md Task 3.
 
-/home/claude/.willikins-agent/session-*.log {
+# session-willikins.log is the heavy transcript from `claude remote-control`
+# (observed 359 MB pre-rotation). The operational logs below use smaller
+# thresholds. Do NOT widen this to `session-*.log` — that glob also matches
+# `session-manager.log`, which is in the second block, and logrotate errors
+# on the resulting duplicate entry.
+/home/claude/.willikins-agent/session-willikins.log {
     size 50M
     rotate 5
     compress


### PR DESCRIPTION
## Summary

One-line fix to `kali/scripts/logrotate.conf`: narrow the first block's glob from `session-*.log` to `session-willikins.log` so it no longer overlaps with the operational-logs block below.

## Why

Surfaced during the Phase 3 soak reset on 2026-04-20 — the very first manual `rotate-logs.sh` invocation after the kubectl-driven crontab reseed emitted:

```
error: /opt/scripts/logrotate.conf:18 duplicate log entry for /home/claude/.willikins-agent/session-manager.log
```

Root cause: `session-*.log` matches `session-manager.log`, and the second block lists `session-manager.log` explicitly. Logrotate correctly refuses to rotate the same file under two different policies.

The original intent was:
- **First block** — heavy transcript (`session-willikins.log`): 50 MB threshold, 5 rotations, dated archives (for forensic retention of rare runaway sessions).
- **Second block** — operational logs (`vk-bridge.log`, `session-manager.log`, `audit.jsonl`): 20 MB threshold, 3 rotations, no dateext (small rolling window).

The `session-*.log` glob was a slip that was invisible until rotation actually ran.

## Impact today

Minimal. The session-willikins.log rotation already succeeded (359M → 0 via copytruncate) despite the error — logrotate processed it under the first block's policy before failing the duplicate check on the second block. The operational logs are all well under their 20 MB threshold:

| File | Size | Threshold |
|---|---|---|
| `session-manager.log` | 512 KB | 20 MB |
| `vk-bridge.log` | 4.8 MB | 20 MB |
| `audit.jsonl` | 75 KB | 20 MB |

But the duplicate-entry error would fire on every hourly cron run, and the moment any operational log grows past 20 MB, rotation would start failing with unclear symptoms.

## Inline guard rail

Added a comment above the narrowed glob explaining *why* it must not be widened back — so a future reader doesn't helpfully "simplify" it and reintroduce the bug.

## Plan update

`docs/superpowers/plans/2026-04-18-persistent-agent-reliability.md`:
- New **D5** entry in "Deployment Deviations" with symptom, root cause, remediation, and operational impact.
- `Status:` promoted from "Phase 3 soak reset" to "Phase 3 soak running" — D1 (preStop) and D3 (findings doc) shipped via `#4` + `derio-net/frank#114`, D2 (stale crontab) remediated via the runbook kubectl reseed, D5 fixed in this PR.

## Test plan

- [x] `vk plan self-review` passes
- [x] Verified locally that `session-willikins.log` (the only heavy log) is the intended target of the first-block policy
- [ ] After merge + image rebuild + pod roll: confirm next `rotate-logs.sh` run produces no `duplicate log entry` in `logrotate.log`
- [ ] Soak continues; observe rotation cadence at T+2h/T+8h/T+24h