### PR TITLE
fix(wrap-claude): scrape env_id from stdout, not just stderr

### DIFF
--- a/kali/scripts/wrap-claude.py
+++ b/kali/scripts/wrap-claude.py
@@ -68,10 +68,17 @@ def main() -> int:
     else:
         argv = ["claude", "remote-control", "--name", session, *extra]
 
+    # Capture stdout (and merge stderr into it) so we can scrape env_id from
+    # the full output stream. The real `claude remote-control` TUI banner —
+    # "Continue coding in the Claude app or https://claude.ai/code?environment=env_..."
+    # — emits on stdout, not stderr. The original spike-era wrapper tailed
+    # stderr only and silently dropped every env_id in production. Merging
+    # also matches the session-manager.sh `>> log 2>&1` redirect downstream,
+    # so no observable difference in the log file.
     child = subprocess.Popen(
         argv,
-        stdout=sys.stdout,
-        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
         stdin=sys.stdin,
         bufsize=1,
         text=True,
@@ -93,12 +100,12 @@ def main() -> int:
     signal.signal(signal.SIGTERM, forward)
     signal.signal(signal.SIGINT, forward)
 
-    def tail_stderr():
-        assert child.stderr is not None
+    def tail_output():
+        assert child.stdout is not None
         seen_env = False
-        for line in child.stderr:
-            sys.stderr.write(line)
-            sys.stderr.flush()
+        for line in child.stdout:
+            sys.stdout.write(line)
+            sys.stdout.flush()
             if seen_env:
                 continue
             m = ENV_RE.search(line)
@@ -110,7 +117,7 @@ def main() -> int:
                 }))
                 seen_env = True
 
-    t = threading.Thread(target=tail_stderr, daemon=True)
+    t = threading.Thread(target=tail_output, daemon=True)
     t.start()
 
     rc = child.wait()

--- a/kali/tests/test_wrap_claude.py
+++ b/kali/tests/test_wrap_claude.py
@@ -10,12 +10,17 @@ from pathlib import Path
 WRAP = Path(__file__).parent.parent / "scripts" / "wrap-claude.py"
 
 
-def _fake_claude(tmp_path: Path) -> Path:
-    """Write a script that prints a registration line then sleeps."""
+def _fake_claude(tmp_path: Path, *, fd: str = "2") -> Path:
+    """Write a fake claude that prints an env_id banner then sleeps.
+
+    `fd` selects the stream the banner is emitted on: "1" (stdout) matches
+    the real `claude remote-control` TUI banner, "2" (stderr) preserves the
+    original spike-era assumption.
+    """
     path = tmp_path / "fake-claude"
     path.write_text(
         "#!/usr/bin/env bash\n"
-        "echo 'registered environment env_01TEST456789ABCDEFGH0' >&2\n"
+        f"echo 'registered environment env_01TEST456789ABCDEFGH0' >&{fd}\n"
         "trap 'exit 0' TERM\n"
         "sleep 300 &\n"
         "wait $!\n"
@@ -111,3 +116,40 @@ def test_sigkill_leaves_envs_file(tmp_path):
         raise AssertionError(
             f"child {child_pid} survived wrapper SIGKILL — pdeathsig did not fire"
         )
+
+
+def test_env_id_on_stdout_is_captured(tmp_path):
+    """Real `claude remote-control` prints the env_id banner on stdout, not
+    stderr (the spike-era assumption baked into the original wrapper). This
+    test pins the fix in place — if the wrapper regresses to stderr-only
+    scraping, production envs/<session>.json files will silently stay empty
+    and the reaper will be a no-op, exactly as observed on c804fab."""
+    agent_dir = tmp_path / ".willikins-agent"
+    envs_dir = agent_dir / "envs"
+    envs_dir.mkdir(parents=True)
+
+    fake = _fake_claude(tmp_path, fd="1")  # stdout
+    env = {
+        **os.environ,
+        "WILLIKINS_AGENT_DIR": str(agent_dir),
+        "CLAUDE_BIN_OVERRIDE": str(fake),
+    }
+    proc = subprocess.Popen(
+        ["python3", "-u", str(WRAP), "willikins-test"],
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    target = envs_dir / "willikins-test.json"
+    try:
+        for _ in range(40):
+            if target.exists():
+                break
+            time.sleep(0.1)
+        assert target.exists(), (
+            "envs file not created — wrapper failed to scrape env_id from stdout"
+        )
+        assert json.loads(target.read_text())["env_id"] == "env_01TEST456789ABCDEFGH0"
+    finally:
+        proc.send_signal(signal.SIGTERM)
+        proc.wait(timeout=10)


### PR DESCRIPTION
## Summary

Phase 1's reaper is a silent no-op in production. Diagnosed against the live `secure-agent-pod` running image `c804fab`:

- Wrapper IS running: `python3 -u /opt/scripts/wrap-claude.py willikins` (PID 748) supervises `claude remote-control --name willikins` (PID 759). Process tree is correct.
- `~/.willikins-agent/envs/` is **empty** — wrapper never wrote `willikins.json`.
- Yet the session log shows two distinct env_ids for this single PID:
  - `env_01DJZZvx4BstRrUCojof6T5s`
  - `env_01JhUdaS21knBrKEVkVA9pDw`
- So claude has already silent-reconnected once — the exact failure mode the reaper exists to catch — but the reaper has nothing to look up.

## Root cause

`tail_stderr` only reads `child.stderr`. The real `claude remote-control` TUI banner —

```
Continue coding in the Claude app or
https://claude.ai/code?environment=env_01...
```

— is emitted on stdout (TUI surface), not stderr (diagnostic surface). The original spike-era assumption came from this stub in `test_wrap_claude.py`:

```python
"echo 'registered environment env_X' >&2"
```

— which doesn't reflect real TUI behaviour. The wrapper has never seen an env_id in production.

## Fix

Merge stderr into stdout, capture stdout via PIPE, scrape every line:

```diff
     child = subprocess.Popen(
         argv,
-        stdout=sys.stdout,
-        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
```

Same total bytes still reach the session log (`session-manager.sh` already merges via `>> log 2>&1`), so no observable downstream difference.

## Test changes

- Generalised `_fake_claude` with an `fd` parameter so it can emit on stdout *or* stderr.
- Existing two tests still emit on stderr — they continue to pass via the new merge path, exercising the backward-compat behaviour.
- New `test_env_id_on_stdout_is_captured` emits on stdout (matches real claude). Confirmed it FAILS against the current production wrapper before this fix and PASSES after — pinning the bug in place against future regression.

```
3 passed in 0.37s
```

## Test plan

- [ ] CI green.
- [ ] After deploy + rollout, `~/.willikins-agent/envs/willikins.json` appears within ~30 s of session start.
- [ ] When claude dies (or pod is rolled without graceful drain), reaper DELETEs the env via the API and removes the envs file.
- [ ] Phase 2 48h soak ([#31](https://github.com/derio-net/agent-images/issues/31)) becomes measurable.

## Note on Phase 1's known mid-life rotation gap

The plan explicitly calls out that the *current* wrapper records the *first* env_id only (`if seen_env: continue`). On the live pod, two env_ids appeared for one PID inside ~18 minutes — confirming the rotation case is real and frequent. With this fix, Phase 2 can finally measure how much residue remains after Phase 1's first-env capture, which is the whole point of the soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)