### PR TITLE
feat(kali): vk-local housekeeping — npm cache + worktree prune crons

### DIFF
--- a/kali/config-templates/crontab.txt
+++ b/kali/config-templates/crontab.txt
@@ -30,3 +30,15 @@ PUSHGATEWAY_URL=http://pushgateway.monitoring.svc.cluster.local:9091
 
 # Audit digest — daily summary of all agent activity (21:00 UTC / 23:00 Berlin)
 0 21 * * * /opt/scripts/audit-digest.sh
+
+# vk-local housekeeping — npm cache prune (weekly Sunday 04:00 UTC)
+# Reaps tarballs untouched for >7d, then `npm cache verify` rebuilds the index
+# and reports size. Avoids `npm cache clean --force` which would re-pay download
+# cost on every active session. See plan: frank/2026-04-30--agents--vk-local-oom-remediation.
+0 4 * * 0 /opt/scripts/npm-cache-prune.sh >> __AGENT_HOME__/.willikins-agent/npm-cache-prune.log 2>&1
+
+# vk-local housekeeping — vibe-kanban worktree prune (daily 04:30 UTC)
+# Removes administrative records for worktrees whose checkout directories are
+# gone (e.g. wiped from /var/tmp on pod restart). Heap residue per stale
+# worktree was ~17 MiB in the 2026-04-22 memprofile.
+30 4 * * * /opt/scripts/worktree-prune.sh >> __AGENT_HOME__/.willikins-agent/worktree-prune.log 2>&1

--- a/kali/scripts/npm-cache-prune.sh
+++ b/kali/scripts/npm-cache-prune.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# npm-cache-prune.sh — Weekly cleanup for vk-local's npm file cache.
+#
+# vk-local retains ~900 MiB of npm tarballs across long-running sessions, which
+# inflates the working set seen by cgroup memory accounting. This script:
+#   1. Removes cache files untouched for >7d (atime-based — preserves entries
+#      reused by active sessions).
+#   2. Runs `npm cache verify` so npm rebuilds its index after the deletion and
+#      emits a final size report into the log.
+#
+# The full cache lives under $HOME/.npm/_cacache (npm's default). $HOME is set
+# explicitly so npm doesn't fall back to /tmp when invoked from supercronic.
+#
+# See: frank plan 2026-04-30--agents--vk-local-oom-remediation, Phase 3.
+
+set -u
+HOME="${AGENT_HOME:-${HOME:-/home/claude}}"
+export HOME
+
+CACHE_DIR="$HOME/.npm/_cacache"
+
+if [ ! -d "$CACHE_DIR" ]; then
+    echo "$(date -u +%FT%TZ) cache dir absent at $CACHE_DIR — nothing to prune"
+    exit 0
+fi
+
+echo "$(date -u +%FT%TZ) starting npm cache prune"
+du -sh "$CACHE_DIR" 2>/dev/null | sed 's/^/before: /'
+
+find "$CACHE_DIR" -type f -atime +7 -delete 2>/dev/null
+
+if command -v npm >/dev/null 2>&1; then
+    npm cache verify 2>&1 | sed 's/^/verify: /'
+else
+    echo "npm not on PATH — skipping verify"
+fi
+
+du -sh "$CACHE_DIR" 2>/dev/null | sed 's/^/after:  /'
+echo "$(date -u +%FT%TZ) done"

