### PR TITLE
[derio-net/agent-images] agents--restart-resilience · Phase 4/4 · `vk-local` entrypoint wrapper

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,8 +80,39 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,scope=${{ matrix.image.name }},mode=max
 
-  dispatch-frank:
+  smoke-test-vk-local:
     needs: build-children
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      VK_IMAGE: ghcr.io/derio-net/vk-local
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Smoke test — entrypoint wrapper runs init.d scripts
+        env:
+          IMAGE_SHA: ${{ github.sha }}
+        run: |
+          mkdir -p /tmp/test-home
+          # Run the shared init scripts directly (bypass vibe-kanban startup so
+          # the test stays environment-free). Verifies:
+          #   1. /opt/agent-init.d/* scripts are present and executable
+          #   2. 01-pvc-dirs creates $HOME/repos and other expected dirs
+          #   3. Wrapper iterates scripts correctly as the claude user
+          docker run --rm \
+            --user 1000:1000 \
+            -v /tmp/test-home:/home/claude \
+            --entrypoint /bin/sh \
+            "${VK_IMAGE}:${IMAGE_SHA}" \
+            -c 'for s in /opt/agent-init.d/*; do [ -x "$s" ] && "$s"; done && ls /home/claude/repos /home/claude/.ssh'
+
+  dispatch-frank:
+    needs: [build-children, smoke-test-vk-local]
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/vk-local/Dockerfile
+++ b/vk-local/Dockerfile
@@ -26,4 +26,7 @@ USER claude
 WORKDIR /home/claude
 
 EXPOSE 8081
+# Wrapper runs as USER claude (non-root); /opt/agent-init.d/* scripts must be
+# non-root-safe. vibe-kanban exec-replaces the wrapper, so K8s supervises it
+# directly under tini PID 1 — no s6, no extra supervisor layer.
 ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]

--- a/vk-local/Dockerfile
+++ b/vk-local/Dockerfile
@@ -19,9 +19,11 @@ COPY --from=vk-artifact /server /usr/local/bin/vibe-kanban
 RUN chmod +x /usr/local/bin/vibe-kanban \
     && chown claude:claude /usr/local/bin/vibe-kanban
 
+COPY entrypoint-vk-local.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 USER claude
 WORKDIR /home/claude
 
 EXPOSE 8081
-ENTRYPOINT ["/usr/bin/tini", "--"]
-CMD ["/usr/local/bin/vibe-kanban"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/entrypoint.sh"]

--- a/vk-local/entrypoint-vk-local.sh
+++ b/vk-local/entrypoint-vk-local.sh
@@ -1,11 +1,16 @@
 #!/bin/sh
 # entrypoint-vk-local.sh — Run shared first-boot scripts, then exec vibe-kanban.
 # vibe-kanban remains the driver process under tini's PID 1; K8s supervises.
+# Runs as USER claude (non-root); all /opt/agent-init.d/* scripts must be
+# non-root-safe (they create user dirs under $HOME, not system paths).
 set -e
 
+# shopt -s nullglob suppresses literal-glob expansion in bash when the
+# directory is empty. The || true makes it a no-op in POSIX sh (where shopt
+# is unavailable); the [ -x ] guard below is the real safety net in both cases.
 shopt -s nullglob 2>/dev/null || true
 for s in /opt/agent-init.d/*; do
     [ -x "$s" ] && "$s"
 done
 
-exec vibe-kanban "$@"
+exec /usr/local/bin/vibe-kanban "$@"

--- a/vk-local/entrypoint-vk-local.sh
+++ b/vk-local/entrypoint-vk-local.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+# entrypoint-vk-local.sh — Run shared first-boot scripts, then exec vibe-kanban.
+# vibe-kanban remains the driver process under tini's PID 1; K8s supervises.
+set -e
+
+shopt -s nullglob 2>/dev/null || true
+for s in /opt/agent-init.d/*; do
+    [ -x "$s" ] && "$s"
+done
+
+exec vibe-kanban "$@"


### PR DESCRIPTION
📦 Repo:   derio-net/agent-images
📋 Plan:   docs/superpowers/plans/2026-04-27--agents--restart-resilience.md
📐 Spec:   derio-net/frank:docs/superpowers/specs/2026-04-27--agents--restart-resilience-design.md
🎯 Phase:  4/4 — `vk-local` entrypoint wrapper [agentic]
🔗 Issue:  https://github.com/derio-net/agent-images/issues/19

**Goal (from plan):** Build the image foundation that lets the secure-agent-pod (and the planned fleet of sibling agent pods) survive container restarts gracefully. Specifically: introduce `agent-shell-base` (s6-overlay v3 + supervised sshd/supercronic + tmux-resurrect/continuum + parameterized AGENT_USER/AGENT_HOME), migrate secure-agent-kali to use it, and give vk-local consistent first-boot setup without subjecting it to s6 (vibe-kanban stays a single-driver-process container under K8s supervision).

---

## Summary

- Adds `vk-local/entrypoint-vk-local.sh`: thin `/bin/sh` wrapper that iterates `/opt/agent-init.d/*` scripts then `exec`s `vibe-kanban`
- Updates `vk-local/Dockerfile`: `COPY`s the wrapper, `chmod +x`s it, and switches `ENTRYPOINT` from `["/usr/bin/tini", "--"]` (with `CMD`) to `["/usr/bin/tini", "--", "/entrypoint.sh"]`
- `vibe-kanban` remains the driver process under tini PID 1 — K8s supervision contract unchanged, no s6

## What changes at runtime

On every container start, the wrapper runs the shared init.d scripts installed by `agent-base` (Phase 1: PVC dirs, credential migration, credential scrub), then `exec`-replaces itself with `vibe-kanban`. From K8s's perspective, the entrypoint process is still `vibe-kanban`.

## Test plan

- [ ] `docker build` of `vk-local` succeeds with the new entrypoint
- [ ] Matrix CI green
- [ ] `vibe-kanban` still starts and `/api/health` returns 200
- [ ] `/home/claude/repos` dir is created on first boot (confirming `01-pvc-dirs` ran)

Closes #19