### PR TITLE
fix(agent-shell-base): install xz-utils so s6-overlay tarballs can extract

### DIFF
--- a/agent-shell-base/Dockerfile
+++ b/agent-shell-base/Dockerfile
@@ -16,6 +16,7 @@ USER root
 RUN apt-get update && apt-get install -y --no-install-recommends \
       openssh-server \
       tmux mosh locales-all \
+      xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
 ARG TMUX_RESURRECT_REF=v4.0.0


### PR DESCRIPTION
## Summary

Follow-up to #35. With `TMUX_CONTINUUM_REF` re-pinned, `build-shell-base` got past the tmux clone step and immediately failed on the next layer (run [25184287885](https://github.com/derio-net/agent-images/actions/runs/25184287885)):

```
tar (child): xz: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
```

The s6-overlay release assets are `.tar.xz`; `tar -J` shells out to the `xz` binary. The base image (`ghcr.io/derio-net/agent-base`) doesn't ship `xz`, and the apt-install layer here only pulls `openssh-server`, `tmux`, `mosh`, and `locales-all`.

## Fix

Add `xz-utils` to the apt install:

```diff
  RUN apt-get update && apt-get install -y --no-install-recommends \
        openssh-server \
        tmux mosh locales-all \
+       xz-utils \
      && rm -rf /var/lib/apt/lists/*
```

`xz-utils` is the canonical Debian package for `xz` and bundled tooling.

## Test plan

- [ ] `build-shell-base` job extracts both s6-overlay tarballs cleanly.
- [ ] `build-children` proceeds to build `secure-agent-kali`.
- [ ] `dispatch-frank` triggers; pod rolls onto an image carrying the orphan-env reaper from #33.
- [ ] Operator can then start the Phase 2 48 h soak ([#31](https://github.com/derio-net/agent-images/issues/31)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)