### PR TITLE
[derio-net/agent-images] agents--restart-resilience · Phase 1/4 · `/opt/agent-init.d/` shared first-boot scripts in `agent-base`

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -50,6 +50,10 @@ RUN ARCH=$([ "${TARGETARCH}" = "arm64" ] && echo "arm64" || echo "amd64") \
       "https://github.com/aptible/supercronic/releases/download/v${SUPERCRONIC_VERSION}/supercronic-linux-${ARCH}" \
     && chmod +x /usr/local/bin/supercronic
 
+# ── Shared first-boot scripts (called by children's entrypoint or s6 cont-init.d) ──
+COPY opt/agent-init.d/ /opt/agent-init.d/
+RUN chmod +x /opt/agent-init.d/*
+
 # ── Non-root user (UID/GID 1000 — matches PVC ownership) ──
 RUN /usr/sbin/addgroup --gid 1000 claude \
     && /usr/sbin/adduser --uid 1000 --gid 1000 --disabled-password --gecos "" --shell /bin/bash claude

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -7,6 +7,7 @@ ARG SUPERCRONIC_VERSION=0.2.33
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=UTC \
     HOME=/home/claude \
+    AGENT_HOME=/home/claude \
     PATH=/home/claude/.local/bin:/usr/local/bin:/usr/bin:/bin
 
 # ── System packages ──

--- a/base/opt/agent-init.d/01-pvc-dirs
+++ b/base/opt/agent-init.d/01-pvc-dirs
@@ -1,0 +1,7 @@
+#!/bin/bash
+# 01-pvc-dirs — Create PVC-backed directories with correct permissions.
+# Idempotent: every-boot script. Uses $AGENT_HOME (set in agent-base ENV).
+set -e
+HOME="${AGENT_HOME:-$HOME}"
+mkdir -p "$HOME/.ssh-host-keys" "$HOME/.ssh" "$HOME/repos" "$HOME/.claude" "$HOME/.willikins-agent"
+chmod 700 "$HOME/.ssh-host-keys" "$HOME/.ssh"

--- a/base/opt/agent-init.d/02-credential-migrate
+++ b/base/opt/agent-init.d/02-credential-migrate
@@ -1,0 +1,14 @@
+#!/bin/bash
+# 02-credential-migrate — Migrate legacy gitconfig credential helper to /proc/1/environ.
+#
+# The env-var-based helper only worked when the caller had sourced ~/.bashrc
+# (e.g. interactive ssh shells). It silently failed for VS Code's git
+# subprocess and cron jobs. The /proc/1/environ helper works regardless.
+set -e
+HOME="${AGENT_HOME:-$HOME}"
+[ -f /opt/gitconfig ] || exit 0
+[ -f "$HOME/.gitconfig" ] || exit 0
+if grep -qF 'password=$GITHUB_TOKEN' "$HOME/.gitconfig"; then
+    echo "[agent-init] migrating git credential helper to /proc/1/environ reader"
+    cp /opt/gitconfig "$HOME/.gitconfig"
+fi

--- a/base/opt/agent-init.d/03-credential-scrub
+++ b/base/opt/agent-init.d/03-credential-scrub
@@ -1,0 +1,27 @@
+#!/bin/bash
+# 03-credential-scrub — Strip leaked tokens from PVC-resident git config.
+#
+# Removes url.*@github.com/.insteadof rewrites (which embed tokens on disk)
+# and rewrites any ~/repos/* origins that have credentials in the URL.
+# Credentials must only be injected at push time via the $GITHUB_TOKEN env var.
+set -e
+HOME="${AGENT_HOME:-$HOME}"
+
+while IFS= read -r key; do
+    [ -z "$key" ] && continue
+    case "$key" in
+        *@github.com*) git config --global --unset-all "$key" || true ;;
+    esac
+done < <(git config --global --name-only --get-regexp '^url\..*\.insteadof$' 2>/dev/null || true)
+
+shopt -s nullglob
+for repo_dir in "$HOME"/repos/*/; do
+    [ -d "$repo_dir/.git" ] || continue
+    origin_url=$(git -C "$repo_dir" remote get-url origin 2>/dev/null) || continue
+    clean_url=$(printf '%s' "$origin_url" | sed -E 's#https://[^@/]+@github\.com/#https://github.com/#')
+    if [ "$origin_url" != "$clean_url" ]; then
+        git -C "$repo_dir" remote set-url origin "$clean_url"
+        echo "[agent-init] scrubbed credentials from $(basename "$repo_dir") origin"
+    fi
+done
+shopt -u nullglob