--- a/kali/scripts/worktree-prune.sh
+++ b/kali/scripts/worktree-prune.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# worktree-prune.sh — Daily cleanup for vibe-kanban worktree records.
+#
+# vibe-kanban creates one git worktree per execution under /var/tmp (tmpfs that
+# is wiped on pod restart). Each canonical repo at $HOME/repos/<name>/ keeps
+# administrative records for those worktrees in .git/worktrees/, and orphaned
+# records hold ~17 MiB of in-process heap residue per repo per stale worktree
+# (per the 2026-04-22 memprofile). `git worktree prune` removes records whose
+# checkout directory no longer exists.
+#
+# We iterate every git directory directly under $HOME/repos/. This is the
+# canonical project root for vibe-kanban on Frank — worktrees themselves live
+# under /var/tmp/vibe-kanban/worktrees/ and link back via the .git gitdir file.
+#
+# See: frank plan 2026-04-30--agents--vk-local-oom-remediation, Phase 3.
+
+set -u
+HOME="${AGENT_HOME:-${HOME:-/home/claude}}"
+REPO_ROOT="$HOME/repos"
+
+if [ ! -d "$REPO_ROOT" ]; then
+    echo "$(date -u +%FT%TZ) repo root absent at $REPO_ROOT — nothing to prune"
+    exit 0
+fi
+
+echo "$(date -u +%FT%TZ) starting worktree prune"
+
+shopt -s nullglob
+for gitdir in "$REPO_ROOT"/*/.git; do
+    repo="$(dirname "$gitdir")"
+    # Skip submodule-style .git files that are not real git directories.
+    [ -d "$gitdir" ] || continue
+    echo "--- $repo"
+    git --git-dir="$gitdir" worktree prune --verbose --expire=1.day.ago 2>&1 || true
+done
+
+echo "$(date -u +%FT%TZ) done"

--- a/kali/tests/test_npm_cache_prune.sh
+++ b/kali/tests/test_npm_cache_prune.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# test_npm_cache_prune.sh — harness for scripts/npm-cache-prune.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+export AGENT_HOME="$TMP"
+export HOME="$TMP"
+mkdir -p "$AGENT_HOME/.npm/_cacache/content-v2"
+
+# Old file (atime 8 days ago) — must be deleted.
+old="$AGENT_HOME/.npm/_cacache/content-v2/old.tgz"
+echo old > "$old"
+touch -a -t "$(date -u -d '8 days ago' +%Y%m%d%H%M)" "$old"
+
+# Fresh file (atime now) — must remain.
+fresh="$AGENT_HOME/.npm/_cacache/content-v2/fresh.tgz"
+echo fresh > "$fresh"
+touch -a "$fresh"
+
+# Stub npm so the script doesn't depend on a real install.
+STUB_BIN="$TMP/bin"
+mkdir -p "$STUB_BIN"
+cat > "$STUB_BIN/npm" <<'EOS'
+#!/usr/bin/env bash
+echo "npm cache verify (stub) called"
+EOS
+chmod +x "$STUB_BIN/npm"
+export PATH="$STUB_BIN:$PATH"
+
+bash "$SCRIPT_DIR/scripts/npm-cache-prune.sh" >"$TMP/out.log" 2>&1
+
+if [[ -e "$old" ]]; then
+    echo "FAIL: old cache file still present" >&2
+    cat "$TMP/out.log" >&2
+    exit 1
+fi
+if [[ ! -e "$fresh" ]]; then
+    echo "FAIL: fresh cache file was deleted" >&2
+    cat "$TMP/out.log" >&2
+    exit 1
+fi
+if ! grep -q "npm cache verify" "$TMP/out.log"; then
+    echo "FAIL: npm verify was not invoked" >&2
+    cat "$TMP/out.log" >&2
+    exit 1
+fi
+
+# Absent cache dir — script must exit 0 with a noop message.
+rm -rf "$AGENT_HOME/.npm"
+bash "$SCRIPT_DIR/scripts/npm-cache-prune.sh" >"$TMP/out2.log" 2>&1
+if ! grep -q "nothing to prune" "$TMP/out2.log"; then
+    echo "FAIL: empty-state path did not emit noop" >&2
+    cat "$TMP/out2.log" >&2
+    exit 1
+fi
+
+echo PASS

--- a/kali/tests/test_worktree_prune.sh
+++ b/kali/tests/test_worktree_prune.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# test_worktree_prune.sh — harness for scripts/worktree-prune.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+export AGENT_HOME="$TMP"
+export HOME="$TMP"
+
+# Build a real repo with an orphaned worktree record.
+REPO="$AGENT_HOME/repos/sample"
+mkdir -p "$REPO"
+git -C "$REPO" init -q
+git -C "$REPO" -c user.email=test@test -c user.name=test commit -q --allow-empty -m bootstrap
+
+WORKTREE="$TMP/dead-worktree"
+git -C "$REPO" worktree add -q -b dead-branch "$WORKTREE"
+# Confirm record exists.
+test -d "$REPO/.git/worktrees/dead-worktree"
+# Delete the checkout dir without `git worktree remove` — leaves the record orphaned.
+rm -rf "$WORKTREE"
+
+# Backdate the record so --expire=1.day.ago picks it up.
+find "$REPO/.git/worktrees/dead-worktree" -type f -exec \
+    touch -t "$(date -u -d '2 days ago' +%Y%m%d%H%M)" {} +
+
+# Repo lacking .git directory entirely — script must skip it gracefully.
+mkdir -p "$AGENT_HOME/repos/no-git"
+
+bash "$SCRIPT_DIR/scripts/worktree-prune.sh" >"$TMP/out.log" 2>&1
+
+if [[ -d "$REPO/.git/worktrees/dead-worktree" ]]; then
+    echo "FAIL: orphaned worktree record was not pruned" >&2
+    cat "$TMP/out.log" >&2
+    exit 1
+fi
+
+# Empty state: no repos dir.
+rm -rf "$AGENT_HOME/repos"
+bash "$SCRIPT_DIR/scripts/worktree-prune.sh" >"$TMP/out2.log" 2>&1
+if ! grep -q "nothing to prune" "$TMP/out2.log"; then
+    echo "FAIL: empty-state path did not emit noop" >&2
+    cat "$TMP/out2.log" >&2
+    exit 1
+fi
+
+echo PASS


### PR DESCRIPTION
## Summary

Adds two scheduled cron jobs to kali to address the working-set issues identified in the 2026-04-22 vk-local memory profile:

- **npm-cache-prune.sh** (weekly, Sun 04:00 UTC) — reaps `~/.npm/_cacache` entries with atime >7d, then `npm cache verify` rebuilds the index. Targets the ~900 MiB npm tarball cache vk-local accumulates over long sessions.
- **worktree-prune.sh** (daily, 04:30 UTC) — iterates `$AGENT_HOME/repos/*/.git/` and runs `git worktree prune --expire=1.day.ago` to drop records for worktrees wiped from `/var/tmp` on pod restart. Targets the ~17 MiB/worktree heap residue.

Both scripts are idempotent, noop on missing target dirs, and log under `$AGENT_HOME/.willikins-agent/` consistent with existing cron entries. Each ships with a tmpdir-based harness test under `kali/tests/`.

## Cross-references

- Frank plan: [`docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md`](https://github.com/derio-net/frank/blob/main/docs/superpowers/plans/2026-04-30--agents--vk-local-oom-remediation.md), Phase 3
- Findings: [`kali/docs/findings/2026-04-22-vk-local-memory-profile.md`](https://github.com/derio-net/agent-images/blob/main/kali/docs/findings/2026-04-22-vk-local-memory-profile.md)
- Frank tracking issue: derio-net/frank#154

## Path notes vs. plan

The plan example listed placeholder paths; the implementation uses the verified locations on Frank:
- `$AGENT_HOME/.npm/_cacache` (npm default; no change needed)
- `$AGENT_HOME/repos/*/.git/` (canonical repo root — vibe-kanban worktrees under `/var/tmp/vibe-kanban/worktrees/` link back via `.git` gitdir files)
- Logs go to `$AGENT_HOME/.willikins-agent/` (the existing cron logging dir), not `/var/log/agent` (which doesn't exist in this image)

## Existing-PV gotcha

`cont-init.d/50-seed-config` only copies the crontab if `~/.crontab` is absent, so existing PVs (e.g. `secure-agent-pod`'s) keep the older crontab. The two new lines need to be appended once via `kubectl exec` against `~/.crontab`; supercronic auto-reloads on file change, so no pod restart is required. (Same pattern as the existing `frank-gotchas.md` note about `~/.tmux.conf` seeding.)

## Test plan

- [x] `bash kali/tests/test_npm_cache_prune.sh` — passes locally
- [x] `bash kali/tests/test_worktree_prune.sh` — passes locally
- [ ] After merge: image-bumper opens auto-PR in derio-net/frank, deployment.yaml SHA bumps, ArgoCD syncs, supercronic on the live pod auto-reloads (existing-PV manual append done out-of-band)
- [ ] Verify after first weekly tick: `kubectl -n secure-agent-pod exec -c kali deploy/secure-agent-pod -- ls -la /home/claude/.willikins-agent/{npm-cache-prune,worktree-prune}.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)