### PR TITLE
fix(bridge): push failure metric on silent parse_error / unknown_repo paths

### DIFF
--- a/kali/scripts/vk-issue-bridge.py
+++ b/kali/scripts/vk-issue-bridge.py
@@ -778,10 +778,12 @@ def main() -> int:
             parsed = parse_issue_body(i.body)
             if parsed.parse_error:
                 log(f"  x {i.repo}#{i.number}: PARSE ERROR — {parsed.parse_error}")
+                push_failure_metric(str(i.number), "parse_error")
                 failed += 1
                 continue
             if parsed.repos[0] not in vk_repo_names:
                 log(f"  x {i.repo}#{i.number}: unknown repo '{parsed.repos[0]}'")
+                push_failure_metric(str(i.number), "unknown_repo")
                 failed += 1
                 continue
 

--- a/kali/tests/test_vk_issue_bridge.py
+++ b/kali/tests/test_vk_issue_bridge.py
@@ -405,6 +405,54 @@ def test_main_respects_slots_even_when_label_fails(mock_issues, mock_blockers, m
         assert mock_sync.call_count == 3
 
 
+# --- Silent-failure metric tests: main() must push failure_total
+#     on parse_error and unknown_repo paths so degradations are observable ---
+
+@patch.object(mod, "push_heartbeat")
+@patch.object(mod, "push_failure_metric")
+@patch.object(mod, "gh_list_ready_issues")
+def test_main_pushes_metric_on_parse_error(mock_issues, mock_failure, mock_hb):
+    """An issue with a free-form body (no Instruction/Workspace blocks) must
+    push willikins_vk_bridge_failure_total{reason='parse_error'}.
+
+    Regression: 2026-04-29 incident where superpowers-for-vk#55 caused the
+    bridge to exit 1 every 2 minutes without any metric ever incrementing,
+    leaving the existing failure-rate alert blind.
+    """
+    mock_client = _make_mock_client()
+    issue = _make_issue(number=55, title="Workflow gap notes")
+    issue.body = "Two related cross-repo workflow gaps surfaced..."
+    mock_issues.return_value = [issue]
+
+    with patch.object(mod, "VkMcpClient", return_value=mock_client):
+        mod.main()
+
+    mock_failure.assert_called_once_with("55", "parse_error")
+
+
+@patch.object(mod, "push_heartbeat")
+@patch.object(mod, "push_failure_metric")
+@patch.object(mod, "gh_list_ready_issues")
+def test_main_pushes_metric_on_unknown_repo(mock_issues, mock_failure, mock_hb):
+    """An issue whose ## Workspace points at a repo VK doesn't know about
+    must push willikins_vk_bridge_failure_total{reason='unknown_repo'}.
+    """
+    mock_client = _make_mock_client()
+    issue = _make_issue(number=77, title="Task in mystery repo")
+    issue.body = (
+        "## Instruction\n\n"
+        "Use superpowers:executing-plans to implement this task.\n\n"
+        "## Workspace\n\n"
+        "Repos: not-a-real-repo\n"
+    )
+    mock_issues.return_value = [issue]
+
+    with patch.object(mod, "VkMcpClient", return_value=mock_client):
+        mod.main()
+
+    mock_failure.assert_called_once_with("77", "unknown_repo")
+
+
 # --- Dependency parser tests ---
 
 BODY_WITH_DEPS = """Part of: Content Pipeline Foundation


### PR DESCRIPTION
## Summary

- Push `willikins_vk_bridge_failure_total{reason="parse_error"|"unknown_repo"}` from the two `main()` branches that previously incremented `failed` but pushed nothing.
- Add regression tests for both paths.

## Why

Triaging a 2026-04-29 incident, we found the bridge was returning exit status 1 every 2 minutes for hours while VictoriaMetrics showed `willikins_vk_bridge_failure_total` flat across all reasons. The Grafana `vk-bridge-failures` alert (which queries `sum by (reason, issue) (increase(...failure_total[15m]))`) was therefore blind to the degradation.

Root cause: two early-return branches in `main()` —

1. `parsed.parse_error` (lines 779-782): an issue with a free-form body that never went through `vk plan dispatch`, so `## Instruction` / `## Workspace` are missing.
2. `parsed.repos[0] not in vk_repo_names` (lines 783-786): an issue declares a repo that VK doesn't know about.

Both incremented `failed` (driving the cron's exit status 1) but skipped `push_failure_metric()`, so neither produced a metric.

The triggering case in the incident was `derio-net/superpowers-for-vk#55`. With this patch, that issue would have produced `willikins_vk_bridge_failure_total{reason="parse_error",issue="55"}` and the alert would have fired immediately.

## Test plan

- [x] `VK_ORG_ID=test-org VK_DERIO_OPS_PROJECT_ID=test-project python3 -m pytest kali/tests/test_vk_issue_bridge.py` — 100/100 pass (2 new + 98 existing)
- [ ] After image rebuild + deploy, verify `willikins_vk_bridge_failure_total{reason="parse_error"}` appears in pushgateway when a malformed issue is present
- [ ] Verify the existing `vk-bridge-failures` alert fires for the new reasons

## Follow-ups (not in this PR)

- `_classify_gh_error` in this script silently logs HTTP 401 as `warn` without pushing a metric — same blindness pattern. Worth a follow-up so transient gh-auth blackouts also surface as alerts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)