### PR TITLE
[derio-net/agent-images] silent-reconnect-phantoms · Phase 1/3 · Reaper implementation

### DIFF
--- a/docs/superpowers/plans/2026-04-22-silent-reconnect-phantoms.md
+++ b/docs/superpowers/plans/2026-04-22-silent-reconnect-phantoms.md
@@ -197,7 +197,7 @@ Phase 1 Task 1 reads this file and branches on the Decision section.
 **Files:**
 - Read: `kali/docs/findings/2026-04-22-orphan-env-reaper.md`
 
-- [ ] **Step 1: Confirm chosen branch**
+- [x] **Step 1: Confirm chosen branch**
 
 ```bash
 grep -A2 "^**Chosen:**\|^## Decision for Phase 1" kali/docs/findings/2026-04-22-orphan-env-reaper.md
@@ -212,7 +212,7 @@ Record the chosen letter in this session's scratch notes. All subsequent tasks r
 **Files:**
 - Create: `kali/tests/test_reap_orphan_envs.sh`
 
-- [ ] **Step 1: Write the bash test harness**
+- [x] **Step 1: Write the bash test harness**
 
 Create `kali/tests/test_reap_orphan_envs.sh`:
 
@@ -314,7 +314,7 @@ Expected: FAIL (`scripts/reap-orphan-envs.sh` does not yet exist — bash will e
 - Create: `kali/scripts/reap-orphan-envs.sh`
 - Modify: `kali/scripts/session-manager.sh`
 
-- [ ] **Step 1: Write `reap-orphan-envs.sh`**
+- [x] **Step 1: Write `reap-orphan-envs.sh`**
 
 Paths referenced below (`ORG_UUID_PATH`, `ORG_UUID_KEY`, `BEARER_KEY`) must match what Phase 0 Step 4 recorded. The template uses the most likely values — adjust before commit.
 
@@ -452,7 +452,7 @@ exit 0
 chmod +x kali/scripts/reap-orphan-envs.sh
 ```
 
-- [ ] **Step 2: Re-run the bash tests**
+- [x] **Step 2: Re-run the bash tests**
 
 ```bash
 bash kali/tests/test_reap_orphan_envs.sh 2>&1
@@ -460,7 +460,7 @@ bash kali/tests/test_reap_orphan_envs.sh 2>&1
 
 Expected: `OK` (all four test cases pass).
 
-- [ ] **Step 3: Integrate into session-manager**
+- [x] **Step 3: Integrate into session-manager**
 
 In `kali/scripts/session-manager.sh`, after the `SHUTDOWN_MARKER` check (around line 22) and before the `WILLIKINS_REPOS` validation, add:
 
@@ -472,7 +472,7 @@ if [[ "${REAP_ORPHAN_ENVS:-1}" == "1" ]]; then
 fi
 ```
 
-- [ ] **Step 4: Smoke test on the pod (post-build)**
+- [x] **Step 4: Smoke test on the pod (post-build)**
 
 After the image is rebuilt and pushed (Task 5), roll the pod and trigger a stale-PID event manually:
 
@@ -500,7 +500,7 @@ Expected: log shows `reaped env_<id> (HTTP 200)` and the original env is gone fr
 - Create: `kali/tests/test_wrap_claude.py`
 - Modify: `kali/scripts/session-manager.sh`
 
-- [ ] **Step 1: Failing test for wrap-claude.py**
+- [x] **Step 1: Failing test for wrap-claude.py**
 
 Create `kali/tests/test_wrap_claude.py`:
 
@@ -598,7 +598,7 @@ python -m pytest kali/tests/test_wrap_claude.py -x 2>&1 | tail -15
 
 Expected: FAIL (script missing).
 
-- [ ] **Step 2: Implement `wrap-claude.py`**
+- [x] **Step 2: Implement `wrap-claude.py`**
 
 Create `kali/scripts/wrap-claude.py`:
 
@@ -707,7 +707,7 @@ python -m pytest kali/tests/test_wrap_claude.py -x 2>&1 | tail -10
 
 Expected: both tests pass.
 
-- [ ] **Step 3: Branch-B reaper variant**
+- [x] **Step 3: Branch-B reaper variant**
 
 Create `kali/scripts/reap-orphan-envs.sh` as in Task 3 Step 1, but replace the pointer discovery block with:
 
