### PR TITLE
fix(agent-shell-base): use /usr/sbin/ paths for groupadd/useradd

### DIFF
--- a/agent-shell-base/Dockerfile
+++ b/agent-shell-base/Dockerfile
@@ -49,14 +49,14 @@ RUN if id -u "${AGENT_USER}" >/dev/null 2>&1; then \
     else \
         if getent passwd "${AGENT_UID}" >/dev/null; then \
             existing_user=$(getent passwd "${AGENT_UID}" | cut -d: -f1); \
-            userdel -r "${existing_user}" 2>/dev/null || true; \
+            /usr/sbin/userdel -r "${existing_user}" 2>/dev/null || true; \
         fi; \
         if getent group "${AGENT_GID}" >/dev/null; then \
             existing_group=$(getent group "${AGENT_GID}" | cut -d: -f1); \
-            groupdel "${existing_group}" 2>/dev/null || true; \
+            /usr/sbin/groupdel "${existing_group}" 2>/dev/null || true; \
         fi; \
-        groupadd --gid ${AGENT_GID} ${AGENT_USER}; \
-        useradd --uid ${AGENT_UID} --gid ${AGENT_GID} \
+        /usr/sbin/groupadd --gid ${AGENT_GID} ${AGENT_USER}; \
+        /usr/sbin/useradd --uid ${AGENT_UID} --gid ${AGENT_GID} \
                 --create-home --home-dir ${AGENT_HOME} \
                 --shell /bin/bash ${AGENT_USER}; \
     fi


### PR DESCRIPTION
## Summary

#37 was a misdiagnosis. The install log from run [25185164758](https://github.com/derio-net/agent-images/actions/runs/25185164758) shows:

```
passwd is already the newest version (1:4.13+dfsg1-1+deb12u2).
passwd set to manually installed.
```

The `passwd` package is already installed in the parent image — adding it again was a no-op. The real issue is `PATH`.

`base/Dockerfile:11` sets:

```
PATH=/home/claude/.local/bin:/usr/local/bin:/usr/bin:/bin
```

No `/usr/sbin`. But `groupadd`, `useradd`, `groupdel`, `userdel` (and pretty much all sysadmin binaries from the `passwd` package) live in `/usr/sbin/`. So they exist; `/bin/sh` just can't find them.

`base/Dockerfile:59-60` already follows the right convention — it calls `/usr/sbin/addgroup` and `/usr/sbin/adduser` explicitly. The block in `agent-shell-base` should do the same.

## Fix

Prefix the four bare command names with `/usr/sbin/`:

```diff
-            userdel -r "${existing_user}" 2>/dev/null || true;
+            /usr/sbin/userdel -r "${existing_user}" 2>/dev/null || true;
...
-            groupdel "${existing_group}" 2>/dev/null || true;
+            /usr/sbin/groupdel "${existing_group}" 2>/dev/null || true;
...
-        groupadd --gid ${AGENT_GID} ${AGENT_USER};
-        useradd --uid ${AGENT_UID} --gid ${AGENT_GID} \
+        /usr/sbin/groupadd --gid ${AGENT_GID} ${AGENT_USER};
+        /usr/sbin/useradd --uid ${AGENT_UID} --gid ${AGENT_GID} \
```

The redundant `passwd` apt entry from #37 is left in place — harmless; removing it would muddy this diff with an unrelated cleanup.

## Test plan

- [ ] Step 7 of `build-shell-base` (UID/GID block) finds the binaries and runs.
- [ ] Build proceeds through s6 setup, `COPY etc/`, sshd config, USER switch.
- [ ] `build-children` builds and publishes `secure-agent-kali`.
- [ ] `dispatch-frank` rolls the pod onto an image carrying the orphan-env reaper from #33.
- [ ] Operator can then start the Phase 2 48 h soak ([#31](https://github.com/derio-net/agent-images/issues/31)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)