### PR TITLE
fix(crons): tolerate unbound vars in PVC bashrc when sourced from cron

### DIFF
--- a/kali/scripts/audit-digest.sh
+++ b/kali/scripts/audit-digest.sh
@@ -4,8 +4,13 @@
 
 set -euo pipefail
 
-# Source bashrc for env vars (TELEGRAM_BOT_TOKEN, etc.)
+# Source bashrc for env vars (TELEGRAM_BOT_TOKEN, etc.). The PVC-side
+# bashrc may reference shell-state vars bound only in interactive/tmux
+# sessions (e.g. `_TMUX_LAST_PWD`); disable nounset around the source
+# so its missing refs don't kill the cron run.
+set +u
 [[ -f "$HOME/.bashrc" ]] && source "$HOME/.bashrc"
+set -u
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 AUDIT_LOG="/home/claude/.willikins-agent/audit.jsonl"

--- a/kali/scripts/exercise-cron.sh
+++ b/kali/scripts/exercise-cron.sh
@@ -3,8 +3,13 @@
 # Usage: exercise-cron.sh [desk|standing]
 set -euo pipefail
 
-# Source bashrc for env vars (TELEGRAM_BOT_TOKEN, etc.)
+# Source bashrc for env vars (TELEGRAM_BOT_TOKEN, etc.). The PVC-side
+# bashrc may reference shell-state vars bound only in interactive/tmux
+# sessions (e.g. `_TMUX_LAST_PWD`); disable nounset around the source
+# so its missing refs don't kill the cron run.
+set +u
 [[ -f "$HOME/.bashrc" ]] && source "$HOME/.bashrc"
+set -u
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="${WILLIKINS_REPO_PATH:-/home/claude/repos/willikins}"

--- a/kali/scripts/push-heartbeat.sh
+++ b/kali/scripts/push-heartbeat.sh
@@ -11,8 +11,15 @@ set -euo pipefail
 JOB="${1:?Usage: push-heartbeat.sh <job_name> [label=value ...]}"
 shift
 
-# Source bashrc for PUSHGATEWAY_URL if not already set
-[[ -z "${PUSHGATEWAY_URL:-}" ]] && [[ -f "$HOME/.bashrc" ]] && source "$HOME/.bashrc"
+# Source bashrc for PUSHGATEWAY_URL if not already set. The PVC-side
+# bashrc may reference shell-state vars bound only in interactive/tmux
+# sessions (e.g. `_TMUX_LAST_PWD`); disable nounset around the source
+# so its missing refs don't kill the cron run.
+if [[ -z "${PUSHGATEWAY_URL:-}" ]] && [[ -f "$HOME/.bashrc" ]]; then
+  set +u
+  source "$HOME/.bashrc"
+  set -u
+fi
 
 PUSHGATEWAY_URL="${PUSHGATEWAY_URL:?PUSHGATEWAY_URL must be set}"
 

--- a/kali/scripts/session-manager.sh
+++ b/kali/scripts/session-manager.sh
@@ -6,8 +6,13 @@
 set -euo pipefail
 
 # Source bashrc for env vars (WILLIKINS_REPOS, GITHUB_TOKEN, etc.)
-# Needed when invoked by supercronic which doesn't load login shell
+# Needed when invoked by supercronic which doesn't load login shell.
+# The PVC-side bashrc may reference shell-state vars that are bound
+# only in interactive/tmux sessions (e.g. `_TMUX_LAST_PWD`); disable
+# nounset around the source so its missing refs don't kill the cron run.
+set +u
 [[ -f "$HOME/.bashrc" ]] && source "$HOME/.bashrc"
+set -u
 
 LOGFILE="/home/claude/.willikins-agent/session-manager.log"
 PIDDIR="/home/claude/.willikins-agent/pids"


### PR DESCRIPTION
## Summary

- Wrap the `source ~/.bashrc` call in `set +u` / `set -u` in `session-manager.sh`, `audit-digest.sh`, `exercise-cron.sh`, and `push-heartbeat.sh` so they survive a bashrc that references shell-state variables only bound in interactive/tmux sessions.

## Why

These four scripts all open with `set -euo pipefail` and then source the PVC-side `~/.bashrc` to pick up env vars (`WILLIKINS_REPOS`, `PUSHGATEWAY_URL`, `TELEGRAM_BOT_TOKEN`, etc.) that supercronic's cron context doesn't inherit. The bashrc on the PVC gets edited by humans — most recently as part of the Apr 26 tmux/mosh persistent-shell work, which added a reference to `_TMUX_LAST_PWD`. Inside tmux that variable is set; from supercronic it isn't, so `nounset` trips on the source and the cron exits 1 **before reaching `push-heartbeat.sh`** — silently freezing the heartbeat metric.

This was the actual root cause of the chronically-firing Layer 18 alert in the 2026-04-29 incident: the `session_manager` heartbeat had been frozen at `2026-04-26 16:00:00 UTC` (≈2h after the tmux integration deployed), and a separate Telegram `parse_mode: Markdown` bug in frank (fixed in derio-net/frank#143) was rendering the alert label as `job=sessionmanager` regardless of which job actually fired — masking which cron was the persistent culprit. The vk-local OOM crashloop was a separate, additive degradation that overlapped.

## Verification

Synthetic reproduction:

```
$ cat > /tmp/.bashrc <<EOF
echo "\$_TMUX_LAST_PWD" > /dev/null
EOF

# pre-fix: dies before reaching anything that follows the source
$ HOME=/tmp bash -c 'set -euo pipefail; source "$HOME/.bashrc"; echo REACHED'
.bashrc: line 1: _TMUX_LAST_PWD: unbound variable

# post-fix: survives
$ HOME=/tmp bash -c 'set -euo pipefail; set +u; source "$HOME/.bashrc"; set -u; echo REACHED'
REACHED
```

`bash -n` syntax check passes on all four edited scripts.

## Test plan

- [ ] After image rebuild + deploy, supercronic logs no longer show `unbound variable` on session-manager / audit-digest / exercise-cron invocations
- [ ] `willikins_heartbeat_last_success_timestamp{job="session_manager"}` and `{job="audit_digest"}` start advancing within their respective cron intervals (5 min and ~daily)
- [ ] Layer 18 Persistent Agent alert moves from chronically-firing to resolved

## Note

A more robust fix is in flight (planned out-of-scope here). This stopgap unblocks heartbeat reporting until then.

Generated with Claude Code
