### PR TITLE
fix(agent-shell-base): with-contenv shebang must be /command/with-contenv

### DIFF
--- a/agent-shell-base/etc/cont-finish.d/01-shutdown
+++ b/agent-shell-base/etc/cont-finish.d/01-shutdown
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 set +e
 # Write shutdown marker for session-manager.sh. Note: in s6-overlay v3, cont-finish.d
 # runs AFTER all services are already stopped, so the marker arrives too late to prevent

--- a/agent-shell-base/etc/cont-finish.d/02-tmux-save
+++ b/agent-shell-base/etc/cont-finish.d/02-tmux-save
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 # 02-tmux-save — Force tmux-resurrect save before s6 tears down services.
 # Container runs as ${AGENT_USER} already; no `su` needed (and `su` would
 # require a password when invoked from a non-root context).

--- a/agent-shell-base/etc/cont-init.d/00-run-agent-init
+++ b/agent-shell-base/etc/cont-init.d/00-run-agent-init
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 # 00-run-agent-init — Call shared first-boot scripts from agent-base.
 set -e
 shopt -s nullglob

--- a/agent-shell-base/etc/cont-init.d/10-ssh-host-keys
+++ b/agent-shell-base/etc/cont-init.d/10-ssh-host-keys
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 # 10-ssh-host-keys — Generate sshd host keys on first boot, idempotent.
 # 00-run-agent-init (which runs first by lex order) calls /opt/agent-init.d/01-pvc-dirs
 # which creates and chmods $KEYDIR. We mkdir defensively here in case ordering changes.

--- a/agent-shell-base/etc/cont-init.d/20-venv
+++ b/agent-shell-base/etc/cont-init.d/20-venv
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 # 20-venv — Python venv for cron heartbeat scripts (compute-next-run.py,
 # push-next-expected.sh use croniter).
 set -e

--- a/agent-shell-base/etc/cont-init.d/30-authorized-keys
+++ b/agent-shell-base/etc/cont-init.d/30-authorized-keys
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 set -e
 if [ -f /etc/ssh-keys/authorized_keys ]; then
     cp /etc/ssh-keys/authorized_keys "${AGENT_HOME}/.ssh/authorized_keys"

--- a/agent-shell-base/etc/cont-init.d/40-skel
+++ b/agent-shell-base/etc/cont-init.d/40-skel
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 # 40-skel — Seed missing dotfiles from /etc/skel into $AGENT_HOME on first boot.
 # `useradd --create-home` only seeds skel into the image-layer home; once the
 # PVC is mounted at runtime it overlays $AGENT_HOME and hides any baked-in files.

--- a/agent-shell-base/etc/services.d/sshd/finish
+++ b/agent-shell-base/etc/services.d/sshd/finish
@@ -1,3 +1,3 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 echo "[s6] sshd exited code=$1 (signal=$2)"
 exit 0

--- a/agent-shell-base/etc/services.d/sshd/run
+++ b/agent-shell-base/etc/services.d/sshd/run
@@ -1,2 +1,2 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 exec /usr/sbin/sshd -f /opt/sshd_config -D -e

--- a/agent-shell-base/etc/services.d/supercronic/finish
+++ b/agent-shell-base/etc/services.d/supercronic/finish
@@ -1,3 +1,3 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 echo "[s6] supercronic exited code=$1 (signal=$2)"
 exit 0

--- a/agent-shell-base/etc/services.d/supercronic/run
+++ b/agent-shell-base/etc/services.d/supercronic/run
@@ -1,2 +1,2 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 exec supercronic "${AGENT_HOME}/.crontab"

--- a/kali/etc/cont-init.d/50-seed-config
+++ b/kali/etc/cont-init.d/50-seed-config
@@ -1,4 +1,4 @@
-#!/usr/bin/with-contenv bash
+#!/command/with-contenv bash
 # 50-seed-config — Seed kali config templates to PVC on first boot.
 # Idempotent: only copies when the target file is absent.
 set -e


### PR DESCRIPTION
## Summary

Every `cont-init.d` / `cont-finish.d` / `services.d` script in the s6-overlay supervision tree used the shebang `#!/usr/bin/with-contenv bash`, but s6-overlay v3 only installs `with-contenv` to `/command/with-contenv` (and the package-private path under `/package/admin/...`). There is no `/usr/bin/with-contenv` to be found, so every script exited 127 ("not found") on the interpreter — dragging the s6 stage to `unable to start service legacy-cont-init` and a fatal `rc.init: stopping the container`.

This was masked by the prior `/run` ownership failure that bailed earlier in preinit. After PR #41 fixed `/run`, the new `smoke-test-secure-agent-kali` job caught this on the very first run — exactly the regression-test scenario the new job was added for. (See https://github.com/derio-net/agent-images/actions/runs/25244751273 — `smoke-test-secure-agent-kali` failed with the cont-init 127 storm; everything else green.)

## Fix

Switch all 12 affected scripts to the canonical s6-overlay v3 shebang `#!/command/with-contenv bash` per the upstream docs.

```
agent-shell-base/etc/cont-init.d/{00-run-agent-init,10-ssh-host-keys,
                                  20-venv,30-authorized-keys,40-skel}
agent-shell-base/etc/cont-finish.d/{01-shutdown,02-tmux-save}
agent-shell-base/etc/services.d/sshd/{run,finish}
agent-shell-base/etc/services.d/supercronic/{run,finish}
kali/etc/cont-init.d/50-seed-config
```

## Test plan

- [ ] `smoke-test-secure-agent-kali` reaches `s6-svstat /run/service/sshd → up` within 30s and the run finishes green
- [ ] `dispatch-frank` runs (it was skipped on PR #41's run because of the kali smoke test failure) — bumper opens chore PR in `derio-net/frank`
- [ ] After the bumper PR syncs, `kubectl get pods -n secure-agent-pod` reports both containers `Running`

🤖 Generated with [Claude Code](https://claude.com/claude-code)