### PR TITLE
fix(crons): also disable errexit (not just nounset) around bashrc source

### DIFF
--- a/kali/scripts/audit-digest.sh
+++ b/kali/scripts/audit-digest.sh
@@ -5,12 +5,14 @@
 set -euo pipefail
 
 # Source bashrc for env vars (TELEGRAM_BOT_TOKEN, etc.). The PVC-side
-# bashrc may reference shell-state vars bound only in interactive/tmux
-# sessions (e.g. `_TMUX_LAST_PWD`); disable nounset around the source
-# so its missing refs don't kill the cron run.
-set +u
+# bashrc routinely contains code only valid in an interactive/tmux
+# context (e.g. tmux helper functions invoking `[ -n "$TMUX" ]` which
+# returns 1 in cron). Disable BOTH errexit and nounset around the
+# source so a non-zero command or unbound-var reference in bashrc
+# doesn't propagate up and kill the cron run.
+set +eu
 [[ -f "$HOME/.bashrc" ]] && source "$HOME/.bashrc"
-set -u
+set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 AUDIT_LOG="/home/claude/.willikins-agent/audit.jsonl"

--- a/kali/scripts/exercise-cron.sh
+++ b/kali/scripts/exercise-cron.sh
@@ -4,12 +4,14 @@
 set -euo pipefail
 
 # Source bashrc for env vars (TELEGRAM_BOT_TOKEN, etc.). The PVC-side
-# bashrc may reference shell-state vars bound only in interactive/tmux
-# sessions (e.g. `_TMUX_LAST_PWD`); disable nounset around the source
-# so its missing refs don't kill the cron run.
-set +u
+# bashrc routinely contains code only valid in an interactive/tmux
+# context (e.g. tmux helper functions invoking `[ -n "$TMUX" ]` which
+# returns 1 in cron). Disable BOTH errexit and nounset around the
+# source so a non-zero command or unbound-var reference in bashrc
+# doesn't propagate up and kill the cron run.
+set +eu
 [[ -f "$HOME/.bashrc" ]] && source "$HOME/.bashrc"
-set -u
+set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_DIR="${WILLIKINS_REPO_PATH:-/home/claude/repos/willikins}"

--- a/kali/scripts/push-heartbeat.sh
+++ b/kali/scripts/push-heartbeat.sh
@@ -12,13 +12,15 @@ JOB="${1:?Usage: push-heartbeat.sh <job_name> [label=value ...]}"
 shift
 
 # Source bashrc for PUSHGATEWAY_URL if not already set. The PVC-side
-# bashrc may reference shell-state vars bound only in interactive/tmux
-# sessions (e.g. `_TMUX_LAST_PWD`); disable nounset around the source
-# so its missing refs don't kill the cron run.
+# bashrc routinely contains code only valid in an interactive/tmux
+# context (e.g. tmux helper functions invoking `[ -n "$TMUX" ]` which
+# returns 1 in cron). Disable BOTH errexit and nounset around the
+# source so a non-zero command or unbound-var reference in bashrc
+# doesn't propagate up and kill the cron run.
 if [[ -z "${PUSHGATEWAY_URL:-}" ]] && [[ -f "$HOME/.bashrc" ]]; then
-  set +u
+  set +eu
   source "$HOME/.bashrc"
-  set -u
+  set -eu
 fi
 
 PUSHGATEWAY_URL="${PUSHGATEWAY_URL:?PUSHGATEWAY_URL must be set}"

--- a/kali/scripts/session-manager.sh
+++ b/kali/scripts/session-manager.sh
@@ -7,12 +7,14 @@ set -euo pipefail
 
 # Source bashrc for env vars (WILLIKINS_REPOS, GITHUB_TOKEN, etc.)
 # Needed when invoked by supercronic which doesn't load login shell.
-# The PVC-side bashrc may reference shell-state vars that are bound
-# only in interactive/tmux sessions (e.g. `_TMUX_LAST_PWD`); disable
-# nounset around the source so its missing refs don't kill the cron run.
-set +u
+# The PVC-side bashrc routinely contains code that's only valid in an
+# interactive/tmux context (e.g. tmux helper functions invoking
+# `[ -n "$TMUX" ]` which returns 1 in cron). Disable BOTH errexit
+# and nounset around the source so a non-zero command or unbound-var
+# reference in bashrc doesn't propagate up and kill the cron run.
+set +eu
 [[ -f "$HOME/.bashrc" ]] && source "$HOME/.bashrc"