### PR DESCRIPTION
📦 Repo:   derio-net/agent-images
📋 Plan:   docs/superpowers/plans/2026-04-27--agents--restart-resilience.md
📐 Spec:   derio-net/frank:docs/superpowers/specs/2026-04-27--agents--restart-resilience-design.md
🎯 Phase:  1/4 — `/opt/agent-init.d/` shared first-boot scripts in `agent-base` [agentic]
🔗 Issue:  https://github.com/derio-net/agent-images/issues/16

**Goal (from plan):** Build the image foundation that lets the secure-agent-pod (and the planned fleet of sibling agent pods) survive container restarts gracefully. Specifically: introduce `agent-shell-base` (s6-overlay v3 + supervised sshd/supercronic + tmux-resurrect/continuum + parameterized AGENT_USER/AGENT_HOME), migrate secure-agent-kali to use it, and give vk-local consistent first-boot setup without subjecting it to s6 (vibe-kanban stays a single-driver-process container under K8s supervision).

---

## Summary

Lifts first-boot setup currently inline in `kali/entrypoint.sh` into per-script files under `/opt/agent-init.d/`, so both upcoming consumers can call them:

- **`agent-shell-base`** (Phase 2, via s6 `cont-init.d` wrapper) — used by kali after Phase 3 cuts it over.
- **`vk-local`** (Phase 4, via thin entrypoint wrapper) — keeps `vibe-kanban` as PID 1 driver process, no s6.

No behavior change to existing children yet — kali still has its own `entrypoint.sh` that doesn't call these. Phase 3 cuts kali over.

## Scripts added

| Script | Purpose |
|---|---|
| `01-pvc-dirs` | Create PVC-backed dirs (`.ssh-host-keys`, `.ssh`, `repos`, `.claude`, `.willikins-agent`) with correct perms. |
| `02-credential-migrate` | Migrate legacy gitconfig credential helper (env-var → `/proc/1/environ` reader). |
| `03-credential-scrub` | Strip leaked tokens from PVC-resident git config (`url.*@github.com.insteadof` rewrites and embedded-token origin URLs). |

All three are idempotent (every-boot safe), use `${AGENT_HOME:-$HOME}` so they work for both legacy `claude`/`/home/claude` and future `agent`/`/home/agent` identity, and are safe to call as the non-root agent user.

## Dockerfile change

`base/Dockerfile` gains:

```dockerfile
COPY opt/agent-init.d/ /opt/agent-init.d/
RUN chmod +x /opt/agent-init.d/*
```

## Test plan

- [x] Scripts run to completion exit 0 on a fresh `$AGENT_HOME` (verified standalone in worktree).
- [x] `01-pvc-dirs` creates expected dirs with `700` on `.ssh-host-keys`/`.ssh`.
- [x] Re-run is a no-op (idempotency verified).
- [x] `02-credential-migrate` exits early when `/opt/gitconfig` is absent.
- [x] `03-credential-scrub` exits clean when no `~/repos/*` are present.
- [ ] CI matrix builds `agent-base` + `secure-agent-kali` + `vk-local` green.

## Coordination

Per the plan:

> The bumper workflow will fire a chore PR in frank — **do not merge it yet** until Phase 4 lands. Hold or close the bump PR.

Bundling all four phases (1–4) into a single frank-side cutover keeps the rollout atomic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)