### PR TITLE
fix(ci): smoke-test must call s6-svstat by full /command/ path

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -174,8 +174,10 @@ jobs:
             "${KALI_IMAGE}:${IMAGE_SHA}"
           # /init must reach stage 2 (services up). 30s is plenty for the
           # shell-base startup; CrashLoopBackOff would surface inside ~3s.
+          # s6-overlay v3 installs binaries under /command/ — the agent-base
+          # PATH does not include it, so we must call s6-svstat by full path.
           for i in $(seq 1 30); do
-            if docker exec kali-smoke s6-svstat /run/service/sshd 2>/dev/null | grep -q '^up'; then
+            if docker exec kali-smoke /command/s6-svstat /run/service/sshd 2>/dev/null | grep -q '^up'; then
               echo "✓ s6-overlay started, sshd is up"
               docker logs kali-smoke
               docker rm -f kali-smoke


### PR DESCRIPTION
## Summary

s6-overlay v3 installs its commands under \`/command/\`, but agent-base's PATH does not include that directory. The \`smoke-test-secure-agent-kali\` job called bare \`s6-svstat\` via \`docker exec\`, which does PATH lookup, and silently failed with ENOENT (suppressed by \`2>/dev/null\`). The 30s loop never matched and the test reported sshd never came up — even though the container was actually healthy:

\`\`\`
Server listening on 0.0.0.0 port 2222.
read crontab: /home/claude/.crontab
cont-init: info: /etc/cont-init.d/50-seed-config exited 0
\`\`\`

Use the full path \`/command/s6-svstat\` so the test actually queries the supervisor.

## Context

This is the third (and last expected) latent issue in the post-Phase-3 image chain:
1. PR #41 — chown \`/run\` itself (preinit was bailing).
2. PR #42 — fix \`with-contenv\` shebang to \`/command/with-contenv\` (cont-init scripts were exiting 127).
3. This PR — fix the smoke test so it can actually verify the now-working supervisor.

With this in, \`dispatch-frank\` should finally fire and the bumper roundtrip should restore the live cluster.

## Test plan

- [ ] Post-merge build: \`smoke-test-secure-agent-kali\` reports \`✓ s6-overlay started, sshd is up\` and exits 0
- [ ] \`dispatch-frank\` runs (no longer skipped)
- [ ] Bumper opens chore PR in \`derio-net/frank\`
- [ ] After that PR syncs: \`kubectl get pods -n secure-agent-pod\` reports both containers \`Running\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)