-set -u
+set -eu
 
 LOGFILE="/home/claude/.willikins-agent/session-manager.log"
 PIDDIR="/home/claude/.willikins-agent/pids"


### PR DESCRIPTION
## Summary

Follow-up to #23. Wrap the bashrc source with `set +eu` (disable BOTH errexit and nounset) instead of just `set +u`. Without this, an inherited `set -e` from the parent script aborts the source mid-bashrc when any sourced command returns non-zero — and the live PVC bashrc reliably has such commands.

## Why

After #23 deployed, supercronic logs no longer show the `_TMUX_LAST_PWD: unbound variable` stderr line, but `session-manager.sh` is still exiting status 1 every 5 minutes (with no stderr). Tracing the live PVC bashrc:

```bash
PROMPT_COMMAND="_tmux_cwd_check${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
_tmux_cwd_check          # ← direct, unconditional function call
```

Inside `_tmux_cwd_check`:

```bash
_tmux_color_by_cwd() {
  [ -n "$TMUX" ] && ~/.config/tmux/color-by-cwd.sh "$PWD"
}
```

In supercronic's cron context `$TMUX` is empty, so `[ -n "$TMUX" ]` returns 1, the `&&` short-circuits, and the function returns 1. The unconditional `_tmux_cwd_check` call inherits that exit status. With `set -e` still on after #23, the inherited errexit aborts the source mid-bashrc. `WILLIKINS_REPOS` does get exported earlier in bashrc, but errexit also kills the parent script — so `session-manager.sh` exits status 1 immediately without ever calling `log()` or `push-heartbeat.sh`. That perfectly matches the observed "exit 1, no stderr" supercronic line.

## Verification

Realistic synthetic reproduction (mirroring the live bashrc structure):

```
$ cat > /tmp/.bashrc <<EOF
export WILLIKINS_REPOS="/tmp/repos:test"
_tmux_color_by_cwd() { [ -n "\$TMUX" ] && echo "tmux active"; }
_tmux_cwd_check() { _TMUX_LAST_PWD="\${_TMUX_LAST_PWD:-}"; [ "\$PWD" != "\$_TMUX_LAST_PWD" ] && _tmux_color_by_cwd; }
_tmux_cwd_check
EOF

# Pre-fix (PR #23 alone): errexit aborts source, parent dies
$ unset TMUX; HOME=/tmp bash -c 'set -euo pipefail; set +u; source "$HOME/.bashrc"; set -u; echo REACHED'
$ echo $?
1

# This PR: source completes, parent reaches REACHED
$ unset TMUX; HOME=/tmp bash -c 'set -euo pipefail; set +eu; source "$HOME/.bashrc"; set -eu; echo REACHED'
REACHED
$ echo $?
0
```

`bash -n` syntax check passes on all four edited scripts.

## Why #23's test missed this

The synthetic bashrc in #23 only exercised the `nounset` failure path (`echo "$_TMUX_LAST_PWD"` with `set -u`). It didn't include a direct unconditional function call that returns non-zero, which is the actual `errexit` failure mode in the live bashrc. Future test bashrcs should mirror the structural shape of the production file (function defs + direct calls + `[ -n "$TMUX" ]` tests), not just one-off variable references.

## Test plan

- [ ] After image rebuild + deploy, supercronic stops emitting `error running command: exit status 1` for `session-manager.sh` and `audit-digest.sh`
- [ ] `willikins_heartbeat_last_success_timestamp{job="session_manager"}` advances within 5 min of pod ready
- [ ] `willikins_heartbeat_last_success_timestamp{job="audit_digest"}` advances on its next scheduled run
- [ ] Layer 18 Persistent Agent + session-manager-stale + audit-digest-stale all resolve

## Note

A more robust fix is in flight upstream (env injection out of bashrc entirely). This PR keeps alerts quiet until that lands.

Generated with Claude Code
