### PR TITLE
fix(agent-shell-base): install passwd so groupadd/useradd are available

### DIFF
--- a/agent-shell-base/Dockerfile
+++ b/agent-shell-base/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       openssh-server \
       tmux mosh locales-all \
       xz-utils \
+      passwd \
     && rm -rf /var/lib/apt/lists/*
 
 ARG TMUX_RESURRECT_REF=v4.0.0


### PR DESCRIPTION
## Summary

Third in a chain of fixes for `build-shell-base` (after #35 tmux-continuum pin, #36 xz-utils). With xz-utils landed, the next step failed (run [25184732691](https://github.com/derio-net/agent-images/actions/runs/25184732691)):

```
/bin/sh: 1: groupadd: not found
/bin/sh: 1: useradd: not found
```

`agent-shell-base/Dockerfile:46-60` reconciles existing UID/GID conflicts using `groupadd`, `useradd`, `groupdel`, `userdel` — all from the Debian `passwd` package. The base image (`agent-base`) only installs `adduser` (which provides `adduser`/`addgroup`/`deluser`/`delgroup`), not `passwd`. So this RUN step has never been executable.

## Fix

```diff
  RUN apt-get update && apt-get install -y --no-install-recommends \
        openssh-server \
        tmux mosh locales-all \
        xz-utils \
+       passwd \
      && rm -rf /var/lib/apt/lists/*
```

Alternative: rewrite the block to use `adduser`/`addgroup`/`deluser`/`delgroup` (which the base already has). Rejected — the existing logic is unusual (UID-conflict reconciliation with `--gid <n>` not just `--ingroup <name>`); preserving it is the smaller, lower-risk change.

## Test plan

- [ ] Step 7 of `build-shell-base` (UID/GID block) runs cleanly.
- [ ] Build proceeds through s6 setup, `COPY etc/`, sshd config, USER switch.
- [ ] `build-children` (kali) starts, completes, publishes a new tag.
- [ ] `dispatch-frank` rolls the pod onto an image carrying the orphan-env reaper from #33.
- [ ] Operator can then start the Phase 2 48 h soak ([#31](https://github.com/derio-net/agent-images/issues/31)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)