### PR TITLE
fix(kali): use /usr/sbin/ paths for groupadd/useradd

### DIFF
--- a/kali/Dockerfile
+++ b/kali/Dockerfile
@@ -17,14 +17,14 @@ USER root
 RUN if ! id -u "${AGENT_USER}" >/dev/null 2>&1; then \
         if getent passwd 1000 >/dev/null; then \
             existing=$(getent passwd 1000 | cut -d: -f1); \
-            userdel -r "${existing}" 2>/dev/null || true; \
+            /usr/sbin/userdel -r "${existing}" 2>/dev/null || true; \
         fi; \
         if getent group 1000 >/dev/null; then \
             existing_grp=$(getent group 1000 | cut -d: -f1); \
-            groupdel "${existing_grp}" 2>/dev/null || true; \
+            /usr/sbin/groupdel "${existing_grp}" 2>/dev/null || true; \
         fi; \
-        groupadd --gid 1000 ${AGENT_USER}; \
-        useradd --uid 1000 --gid 1000 \
+        /usr/sbin/groupadd --gid 1000 ${AGENT_USER}; \
+        /usr/sbin/useradd --uid 1000 --gid 1000 \
                 --create-home --home-dir ${AGENT_HOME} \
                 --shell /bin/bash ${AGENT_USER}; \
     fi


### PR DESCRIPTION
## Summary

Follow-up to #38, which fixed the same PATH bug in `agent-shell-base/Dockerfile`. Build [25185352041](https://github.com/derio-net/agent-images/actions/runs/25185352041) confirms `build-shell-base` is now green; `build-children (secure-agent-kali)` then fails on the same bare-name binaries:

```
/bin/sh: 1: groupadd: not found
/bin/sh: 1: useradd: not found
```

`kali/Dockerfile:17-30` carries its own copy of the UID/GID reconciliation block (since kali uses the legacy `claude` identity rather than the `agent` default from `agent-shell-base`). The block has the same PATH bug — `agent-base/Dockerfile:11` sets `PATH` without `/usr/sbin`, so `/bin/sh` can't find `/usr/sbin/groupadd` etc.

## Fix

Same shape as #38 — prefix the four bare command names with `/usr/sbin/`:

```diff
-            userdel -r "${existing}" 2>/dev/null || true;
+            /usr/sbin/userdel -r "${existing}" 2>/dev/null || true;
...
-            groupdel "${existing_grp}" 2>/dev/null || true;
+            /usr/sbin/groupdel "${existing_grp}" 2>/dev/null || true;
...
-        groupadd --gid 1000 ${AGENT_USER};
-        useradd --uid 1000 --gid 1000 \
+        /usr/sbin/groupadd --gid 1000 ${AGENT_USER};
+        /usr/sbin/useradd --uid 1000 --gid 1000 \
```

`vk-local/Dockerfile` was checked — it inherits the existing `claude` user from `agent-base` directly and has no UID/GID block, so it isn't affected.

## Test plan

- [ ] Step 6 of `build-children (secure-agent-kali)` finds the binaries and runs.
- [ ] kali image builds, publishes, and `dispatch-frank` rolls the pod.
- [ ] Pod runs an image carrying the orphan-env reaper from #33.
- [ ] Operator can then start the Phase 2 48 h soak ([#31](https://github.com/derio-net/agent-images/issues/31)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)