@@ -720,7 +720,7 @@ envs_files=( "$AGENT_DIR/envs"/*.json )
 
 All other logic (credentials, DELETE, backoff, status handling) is identical.
 
-- [ ] **Step 4: Update session-manager spawn line**
+- [x] **Step 4: Update session-manager spawn line**
 
 In `kali/scripts/session-manager.sh`, replace line 54:
 
@@ -740,7 +740,7 @@ Also add the reaper invocation per Task 3 Step 3.
 
 ### Task 5: Open PR
 
-- [ ] **Step 1: Verify all tests pass**
+- [x] **Step 1: Verify all tests pass**
 
 Branch A:
 

--- a/docs/superpowers/plans/2026-04-22-silent-reconnect-phantoms.md
+++ b/docs/superpowers/plans/2026-04-22-silent-reconnect-phantoms.md
@@ -17,6 +17,8 @@
 
 **Scope boundary:** This plan does **not** change any `derio-net/frank` manifests (no new preStop or grace-period changes — existing Phase 2 wiring is sufficient), does **not** reduce OOMKill *frequency* (owned by `2026-04-22-vk-local-memory-profile.md`), and does **not** touch `WILLIKINS_REPOS` multi-session expansion. It ships only the orphan cleanup mechanism and a 48h soak.
 
+**Phase 1 covers post-mortem leaks only.** The supervisor records the *first* env_id it scrapes from claude's stderr (`if seen_env: continue`); the reaper only acts when the owning PID is dead. That fully covers the OOMKill half (~6 phantoms) and the silent-reconnect cases that end with the claude process dying inside the soak window — at death we DELETE that first env_id. **Mid-process-life env_id rotation** is *not* fixed: if claude silent-reconnects to a new env_id while the same PID keeps running, the *old* env_id becomes a phantom the reaper cannot find (PID still alive), and the *new* env_id is never recorded. Phase 2 soak quantifies this residue. If T+48h phantom growth exceeds the spec acceptance criterion, Phase 2's outcome note triggers a follow-up plan that either (a) DELETEs the prior env_id on rotation from inside the wrapper or (b) maintains a per-env_id file rather than a per-session file. Acceptance for Phase 1 is therefore "≥ OOMKill-portion (~6/17) reduction" — full closure of the silent-reconnect rotation case is explicitly Phase 2 territory.
+
 ---
 
 ## Phase 0: Recon spike [agentic]
@@ -212,7 +214,7 @@ Record the chosen letter in this session's scratch notes. All subsequent tasks r
 **Files:**
 - Create: `kali/tests/test_reap_orphan_envs.sh`
 
-- [x] **Step 1: Write the bash test harness**
+- [-] **Step 1: Write the bash test harness** _(skipped — Branch A; the equivalent test was authored in Task 4 against `$WILLIKINS_AGENT_DIR/envs/*.json` per Phase 0 findings.)_
 
 Create `kali/tests/test_reap_orphan_envs.sh`:
 
@@ -314,7 +316,7 @@ Expected: FAIL (`scripts/reap-orphan-envs.sh` does not yet exist — bash will e
 - Create: `kali/scripts/reap-orphan-envs.sh`
 - Modify: `kali/scripts/session-manager.sh`
 
-- [x] **Step 1: Write `reap-orphan-envs.sh`**
+- [-] **Step 1: Write `reap-orphan-envs.sh`** _(skipped — Branch A pointer-based reaper; the Branch B variant scanning `$WILLIKINS_AGENT_DIR/envs/*.json` was authored in Task 4 Step 3.)_
 
 Paths referenced below (`ORG_UUID_PATH`, `ORG_UUID_KEY`, `BEARER_KEY`) must match what Phase 0 Step 4 recorded. The template uses the most likely values — adjust before commit.
 
@@ -452,7 +454,7 @@ exit 0
 chmod +x kali/scripts/reap-orphan-envs.sh
 ```
 
-- [x] **Step 2: Re-run the bash tests**
+- [-] **Step 2: Re-run the bash tests** _(skipped — Branch A; covered by Task 4 Step 3's bash tests against the Branch B reaper.)_
 
 ```bash
 bash kali/tests/test_reap_orphan_envs.sh 2>&1
@@ -460,7 +462,7 @@ bash kali/tests/test_reap_orphan_envs.sh 2>&1
 
 Expected: `OK` (all four test cases pass).
 
-- [x] **Step 3: Integrate into session-manager**
+- [-] **Step 3: Integrate into session-manager** _(skipped — Branch A; the same integration is performed in Task 4 Step 4 alongside the wrapper spawn-line change.)_
 
 In `kali/scripts/session-manager.sh`, after the `SHUTDOWN_MARKER` check (around line 22) and before the `WILLIKINS_REPOS` validation, add:
 
@@ -472,7 +474,7 @@ if [[ "${REAP_ORPHAN_ENVS:-1}" == "1" ]]; then
 fi
 ```
 
-- [x] **Step 4: Smoke test on the pod (post-build)**
+- [-] **Step 4: Smoke test on the pod (post-build)** _(deferred — runs after PR merges and the image is rebuilt; the Phase 2 soak exercises this path. Plan note: "Defer to Phase 2 for the soak-level acceptance.")_
 
 After the image is rebuilt and pushed (Task 5), roll the pod and trigger a stale-PID event manually:
 

--- a/kali/scripts/reap-orphan-envs.sh
+++ b/kali/scripts/reap-orphan-envs.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# reap-orphan-envs.sh — DELETE orphaned claude remote-control bridge envs.
+#
+# Invoked by session-manager.sh on each 5-minute tick. Scans the envs files
+# written by wrap-claude.py and, for any whose owning PID is gone, calls
+# DELETE /v1/environments/bridge/<env_id> against the Anthropic API.
+# See docs/findings/2026-04-22-orphan-env-reaper.md for reconnaissance and
+# the rationale for Branch B (supervisor-recorded envs files, not pointer
+# files written by claude).
+set -euo pipefail
+
+AGENT_DIR="${WILLIKINS_AGENT_DIR:-$HOME/.willikins-agent}"
+ENVS_DIR="$AGENT_DIR/envs"
+LOGFILE="$AGENT_DIR/reap-orphan-envs.log"
+AUTH_STATE="$AGENT_DIR/reap-auth-error.state"
+AUTH_BACKOFF_SECS=3600
+AUTH_FAIL_THRESHOLD=3
+API_BASE="${CLAUDE_API_BASE:-https://api.anthropic.com}"
+ANTHROPIC_BETA="environments-2025-11-01"
+
+# Phase 0 findings: bearer is at .claudeAiOauth.accessToken in
+# ~/.claude/.credentials.json; org UUID is at .oauthAccount.organizationUuid
+# in ~/.claude.json (NOT ~/.claude/config.json).
+BEARER_PATH="$HOME/.claude/.credentials.json"
+BEARER_KEY=".claudeAiOauth.accessToken // empty"
+ORG_UUID_PATH="$HOME/.claude.json"
+ORG_UUID_KEY=".oauthAccount.organizationUuid // empty"
+
+mkdir -p "$AGENT_DIR"
+
+log() {
+  local msg="[$(date -u '+%Y-%m-%d %H:%M:%S')] [reap] $*"
+  echo "$msg" >&2
+  echo "$msg" >> "$LOGFILE" 2>/dev/null || true
+}
+
+if [[ -f "$AUTH_STATE" ]]; then
+  last_err=$(awk '{print $1}' "$AUTH_STATE" 2>/dev/null || echo 0)
+  fail_count=$(awk '{print $2}' "$AUTH_STATE" 2>/dev/null || echo 0)
+  if (( fail_count >= AUTH_FAIL_THRESHOLD )); then
+    now=$(date +%s)
+    if (( now - last_err < AUTH_BACKOFF_SECS )); then
+      log "auth-backoff active (${fail_count} recent failures); skipping"
+      exit 0
+    fi
+  fi
+fi
+
+shopt -s nullglob
+envs_files=( "$ENVS_DIR"/*.json )
+
+if (( ${#envs_files[@]} == 0 )); then
+  exit 0
+fi
+
+bearer=""; org_uuid=""
+read_creds() {
+  if [[ ! -f "$BEARER_PATH" ]]; then
+    log "error: $BEARER_PATH missing"; return 1
+  fi
+  bearer=$(jq -r "$BEARER_KEY" "$BEARER_PATH" 2>/dev/null || true)
+  if [[ -z "$bearer" || "$bearer" == "null" ]]; then
+    log "error: empty bearer at $BEARER_PATH key=$BEARER_KEY (creds-format drift?)"
+    return 1
+  fi
+  if [[ ! -f "$ORG_UUID_PATH" ]]; then
+    log "error: $ORG_UUID_PATH missing"; return 1
+  fi
+  org_uuid=$(jq -r "$ORG_UUID_KEY" "$ORG_UUID_PATH" 2>/dev/null || true)
+  if [[ -z "$org_uuid" || "$org_uuid" == "null" ]]; then
+    log "error: empty org UUID at $ORG_UUID_PATH key=$ORG_UUID_KEY"
+    return 1
+  fi
+  return 0
+}
+
+auth_error=0
+reaped=0
+
+for envfile in "${envs_files[@]}"; do
+  env_id=$(jq -r '.env_id // empty' "$envfile" 2>/dev/null || true)
+  pid=$(jq -r '.pid // empty' "$envfile" 2>/dev/null || true)
+  if [[ -z "$env_id" ]]; then
+    log "skip: no env_id in $envfile"
+    continue
+  fi
+  if [[ -n "$pid" && "$pid" =~ ^[1-9][0-9]*$ ]] && kill -0 "$pid" 2>/dev/null; then
+    continue
+  fi
+
+  if [[ -z "$bearer" ]]; then
+    read_creds || { log "aborting — credentials unresolved"; exit 0; }
+  fi
+
+  log "DELETE $env_id (file=$envfile pid=${pid:-none})"
+  http_code=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE \
+    -H "Authorization: Bearer $bearer" \
+    -H "x-organization-uuid: $org_uuid" \
+    -H "anthropic-beta: $ANTHROPIC_BETA" \
+    "$API_BASE/v1/environments/bridge/$env_id" || echo "000")
+
+  case "$http_code" in
+    2*|404)
+      log "reaped $env_id (HTTP $http_code)"
+      rm -f "$envfile"
+      reaped=$((reaped+1))
+      ;;
+    401|403)
+      log "auth-error $env_id (HTTP $http_code) — leaving file"
+      auth_error=1
+      ;;
+    5*)
+      log "transient $env_id (HTTP $http_code) — leaving file"
+      ;;
+    *)
+      log "unexpected $env_id (HTTP $http_code) — leaving file"
+      ;;
+  esac
+done
+
+if (( auth_error == 1 )); then
+  now=$(date +%s)
+  prev=0
+  [[ -f "$AUTH_STATE" ]] && prev=$(awk '{print $2}' "$AUTH_STATE" 2>/dev/null || echo 0)
+  echo "$now $((prev+1))" > "$AUTH_STATE"
+else
+  rm -f "$AUTH_STATE"
+fi
+
+(( reaped > 0 )) && log "reaped $reaped orphan env(s)"
+exit 0

--- a/kali/scripts/reap-orphan-envs.sh
+++ b/kali/scripts/reap-orphan-envs.sh
@@ -34,6 +34,25 @@ log() {
   echo "$msg" >> "$LOGFILE" 2>/dev/null || true
 }
 
+# Serialise overlapping ticks. supercronic fires every 5min; if a tick is slow
+# (large queue, 5xx waits, or post-I-4 timeouts), the next tick can stomp
+# into the same envs files. The Anthropic API is idempotent so this never
+# corrupts state, but it doubles "[reap]" log lines and DELETE counts which
+# muddies the Phase 2 soak's accounting. Non-blocking lock — a contended
+# tick exits cleanly and the next tick picks up.
+LOCKFILE="$AGENT_DIR/reap.lock"
+exec 9>"$LOCKFILE"
+if ! flock -n 9; then
+  log "another reaper tick in flight; skipping"
+  exit 0
+fi
+
+# Surface credential-format drift early. The reaper resolves creds lazily
+# (only when at least one orphan exists), which means a missing file would
+# otherwise stay invisible until the first orphan turns up — possibly weeks.
+[[ -f "$BEARER_PATH" ]] || log "[warn] $BEARER_PATH missing — reaper will fail on first orphan"
+[[ -f "$ORG_UUID_PATH" ]] || log "[warn] $ORG_UUID_PATH missing — reaper will fail on first orphan"
+
 if [[ -f "$AUTH_STATE" ]]; then
   last_err=$(awk '{print $1}' "$AUTH_STATE" 2>/dev/null || echo 0)
   fail_count=$(awk '{print $2}' "$AUTH_STATE" 2>/dev/null || echo 0)
@@ -93,7 +112,12 @@ for envfile in "${envs_files[@]}"; do
   fi
 
   log "DELETE $env_id (file=$envfile pid=${pid:-none})"
-  http_code=$(curl -sS -o /dev/null -w '%{http_code}' -X DELETE \
+  # --max-time / --connect-timeout: a hung TCP connection must not block
+  # the entire 5-minute tick. With ~17 baseline phantoms and worst-case
+  # 15s per call this caps a stuck reaper at ~4.5 minutes, leaving headroom
+  # before the next supercronic tick fires.
+  http_code=$(curl -sS --max-time 15 --connect-timeout 5 \
+    -o /dev/null -w '%{http_code}' -X DELETE \
     -H "Authorization: Bearer $bearer" \
     -H "x-organization-uuid: $org_uuid" \
     -H "anthropic-beta: $ANTHROPIC_BETA" \

--- a/kali/scripts/session-manager.sh
+++ b/kali/scripts/session-manager.sh
@@ -29,6 +29,15 @@ if [[ -f "$SHUTDOWN_MARKER" ]]; then
   log "Shutdown in progress — skipping session check"; exit 0
 fi
 
+# Reap any orphaned bridge envs before spawning new sessions. Non-fatal —
+# the reaper exits 0 on any expected error path; only catastrophic shell
+# failures would propagate here, in which case continuing is still the
+# right choice (a missed reap tick is recovered next cycle).
+if [[ "${REAP_ORPHAN_ENVS:-1}" == "1" ]]; then
+  "$(dirname "$0")/reap-orphan-envs.sh" 2>/dev/null \
+    || log "[warn] reap-orphan-envs returned non-zero"
+fi
+
 if [[ -z "${WILLIKINS_REPOS:-}" ]]; then
   log "ERROR: WILLIKINS_REPOS not set"; exit 1
 fi
@@ -54,11 +63,14 @@ for ((i=0; i<${#ENTRIES[@]}; i+=2)); do
 
   log "Starting session '$SESSION_NAME' in $REPO_PATH"
   cd "$REPO_PATH"
-  # `exec` replaces the bash wrapper in place, so $! below is claude's own
-  # PID — required for SIGTERM to reach the bridge:shutdown handler that
-  # calls DELETE /v1/environments/bridge/<env_id>. Using a process-
-  # substitution stdin avoids a pipeline (which would again fork).
-  nohup bash -c "exec claude remote-control --name '$SESSION_NAME' < <(echo y)" \
+  # Spawn through wrap-claude.py: the supervisor scrapes the bridge env_id
+  # from claude's stderr and writes ~/.willikins-agent/envs/<session>.json
+  # so reap-orphan-envs.sh can DELETE the env when claude dies without
+  # running its own bridge:shutdown handler (OOMKill, stdin-close cascade,
+  # etc.). On graceful SIGTERM the wrapper forwards the signal and unlinks
+  # the file after a clean exit. The `exec` replaces the bash wrapper in
+  # place, so $! below is the python supervisor's PID.
+  nohup bash -c "exec python3 -u /opt/scripts/wrap-claude.py '$SESSION_NAME' < <(echo y)" \
     >> "${HOME}/.willikins-agent/session-${SESSION_NAME}.log" 2>&1 &
   echo $! > "$PIDFILE"
   log "Session '$SESSION_NAME' started (PID $!)"

--- a/kali/scripts/shutdown.sh
+++ b/kali/scripts/shutdown.sh
@@ -4,10 +4,16 @@
 # Invoked by K8s preStop hook or by an operator during pod drain. Per
 # docs/findings/2026-04-18-remote-control-shutdown.md, the `claude` CLI's
 # SIGTERM handler calls DELETE /v1/environments/bridge/<env_id>, which is
-# how we avoid phantom sessions in claude.ai. We therefore rely on
-# session-manager.sh recording claude's own PID (not a bash wrapper's)
-# in each pidfile, send SIGTERM, and wait for the bridge:shutdown path
-# to drain (~30s per the CLI's loop_grace_ms default) before SIGKILL.
+# how we avoid phantom sessions in claude.ai.
+#
+# Since silent-reconnect-phantoms Phase 1, session-manager.sh records the
+# wrap-claude.py supervisor's PID (not claude's) in each pidfile. The
+# supervisor forwards SIGTERM to its claude child's process group, so the
+# bridge:shutdown drain still runs end-to-end. If GRACE_SECONDS expires
+# we SIGKILL the supervisor; PDEATHSIG (set by the supervisor's preexec)
+# then sends SIGTERM to the claude child as the kernel reaps the parent.
+# Any envs file the supervisor left behind is cleaned up by
+# reap-orphan-envs.sh on the next session-manager tick.
 set -euo pipefail
 
 AGENT_DIR="${WILLIKINS_AGENT_DIR:-$HOME/.willikins-agent}"

--- a/kali/scripts/wrap-claude.py
+++ b/kali/scripts/wrap-claude.py
@@ -12,8 +12,10 @@ Environment:
 """
 from __future__ import annotations
 
+import ctypes
 import json
 import os
+import platform
 import re
 import signal
 import subprocess
@@ -22,7 +24,31 @@ import threading
 import time
 from pathlib import Path
 
-ENV_RE = re.compile(r"env_[A-Za-z0-9_-]{6,}")
+# env IDs observed in the wild are 24+ chars of [A-Za-z0-9] (e.g.
+# env_01MPTBz8CJR82vP2qXJKpUvt — see Phase 0 findings). Tighten the regex to
+# match that shape rather than the looser `env_[A-Za-z0-9_-]{6,}` template,
+# which would false-positive on stray `env_foo` substrings in unrelated logs.
+ENV_RE = re.compile(r"env_[A-Za-z0-9]{20,}")
+
+# PR_SET_PDEATHSIG: when the wrapper process dies (including via SIGKILL),
+# the kernel delivers this signal to the child. Closes the orphan-on-
+# wrapper-SIGKILL hole — without it, shutdown.sh's grace-window SIGKILL
+# would leave claude reparented to PID 1.
+_PR_SET_PDEATHSIG = 1
+
+
+def _set_pdeathsig() -> None:
+    """preexec_fn — runs in the child between fork and program-image swap."""
+    if platform.system() != "Linux":
+        return
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+    except OSError:
+        return
+    # Send SIGTERM to the child if the parent dies. claude's own SIGTERM
+    # handler still runs bridge:shutdown if it's responsive; if it isn't,
+    # the container teardown takes it the rest of the way.
+    libc.prctl(_PR_SET_PDEATHSIG, signal.SIGTERM, 0, 0, 0)
 
 
 def main() -> int:
@@ -49,11 +75,21 @@ def main() -> int:
         stdin=sys.stdin,
         bufsize=1,
         text=True,
+        # New session/process group so we can signal the whole tree, and so
+        # PDEATHSIG (set in preexec) takes effect on the right boundary.
+        start_new_session=True,
+        preexec_fn=_set_pdeathsig,
     )
 
     def forward(signum, _frame):
         if child.poll() is None:
-            child.send_signal(signum)
+            try:
+                # Forward to the entire process group — claude may have
+                # spawned helpers (e.g. an MCP server) that should drain
+                # together.
+                os.killpg(child.pid, signum)
+            except ProcessLookupError:
+                pass
     signal.signal(signal.SIGTERM, forward)
     signal.signal(signal.SIGINT, forward)
 

--- a/kali/scripts/wrap-claude.py
+++ b/kali/scripts/wrap-claude.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""wrap-claude.py — supervisor around `claude remote-control` that records the
+bridge env_id to a file we own, so an orphan reaper can clean up when claude
+dies without invoking its own bridge:shutdown handler.
+
+Usage:
+  wrap-claude.py <session_name> [extra claude args...]
+
+Environment:
+  WILLIKINS_AGENT_DIR  — default ~/.willikins-agent (envs file lives here)
+  CLAUDE_BIN_OVERRIDE  — alternate binary path, for tests
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+ENV_RE = re.compile(r"env_[A-Za-z0-9_-]{6,}")
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: wrap-claude.py <session_name> [extra args]", file=sys.stderr)
+        return 2
+    session = sys.argv[1]
+    extra = sys.argv[2:]
+    agent_dir = Path(os.environ.get("WILLIKINS_AGENT_DIR", Path.home() / ".willikins-agent"))
+    envs_dir = agent_dir / "envs"
+    envs_dir.mkdir(parents=True, exist_ok=True)
+    envs_file = envs_dir / f"{session}.json"
+
+    claude_bin = os.environ.get("CLAUDE_BIN_OVERRIDE")
+    if claude_bin:
+        argv = [claude_bin]
+    else:
+        argv = ["claude", "remote-control", "--name", session, *extra]
+
+    child = subprocess.Popen(
+        argv,
+        stdout=sys.stdout,
+        stderr=subprocess.PIPE,
+        stdin=sys.stdin,
+        bufsize=1,
+        text=True,
+    )
+
+    def forward(signum, _frame):
+        if child.poll() is None:
+            child.send_signal(signum)
+    signal.signal(signal.SIGTERM, forward)
+    signal.signal(signal.SIGINT, forward)
+
+    def tail_stderr():
+        assert child.stderr is not None
+        seen_env = False
+        for line in child.stderr:
+            sys.stderr.write(line)
+            sys.stderr.flush()
+            if seen_env:
+                continue
+            m = ENV_RE.search(line)
+            if m:
+                envs_file.write_text(json.dumps({
+                    "env_id": m.group(0),
+                    "pid": child.pid,
+                    "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                }))
+                seen_env = True
+
+    t = threading.Thread(target=tail_stderr, daemon=True)
+    t.start()
+
+    rc = child.wait()
+    t.join(timeout=2)
+
+    if rc == 0:
+        try:
+            envs_file.unlink()
+        except FileNotFoundError:
+            pass
+
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kali/tests/test_reap_orphan_envs.sh
+++ b/kali/tests/test_reap_orphan_envs.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# test_reap_orphan_envs.sh — harness for scripts/reap-orphan-envs.sh
+# Branch B: scans $WILLIKINS_AGENT_DIR/envs/*.json (written by wrap-claude.py),
+# not pointer files under ~/.claude/projects.
+set -euo pipefail
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+export HOME="$TMP"
+export WILLIKINS_AGENT_DIR="$TMP/.willikins-agent"
+ENVS_DIR="$WILLIKINS_AGENT_DIR/envs"
+mkdir -p "$ENVS_DIR" "$HOME/.claude"
+
+# Fake credentials at the real Phase 0 paths.
+cat > "$HOME/.claude/.credentials.json" <<'EOF'
+{"claudeAiOauth":{"accessToken":"sk-ant-test-bearer","expiresAt":0}}
+EOF
+cat > "$HOME/.claude.json" <<'EOF'
+{"oauthAccount":{"organizationUuid":"org-uuid-test-000"}}
+EOF
+
+# Envs file for a dead-PID env (PID 999999 — almost certainly dead).
+cat > "$ENVS_DIR/dead.json" <<'EOF'
+{"env_id":"env_orphan_A","pid":999999,"started_at":"2026-04-22T00:00:00Z"}
+EOF
+
+# Envs file for a live env — bind to our own test PID so kill -0 succeeds.
+printf '{"env_id":"env_live_B","pid":%d,"started_at":"2026-04-22T00:00:00Z"}\n' "$$" \
+  > "$ENVS_DIR/live.json"
+
+# Stub curl on PATH.
+STUB_DIR="$TMP/stubs"
+mkdir -p "$STUB_DIR"
+cat > "$STUB_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+# Record args + emit canned HTTP code via -w. Honor -o /dev/null.
+echo "curl $*" >> "$CURL_LOG"
+code="${CURL_STUB_CODE:-200}"
+out=""
+# Emulate curl's -w '%{http_code}' (the only formatter the reaper uses).
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -w) out="$2"; shift 2 ;;
+    -o) shift 2 ;;
+    *) shift ;;
+  esac
+done
+if [[ "$out" == "%{http_code}" ]]; then
+  printf '%s' "$code"
+fi
+# Match curl exit semantics loosely: 0 unless we want to simulate transport
+# failure (which the reaper handles via the "000" branch when curl exits >0).
+exit 0
+EOF
+chmod +x "$STUB_DIR/curl"
+export PATH="$STUB_DIR:$PATH"
+export CURL_LOG="$TMP/curl.log"
+
+REAPER="$(cd "$(dirname "$0")/.." && pwd)/scripts/reap-orphan-envs.sh"
+
+run_reaper() { CURL_STUB_CODE="$1" bash "$REAPER"; }
+
+# --- Test 1: happy path (dead reaped, live untouched) ---
+: > "$CURL_LOG"
+run_reaper 200
+
+grep -q "env_orphan_A" "$CURL_LOG" || { echo "FAIL: no DELETE for env_orphan_A"; exit 1; }
+if grep -q "env_live_B" "$CURL_LOG"; then echo "FAIL: DELETE called for live env_live_B"; exit 1; fi
+[[ -f "$ENVS_DIR/dead.json" ]] && { echo "FAIL: dead envs file not removed"; exit 1; } || true
+[[ -f "$ENVS_DIR/live.json" ]] || { echo "FAIL: live envs file wrongly removed"; exit 1; }
+
+# --- Test 2: 404 treated as success, file removed ---
+cat > "$ENVS_DIR/dead.json" <<'EOF'
+{"env_id":"env_orphan_A2","pid":999999,"started_at":"2026-04-22T00:00:00Z"}
+EOF
+: > "$CURL_LOG"
+run_reaper 404
+[[ -f "$ENVS_DIR/dead.json" ]] && { echo "FAIL: file not removed on 404"; exit 1; } || true
+
+# --- Test 3: 401 treated as auth-error, file left in place ---
+cat > "$ENVS_DIR/dead.json" <<'EOF'
+{"env_id":"env_orphan_A3","pid":999999,"started_at":"2026-04-22T00:00:00Z"}
+EOF
+: > "$CURL_LOG"
+run_reaper 401
+[[ -f "$ENVS_DIR/dead.json" ]] || { echo "FAIL: file removed despite 401"; exit 1; }
+
+# --- Test 4: 5xx treated as transient, file left in place ---
+cat > "$ENVS_DIR/dead.json" <<'EOF'
+{"env_id":"env_orphan_A4","pid":999999,"started_at":"2026-04-22T00:00:00Z"}
+EOF
+: > "$CURL_LOG"
+run_reaper 503
+[[ -f "$ENVS_DIR/dead.json" ]] || { echo "FAIL: file removed despite 5xx"; exit 1; }
+
+# --- Test 5: anthropic-beta header is sent ---
+cat > "$ENVS_DIR/dead.json" <<'EOF'
+{"env_id":"env_orphan_A5","pid":999999,"started_at":"2026-04-22T00:00:00Z"}
+EOF
+: > "$CURL_LOG"
+run_reaper 200
+grep -q "anthropic-beta: environments-2025-11-01" "$CURL_LOG" \
+  || { echo "FAIL: anthropic-beta header missing"; exit 1; }
+
+echo "OK"

--- a/kali/tests/test_wrap_claude.py
+++ b/kali/tests/test_wrap_claude.py
@@ -15,7 +15,7 @@ def _fake_claude(tmp_path: Path) -> Path:
     path = tmp_path / "fake-claude"
     path.write_text(
         "#!/usr/bin/env bash\n"
-        "echo 'registered environment env_TEST123' >&2\n"
+        "echo 'registered environment env_01TEST456789ABCDEFGH0' >&2\n"
         "trap 'exit 0' TERM\n"
         "sleep 300 &\n"
         "wait $!\n"
@@ -48,7 +48,7 @@ def test_graceful_sigterm_clears_envs_file(tmp_path):
         time.sleep(0.1)
     assert target.exists(), f"envs file not created: {list(envs_dir.iterdir())}"
     data = json.loads(target.read_text())
-    assert data["env_id"] == "env_TEST123"
+    assert data["env_id"] == "env_01TEST456789ABCDEFGH0"
     assert data["pid"] > 0
 
     proc.send_signal(signal.SIGTERM)
@@ -79,14 +79,35 @@ def test_sigkill_leaves_envs_file(tmp_path):
         time.sleep(0.1)
     assert target.exists()
 
+    # Capture the child PID for post-SIGKILL liveness check below. We can
+    # read it from the envs file because the wrapper writes child.pid there.
+    child_pid = json.loads(target.read_text())["pid"]
+
     proc.send_signal(signal.SIGKILL)
     proc.wait(timeout=5)
     # SIGKILL on the wrapper does not run the unlink path; the file is left
     # behind for the reaper to find.
     assert target.exists(), "envs file should persist on SIGKILL"
 
-    # Best-effort cleanup of the orphaned fake-claude child so pytest exits.
-    try:
-        subprocess.run(["pkill", "-9", "-f", "fake-claude"], check=False)
-    except FileNotFoundError:
-        pass
+    # PDEATHSIG: when the wrapper dies the kernel sends SIGTERM to the
+    # child. fake-claude's TERM trap exits cleanly. Verify within a short
+    # window that the child does not outlive the wrapper — that's the
+    # whole point of pdeathsig vs. the previous test's pkill cleanup hack.
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        try:
+            os.kill(child_pid, 0)
+        except ProcessLookupError:
+            break
+        time.sleep(0.05)
+    else:
+        # Best-effort cleanup so pytest still exits if pdeathsig didn't fire
+        # (e.g. running under a non-Linux kernel where _set_pdeathsig is a
+        # no-op).
+        try:
+            os.kill(child_pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        raise AssertionError(
+            f"child {child_pid} survived wrapper SIGKILL — pdeathsig did not fire"
+        )

--- a/kali/tests/test_wrap_claude.py
+++ b/kali/tests/test_wrap_claude.py
@@ -1,0 +1,92 @@
+"""Tests for wrap-claude.py supervisor: envs file lifecycle."""
+from __future__ import annotations
+import json
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+WRAP = Path(__file__).parent.parent / "scripts" / "wrap-claude.py"
+
+
+def _fake_claude(tmp_path: Path) -> Path:
+    """Write a script that prints a registration line then sleeps."""
+    path = tmp_path / "fake-claude"
+    path.write_text(
+        "#!/usr/bin/env bash\n"
+        "echo 'registered environment env_TEST123' >&2\n"
+        "trap 'exit 0' TERM\n"
+        "sleep 300 &\n"
+        "wait $!\n"
+    )
+    path.chmod(0o755)
+    return path
+
+
+def test_graceful_sigterm_clears_envs_file(tmp_path):
+    agent_dir = tmp_path / ".willikins-agent"
+    envs_dir = agent_dir / "envs"
+    envs_dir.mkdir(parents=True)
+
+    fake = _fake_claude(tmp_path)
+    env = {
+        **os.environ,
+        "WILLIKINS_AGENT_DIR": str(agent_dir),
+        "CLAUDE_BIN_OVERRIDE": str(fake),
+    }
+    proc = subprocess.Popen(
+        ["python3", "-u", str(WRAP), "willikins-test"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    target = envs_dir / "willikins-test.json"
+    for _ in range(40):
+        if target.exists():
+            break
+        time.sleep(0.1)
+    assert target.exists(), f"envs file not created: {list(envs_dir.iterdir())}"
+    data = json.loads(target.read_text())
+    assert data["env_id"] == "env_TEST123"
+    assert data["pid"] > 0
+
+    proc.send_signal(signal.SIGTERM)
+    proc.wait(timeout=10)
+    assert proc.returncode == 0
+    assert not target.exists(), "envs file should be removed on graceful exit"
+
+
+def test_sigkill_leaves_envs_file(tmp_path):
+    agent_dir = tmp_path / ".willikins-agent"
+    envs_dir = agent_dir / "envs"
+    envs_dir.mkdir(parents=True)
+
+    fake = _fake_claude(tmp_path)
+    env = {
+        **os.environ,
+        "WILLIKINS_AGENT_DIR": str(agent_dir),
+        "CLAUDE_BIN_OVERRIDE": str(fake),
+    }
+    proc = subprocess.Popen(
+        ["python3", "-u", str(WRAP), "willikins-test"],
+        env=env,
+    )
+    target = envs_dir / "willikins-test.json"
+    for _ in range(40):
+        if target.exists():
+            break
+        time.sleep(0.1)
+    assert target.exists()
+
+    proc.send_signal(signal.SIGKILL)
+    proc.wait(timeout=5)
+    # SIGKILL on the wrapper does not run the unlink path; the file is left
+    # behind for the reaper to find.
+    assert target.exists(), "envs file should persist on SIGKILL"
+
+    # Best-effort cleanup of the orphaned fake-claude child so pytest exits.
+    try:
+        subprocess.run(["pkill", "-9", "-f", "fake-claude"], check=False)
+    except FileNotFoundError:
+        pass


### PR DESCRIPTION
📦 Repo:   derio-net/agent-images
📋 Plan:   docs/superpowers/plans/2026-04-22-silent-reconnect-phantoms.md
📐 Spec:   docs/superpowers/specs/2026-04-22-silent-reconnect-phantoms-design.md
🎯 Phase:  1/3 — Reaper implementation [agentic]
🔗 Issue:  https://github.com/derio-net/agent-images/issues/30

**Goal (from plan):** Close the phantom-session leak surfaced by the 2026-04-18 persistent-agent-reliability T+48h soak (17 phantoms: ~11 silent-reconnects + ~6 OOMKills) by adding a client-driven orphan-env reaper invoked inline from `kali/scripts/session-manager.sh` on each 5-minute tick.

---

## Summary

Implements Phase 1 of the silent-reconnect-phantoms plan, **Branch B** per the Phase 0 findings (`kali/docs/findings/2026-04-22-orphan-env-reaper.md`). Branch A was structurally impossible — claude `2.1.119` does not write `bridge-pointer.json`, so we have to own the env_id record ourselves.

### Changes

- **`kali/scripts/wrap-claude.py`** (new) — supervisor around `claude remote-control`. Scrapes the bridge env_id from claude's stderr and writes `~/.willikins-agent/envs/<session>.json` with `{env_id, pid, started_at}`. Forwards SIGTERM/SIGINT to claude's process group so the existing `bridge:shutdown` path still fires; unlinks the envs file on graceful (`rc==0`) exit. Spawns claude with `start_new_session=True` and sets `PR_SET_PDEATHSIG` via `prctl` so the claude child cannot outlive the wrapper (closes the orphan-on-wrapper-SIGKILL hole).
- **`kali/scripts/reap-orphan-envs.sh`** (new) — scans `~/.willikins-agent/envs/*.json` each session-manager tick, treats `kill -0 $pid`-failure as orphan, and `DELETE`s against `https://api.anthropic.com/v1/environments/bridge/<env_id>`. Status handling: `2xx`/`404` → file removed; `401`/`403` → auth-error backoff (1h after 3 failures); `5xx` → leave for next tick. Always sends `anthropic-beta: environments-2025-11-01`. Serialised across overlapping supercronic ticks via `flock`; per-call `--max-time 15 --connect-timeout 5` so a hung TCP can't block the entire tick; logs a `[warn]` line at the top of the tick when bearer/org-UUID files are missing so credential drift surfaces immediately.
- **`kali/scripts/session-manager.sh`** — invokes the reaper at the top of every tick (gated by `REAP_ORPHAN_ENVS=1`, default on); spawns through `/opt/scripts/wrap-claude.py` instead of `claude` directly. The PIDFILE now records the supervisor PID; `shutdown.sh`'s SIGTERM is forwarded through to the claude process group unchanged.
- **`kali/scripts/shutdown.sh`** — comment-only update reflecting that the PIDFILE now holds the supervisor's PID, with PDEATHSIG covering the SIGKILL grace-window fallback.

### Phase 0 constants applied

| Constant | Value |
|---|---|
| `BEARER_PATH` | `~/.claude/.credentials.json` |
| `BEARER_KEY` | `.claudeAiOauth.accessToken // empty` |
| `ORG_UUID_PATH` | `~/.claude.json` |
| `ORG_UUID_KEY` | `.oauthAccount.organizationUuid // empty` |
| Required header | `anthropic-beta: environments-2025-11-01` |

### Scope boundary (Phase 1 covers post-mortem leaks only)

The supervisor records the *first* env_id it scrapes from claude's stderr; the reaper only acts when the owning PID is dead. That fully covers:
- All ~6 OOMKill phantoms.
- Silent-reconnect cases that end with the claude process dying inside the soak window.

It does **not** cover **mid-process-life env_id rotation** — claude silent-reconnecting to a new env_id while the same PID keeps running. The previous env_id becomes a phantom the reaper cannot find while the PID is alive, and the new env_id is never recorded. Phase 2 soak quantifies the residual; if T+48h growth exceeds the spec acceptance criterion, follow-up work either (a) DELETEs on rotation from inside the wrapper or (b) maintains a per-env_id file rather than per-session. Acceptance for Phase 1 is therefore "≥ OOMKill-portion (~6/17) reduction"; full silent-reconnect closure is explicitly Phase 2 territory.

## Code review follow-ups in second commit

- I-2: process-group + PDEATHSIG so the claude child dies with the wrapper.
- I-3: shutdown.sh comment now reflects supervisor-PID reality.
- I-4: curl `--max-time 15 --connect-timeout 5`.
- I-5: flock-serialised reaper ticks.
- I-6: Branch-A plan checkboxes flipped to `[-]` with skip annotations.
- S-2: warn at the top of every tick if bearer/org-UUID files are missing.
- S-5: `ENV_RE` tightened to `env_[A-Za-z0-9]{20,}`.

## Test plan

- [x] `kali/tests/test_wrap_claude.py` — graceful SIGTERM clears envs file; SIGKILL leaves envs file behind for the reaper AND verifies the child dies via PDEATHSIG.
- [x] `kali/tests/test_reap_orphan_envs.sh` — happy path, `404` success, `401` auth-error, `5xx` transient, `anthropic-beta` header presence.
- [x] All 118 existing tests still pass (`uv run pytest kali/tests/` + `bash kali/tests/test_shutdown.sh`).
- [ ] Post-merge: image rebuild, pod roll, manual stale-PID smoke test (deferred to Phase 2 soak per `P1.T3.S4`).

Closes #30