### PR TITLE
docs(plan): final deviation summary — three-PR fix chain, resolved

### DIFF
--- a/docs/superpowers/plans/2026-04-27--agents--restart-resilience.md
+++ b/docs/superpowers/plans/2026-04-27--agents--restart-resilience.md
@@ -1,7 +1,7 @@
 # Agent Pod Restart Resilience — Implementation Plan (agent-images side)
 
 **Spec:** `derio-net/frank:docs/superpowers/specs/2026-04-27--agents--restart-resilience-design.md`
-**Status:** In Progress
+**Status:** Complete
 
 **Type:** Foundation extension of the agent-images repo. Companion to the spec in `derio-net/frank` (linked above) and the [frank-side plan](https://github.com/derio-net/frank/blob/main/docs/superpowers/plans/2026-04-27--agents--restart-resilience.md) which handles the cluster-side work (notifications + cutover + verification).
 
@@ -672,9 +672,19 @@ s6-overlay-suexec: fatal: child failed with exit code 100
 
 **Why CI didn't catch it:** the only smoke test (`smoke-test-vk-local`, added in PR #40) targets `vk-local`, which has no s6 supervisor, and uses `--entrypoint /bin/sh` to bypass `/init` entirely. The kali path never ran under K8s-equivalent constraints in CI, so the missing chown surfaced only on live deploy.
 
-**Fix:** `fix(agent-shell-base): chown /run + /var/run for s6-overlay non-root preinit`
+**Fix (three sequential PRs, each unmasked by the previous one):**
 
-- `agent-shell-base/Dockerfile`: replace `chown -R … /run/service /run/s6 …` with `chown -R … /run /var/run` so `/run` itself is agent-owned and preinit's writes succeed.
-- `.github/workflows/build.yaml`: add `smoke-test-secure-agent-kali` job that boots `/init` with `--user 1000:1000 --cap-drop=ALL --security-opt=no-new-privileges`, mirroring the live pod's securityContext, and waits for `s6-svstat /run/service/sshd` to report `up`. Regression-tests this exact failure mode.
+1. **PR #41 — `fix(agent-shell-base): chown /run + /var/run for s6-overlay non-root preinit`** — addresses the root cause above.
+   - `agent-shell-base/Dockerfile`: replace `chown -R … /run/service /run/s6 …` with `chown -R … /run /var/run` so `/run` itself is agent-owned and preinit's writes succeed.
+   - `.github/workflows/build.yaml`: add `smoke-test-secure-agent-kali` job that boots `/init` with `--user 1000:1000 --cap-drop=ALL --security-opt=no-new-privileges`, mirroring the live pod's securityContext, and waits for `s6-svstat /run/service/sshd` to report `up`. Regression-tests this exact failure mode.
 
-**Outcome:** Image rebuilt and bumped via the standard bumper flow; pod returned to `Running`. Gotcha appended to `frank:.claude/rules/frank-gotchas.md`.
+2. **PR #42 — `fix(agent-shell-base): with-contenv shebang must be /command/with-contenv`** — uncovered immediately by #41's new smoke test. Every cont-init.d / cont-finish.d / services.d script used `#!/usr/bin/with-contenv bash`, but s6-overlay v3 only installs `with-contenv` under `/command/` (not `/usr/bin/`), so all 12 supervised scripts exited 127 on the interpreter, dragging legacy-cont-init to "unable to start" and a fatal `rc.init: stopping the container`. Latent since the Phase 3 migration; masked by #41's preinit failure. Fixed all 12 files to `#!/command/with-contenv bash`.
+
+3. **PR #43 — `fix(ci): smoke-test must call s6-svstat by full /command/ path`** — uncovered after #42 made the supervisor actually start. The smoke test's `docker exec kali-smoke s6-svstat …` was failing silently with ENOENT (`/command/` not on agent-base PATH; `2>/dev/null` suppressed the error), so the 30s loop never matched even though sshd and supercronic were healthy. Switched to `/command/s6-svstat` so the regression net actually closes.
+
+**Outcome:** Image SHA `c804fab75ba1a4f71fe8b597f3d6e9d08d862e43` (post-#43) bumped into frank via PR #168; ArgoCD synced; pod `secure-agent-pod-56874b8f5d-*` came up clean (0 restarts, sshd + supercronic both `up` per `s6-svstat`). Gotchas in `frank:.claude/rules/frank-gotchas.md` cover both the `/run` chown requirement and the `with-contenv` shebang path. **Resolved.**
+
+**Lessons recorded for future s6-overlay-style migrations:**
+- A new image lineage with a new init system (s6-overlay vs. tini) MUST get its own end-to-end smoke test exercising `/init` under K8s-equivalent securityContext (`--cap-drop=ALL --security-opt=no-new-privileges`) before being promoted by an auto-bumper. The vk-local-only smoke test predating Phase 3 was structurally unable to catch any kali-side regression.
+- Latent bugs stack. The `/run` chown failure masked the shebang failure, which masked the smoke-test-path failure. Each fix unblocked the next. Plan for two-to-three iterations when reviving an image chain that's been broken for a while.
+- `2>/dev/null` in smoke tests should be used surgically. Suppressing all stderr around a probe converts a "command not found" into a successful "wait longer" — exactly the wrong behavior.


### PR DESCRIPTION
## Summary

Update the Post-deploy deviations entry on the restart-resilience plan to reflect the actual three-PR fix chain that was needed to recover the live \`secure-agent-pod\` after the Phase 3 image migration was first exercised end-to-end:

1. **#41** — chown \`/run\` + \`/var/run\` for non-root preinit (root cause)
2. **#42** — \`with-contenv\` shebang must be \`/command/with-contenv\` (unmasked by #41's new smoke test)
3. **#43** — smoke-test must call \`/command/s6-svstat\` by full path (unmasked by #42 making the supervisor actually start)

Image SHA \`c804fab75ba1a4f71fe8b597f3d6e9d08d862e43\` (post-#43) restored the cluster via \`frank\` PR #168.

Also flip plan **Status: In Progress → Complete** now that the deviation is resolved and the original Phases 1-4 work has been shipped end-to-end on the live cluster.

## Lessons captured

- New init systems need their own end-to-end smoke test under K8s-equivalent securityContext (\`--cap-drop=ALL --security-opt=no-new-privileges\`) before being eligible for auto-bump.
- Plan for 2-3 iterations when reviving an image chain that has been broken for a while — latent bugs unmask each other one at a time.
- Surgical use of \`2>/dev/null\` in smoke tests; suppressing all stderr around a probe converts ENOENT into "wait longer", masking the true failure.

## Test plan

- [ ] Docs-only — no behavior change
- [ ] CI: \`paths-ignore: 'docs/**'\` should skip the rebuild on this merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)