### PR TITLE
fix(ci): chown smoke-test mount target so claude user can write

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -125,7 +125,11 @@ jobs:
         env:
           IMAGE_SHA: ${{ github.sha }}
         run: |
+          # The mount target is owned by the runner (root); chown to UID 1000
+          # so the in-container claude user (also UID 1000) can write into it.
+          # Without this, the init scripts hit EACCES on mkdir.
           mkdir -p /tmp/test-home
+          sudo chown 1000:1000 /tmp/test-home
           # Run the shared init scripts directly (bypass vibe-kanban startup so
           # the test stays environment-free). Verifies:
           #   1. /opt/agent-init.d/* scripts are present and executable


### PR DESCRIPTION
## Summary

After #35, #36, #38, #39 (the agent-shell-base/kali rot fixes), build [25185785627](https://github.com/derio-net/agent-images/actions/runs/25185785627) finally got past `build-children` for both `secure-agent-kali` and `vk-local`. The next failure is `smoke-test-vk-local`:

```
mkdir: cannot create directory '/home/claude/.ssh-host-keys': Permission denied
mkdir: cannot create directory '/home/claude/.ssh': Permission denied
mkdir: cannot create directory '/home/claude/repos': Permission denied
mkdir: cannot create directory '/home/claude/.claude': Permission denied
mkdir: cannot create directory '/home/claude/.willikins-agent': Permission denied
```

The smoke test mounts `/tmp/test-home -> /home/claude` and runs the container as `--user 1000:1000`. The host-side `mkdir -p /tmp/test-home` creates the directory owned by the runner (root), masking the image's properly-owned `/home/claude`. UID 1000 inside the container can't write into it.

This is the first time `smoke-test-vk-local` has actually executed — every prior CI run failed earlier in the pipeline at `build-children`, so the latent bug was never reached.

## Fix

`chown` the mount target to UID 1000 before launching the container:

```diff
+          # The mount target is owned by the runner (root); chown to UID 1000
+          # so the in-container claude user (also UID 1000) can write into it.
+          # Without this, the init scripts hit EACCES on mkdir.
           mkdir -p /tmp/test-home
+          sudo chown 1000:1000 /tmp/test-home
```

Preserves the original test intent — an empty PVC-like dir simulating first boot — only fixes ownership.

## Test plan

- [ ] `smoke-test-vk-local` passes on the next push to main.
- [ ] `dispatch-frank` fires, sending a `repository_dispatch` to `derio-net/frank`.
- [ ] Frank's secure-agent-pod rolls onto a kali image carrying Phase 1's orphan-env reaper from #33.
- [ ] Operator can then start the Phase 2 48 h soak ([#31](https://github.com/derio-net/agent-images/issues/31)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)