### PR TITLE
fix(agent-shell-base): pin tmux-continuum to v3.1.0 (3.1.2 never existed)

### DIFF
--- a/agent-shell-base/Dockerfile
+++ b/agent-shell-base/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ARG TMUX_RESURRECT_REF=v4.0.0
-ARG TMUX_CONTINUUM_REF=3.1.2
+ARG TMUX_CONTINUUM_REF=v3.1.0
 RUN mkdir -p /usr/local/share/tmux-plugins \
     && git clone --depth 1 --branch ${TMUX_RESURRECT_REF} \
          https://github.com/tmux-plugins/tmux-resurrect /usr/local/share/tmux-plugins/tmux-resurrect \


### PR DESCRIPTION
## Summary

`agent-shell-base/Dockerfile` line 22 pinned `TMUX_CONTINUUM_REF=3.1.2`, but `tmux-plugins/tmux-continuum` upstream has no such ref — neither a branch nor a tag. Tags go `v1.0.0 → v2.x → v3.0.0 → v3.1.0` (newest); the only branch is `master`.

Every build of `agent-shell-base` since [6362ca1](https://github.com/derio-net/agent-images/commit/6362ca1) has failed at:

```
fatal: Remote branch 3.1.2 not found in upstream origin
```

That failure short-circuits the workflow: `build-children` and `dispatch-frank` are skipped, so no kali image carrying recent `kali/scripts/` changes ever publishes. Concretely, this blocks deploying the orphan-env reaper from #33, which in turn blocks the Phase 2 soak ([#31](https://github.com/derio-net/agent-images/issues/31)).

## Fix

```diff
- ARG TMUX_CONTINUUM_REF=3.1.2
+ ARG TMUX_CONTINUUM_REF=v3.1.0
```

- `v3.1.0` is the newest existing tag and the closest match to the (non-existent) `3.1.2`.
- Matches the `vX.Y.Z` form already used for `TMUX_RESURRECT_REF=v4.0.0`.
- Pinning to a tag (not `master`) preserves reproducibility.

## Test plan

- [ ] CI's `build-shell-base` job clones tmux-continuum cleanly and the image publishes.
- [ ] `build-children` (kali) runs and publishes a new `secure-agent-kali` tag.
- [ ] `dispatch-frank` triggers, ArgoCD picks up the new image, pod rolls.
- [ ] After roll, the reaper from #33 is in place — verify `/opt/scripts/reap-orphan-envs.sh` exists in the kali container.
- [ ] Operator can then start the Phase 2 48 h soak ([#31](https://github.com/derio-net/agent-images/issues/31)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)