### PR TITLE
fix(kali): harden vk-local housekeeping crons (review follow-up to #34)

### DIFF
--- a/kali/scripts/npm-cache-prune.sh
+++ b/kali/scripts/npm-cache-prune.sh
@@ -3,21 +3,41 @@
 #
 # vk-local retains ~900 MiB of npm tarballs across long-running sessions, which
 # inflates the working set seen by cgroup memory accounting. This script:
-#   1. Removes cache files untouched for >7d (atime-based — preserves entries
-#      reused by active sessions).
-#   2. Runs `npm cache verify` so npm rebuilds its index after the deletion and
+#   1. Detects whether atime updates are reliable on the cache mount (PVCs may
+#      mount with `noatime`, in which case `-atime +7` would never match).
+#      When atime is unreliable, falls back to mtime (file creation time, which
+#      for npm cache content is when it was downloaded — slightly more
+#      conservative but correct).
+#   2. Removes cache files untouched for >7d.
+#   3. Runs `npm cache verify` so npm rebuilds its index after the deletion and
 #      emits a final size report into the log.
 #
-# The full cache lives under $HOME/.npm/_cacache (npm's default). $HOME is set
-# explicitly so npm doesn't fall back to /tmp when invoked from supercronic.
+# A flock guard prevents overlap with a manual `kubectl exec` invocation or a
+# delayed previous tick.
+#
+# HOME is set explicitly (defensive — supercronic does export HOME under s6,
+# but `set -u` would trip if it ever did not, and the AGENT_HOME → HOME chain
+# matches the convention used by other scripts in /opt/scripts/).
 #
 # See: frank plan 2026-04-30--agents--vk-local-oom-remediation, Phase 3.
 
-set -u
+set -uo pipefail
 HOME="${AGENT_HOME:-${HOME:-/home/claude}}"
 export HOME
 
 CACHE_DIR="$HOME/.npm/_cacache"
+LOCK_DIR="$HOME/.willikins-agent"
+LOCK_FILE="$LOCK_DIR/npm-cache-prune.lock"
+
+mkdir -p "$LOCK_DIR"
+
+# flock single-instance guard. -n: fail immediately if another run holds the
+# lock. The fd stays open for the script's lifetime; lock releases on exit.
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    echo "$(date -u +%FT%TZ) another npm-cache-prune is running — exiting"
+    exit 0
+fi
 
 if [ ! -d "$CACHE_DIR" ]; then
     echo "$(date -u +%FT%TZ) cache dir absent at $CACHE_DIR — nothing to prune"
@@ -27,13 +47,44 @@ fi
 echo "$(date -u +%FT%TZ) starting npm cache prune"
 du -sh "$CACHE_DIR" 2>/dev/null | sed 's/^/before: /'
 
-find "$CACHE_DIR" -type f -atime +7 -delete 2>/dev/null
+# Detect whether atime is being updated on this mount. We touch a probe file,
+# read it, then re-stat: if atime did not advance, the mount is `noatime` and
+# we must fall back to mtime.
+TIME_FLAG="-atime"
+PROBE="$(mktemp -p "$CACHE_DIR" .atime-probe.XXXXXX 2>/dev/null || true)"
+if [ -n "${PROBE:-}" ] && [ -f "$PROBE" ]; then
+    # Backdate atime by 1 day. GNU and BSD `date` differ; try GNU first.
+    backdated="$(date -u -d '1 day ago' '+%Y%m%d%H%M' 2>/dev/null \
+                 || date -u -v-1d '+%Y%m%d%H%M' 2>/dev/null \
+                 || echo "")"
+    if [ -n "$backdated" ]; then
+        touch -a -t "$backdated" "$PROBE" 2>/dev/null || true
+        before_atime=$(stat -c %X "$PROBE" 2>/dev/null || echo 0)
+        cat "$PROBE" >/dev/null 2>&1 || true
+        after_atime=$(stat -c %X "$PROBE" 2>/dev/null || echo 0)
+        if [ "$after_atime" -le "$before_atime" ]; then
+            echo "WARN: atime not advancing on $CACHE_DIR (likely noatime mount) — falling back to mtime"
+            TIME_FLAG="-mtime"
+        fi
+    fi
+    rm -f "$PROBE"
+fi
 
+find "$CACHE_DIR" -type f "$TIME_FLAG" +7 -delete 2>/dev/null || true
+
+verify_rc=0
 if command -v npm >/dev/null 2>&1; then
+    set +o pipefail
     npm cache verify 2>&1 | sed 's/^/verify: /'
+    verify_rc=${PIPESTATUS[0]}
+    set -o pipefail
+    if [ "$verify_rc" -ne 0 ]; then
+        echo "WARN: npm cache verify exited $verify_rc"
+    fi
 else
     echo "npm not on PATH — skipping verify"
 fi
 
 du -sh "$CACHE_DIR" 2>/dev/null | sed 's/^/after:  /'
 echo "$(date -u +%FT%TZ) done"
+exit "$verify_rc"

--- a/kali/scripts/worktree-prune.sh
+++ b/kali/scripts/worktree-prune.sh
@@ -12,11 +12,27 @@
 # canonical project root for vibe-kanban on Frank — worktrees themselves live
 # under /var/tmp/vibe-kanban/worktrees/ and link back via the .git gitdir file.
 #
+# A flock guard prevents overlap with a manual `kubectl exec` invocation.
+#
+# HOME is set explicitly (defensive — supercronic does export HOME under s6,
+# but the AGENT_HOME → HOME chain matches the convention used by other scripts
+# in /opt/scripts/).
+#
 # See: frank plan 2026-04-30--agents--vk-local-oom-remediation, Phase 3.
 
-set -u
+set -uo pipefail
 HOME="${AGENT_HOME:-${HOME:-/home/claude}}"
 REPO_ROOT="$HOME/repos"
+LOCK_DIR="$HOME/.willikins-agent"
+LOCK_FILE="$LOCK_DIR/worktree-prune.lock"
+
+mkdir -p "$LOCK_DIR"
+
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    echo "$(date -u +%FT%TZ) another worktree-prune is running — exiting"
+    exit 0
+fi
 
 if [ ! -d "$REPO_ROOT" ]; then
     echo "$(date -u +%FT%TZ) repo root absent at $REPO_ROOT — nothing to prune"
@@ -26,12 +42,17 @@ fi
 echo "$(date -u +%FT%TZ) starting worktree prune"
 
 shopt -s nullglob
+exit_rc=0
 for gitdir in "$REPO_ROOT"/*/.git; do
     repo="$(dirname "$gitdir")"
     # Skip submodule-style .git files that are not real git directories.
     [ -d "$gitdir" ] || continue
     echo "--- $repo"
-    git --git-dir="$gitdir" worktree prune --verbose --expire=1.day.ago 2>&1 || true
+    if ! git --git-dir="$gitdir" worktree prune --verbose --expire=1.day.ago 2>&1; then
+        echo "WARN: prune failed for $repo"
+        exit_rc=1
+    fi
 done
 
 echo "$(date -u +%FT%TZ) done"
+exit "$exit_rc"

--- a/kali/tests/test_npm_cache_prune.sh
+++ b/kali/tests/test_npm_cache_prune.sh
@@ -3,58 +3,83 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/scripts/npm-cache-prune.sh"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-export AGENT_HOME="$TMP"
-export HOME="$TMP"
-mkdir -p "$AGENT_HOME/.npm/_cacache/content-v2"
-
-# Old file (atime 8 days ago) — must be deleted.
-old="$AGENT_HOME/.npm/_cacache/content-v2/old.tgz"
-echo old > "$old"
-touch -a -t "$(date -u -d '8 days ago' +%Y%m%d%H%M)" "$old"
-
-# Fresh file (atime now) — must remain.
-fresh="$AGENT_HOME/.npm/_cacache/content-v2/fresh.tgz"
-echo fresh > "$fresh"
-touch -a "$fresh"
-
-# Stub npm so the script doesn't depend on a real install.
-STUB_BIN="$TMP/bin"
-mkdir -p "$STUB_BIN"
-cat > "$STUB_BIN/npm" <<'EOS'
+run_with_npm_stub() {
+    # $1: npm exit code
+    local rc="$1"
+    cat > "$STUB_BIN/npm" <<EOS
 #!/usr/bin/env bash
 echo "npm cache verify (stub) called"
+exit $rc
 EOS
-chmod +x "$STUB_BIN/npm"
+    chmod +x "$STUB_BIN/npm"
+}
+
+setup_fixture() {
+    rm -rf "$AGENT_HOME"
+    mkdir -p "$AGENT_HOME/.npm/_cacache/content-v2" "$AGENT_HOME/.willikins-agent"
+
+    # Old file (atime 8 days ago) — must be deleted.
+    old="$AGENT_HOME/.npm/_cacache/content-v2/old.tgz"
+    echo old > "$old"
+    touch -a -t "$(date -u -d '8 days ago' +%Y%m%d%H%M)" "$old"
+
+    # Fresh file (atime now) — must remain.
+    fresh="$AGENT_HOME/.npm/_cacache/content-v2/fresh.tgz"
+    echo fresh > "$fresh"
+    touch -a "$fresh"
+}
+
+export AGENT_HOME="$TMP/h"
+export HOME="$AGENT_HOME"
+STUB_BIN="$TMP/bin"
+mkdir -p "$STUB_BIN"
 export PATH="$STUB_BIN:$PATH"
 
-bash "$SCRIPT_DIR/scripts/npm-cache-prune.sh" >"$TMP/out.log" 2>&1
+# --- Case 1: happy path ---
+setup_fixture
+run_with_npm_stub 0
+rc=0
+bash "$SCRIPT" >"$TMP/out.log" 2>&1 || rc=$?
+[[ $rc -eq 0 ]] || { echo "FAIL: happy path exit=$rc" >&2; cat "$TMP/out.log" >&2; exit 1; }
+[[ ! -e "$old" ]]   || { echo "FAIL: old file still present" >&2; cat "$TMP/out.log" >&2; exit 1; }
+[[   -e "$fresh" ]] || { echo "FAIL: fresh file deleted" >&2; cat "$TMP/out.log" >&2; exit 1; }
+grep -q "npm cache verify" "$TMP/out.log" || { echo "FAIL: verify not invoked" >&2; cat "$TMP/out.log" >&2; exit 1; }
 
-if [[ -e "$old" ]]; then
-    echo "FAIL: old cache file still present" >&2
-    cat "$TMP/out.log" >&2
-    exit 1
-fi
-if [[ ! -e "$fresh" ]]; then
-    echo "FAIL: fresh cache file was deleted" >&2
-    cat "$TMP/out.log" >&2
-    exit 1
-fi
-if ! grep -q "npm cache verify" "$TMP/out.log"; then
-    echo "FAIL: npm verify was not invoked" >&2
-    cat "$TMP/out.log" >&2
-    exit 1
-fi
-
-# Absent cache dir — script must exit 0 with a noop message.
+# --- Case 2: empty state (no cache dir) ---
 rm -rf "$AGENT_HOME/.npm"
-bash "$SCRIPT_DIR/scripts/npm-cache-prune.sh" >"$TMP/out2.log" 2>&1
-if ! grep -q "nothing to prune" "$TMP/out2.log"; then
-    echo "FAIL: empty-state path did not emit noop" >&2
-    cat "$TMP/out2.log" >&2
+bash "$SCRIPT" >"$TMP/out2.log" 2>&1
+grep -q "nothing to prune" "$TMP/out2.log" || { echo "FAIL: empty-state path silent" >&2; cat "$TMP/out2.log" >&2; exit 1; }
+
+# --- Case 3: npm cache verify exits non-zero — script should propagate non-zero exit ---
+setup_fixture
+run_with_npm_stub 7
+rc=0
+bash "$SCRIPT" >"$TMP/out3.log" 2>&1 || rc=$?
+[[ $rc -eq 7 ]] || { echo "FAIL: expected exit 7 from failing npm, got $rc" >&2; cat "$TMP/out3.log" >&2; exit 1; }
+grep -q "WARN: npm cache verify exited 7" "$TMP/out3.log" || { echo "FAIL: warn not logged" >&2; cat "$TMP/out3.log" >&2; exit 1; }
+
+# --- Case 4: lock guard — second concurrent run must noop ---
+setup_fixture
+run_with_npm_stub 0
+# Hold the lock from a background subshell; second invocation should bail.
+(
+  exec 9>"$AGENT_HOME/.willikins-agent/npm-cache-prune.lock"
+  flock 9
+  sleep 2
+) &
+held_pid=$!
+sleep 0.3  # give the holder time to grab the lock
+bash "$SCRIPT" >"$TMP/out4.log" 2>&1
+grep -q "another npm-cache-prune is running" "$TMP/out4.log" || {
+    echo "FAIL: lock guard did not block concurrent run" >&2
+    cat "$TMP/out4.log" >&2
+    wait $held_pid 2>/dev/null || true
     exit 1
-fi
+}
+wait $held_pid 2>/dev/null || true
 
 echo PASS

--- a/kali/tests/test_worktree_prune.sh
+++ b/kali/tests/test_worktree_prune.sh
@@ -46,4 +46,22 @@ if ! grep -q "nothing to prune" "$TMP/out2.log"; then
     exit 1
 fi
 
+# Lock guard: a held lock must cause the next run to noop.
+mkdir -p "$AGENT_HOME/.willikins-agent" "$AGENT_HOME/repos"
+(
+    exec 9>"$AGENT_HOME/.willikins-agent/worktree-prune.lock"
+    flock 9
+    sleep 2
+) &
+held_pid=$!
+sleep 0.3
+bash "$SCRIPT_DIR/scripts/worktree-prune.sh" >"$TMP/out3.log" 2>&1
+if ! grep -q "another worktree-prune is running" "$TMP/out3.log"; then
+    echo "FAIL: lock guard did not block concurrent run" >&2
+    cat "$TMP/out3.log" >&2
+    wait $held_pid 2>/dev/null || true
+    exit 1
+fi
+wait $held_pid 2>/dev/null || true
+
 echo PASS


### PR DESCRIPTION
## Summary

Review follow-up to merged PR #34. Addresses three Important findings and several Suggestions from code review:

- **flock single-instance guard** on both `npm-cache-prune.sh` and `worktree-prune.sh`. Supercronic does not overlap-protect, so a slow `npm cache verify` could collide with a manual `kubectl exec` invocation or a delayed prior tick.
- **noatime fallback** in `npm-cache-prune.sh`. The PVC may mount with `noatime` (or `relatime`), in which case `-atime +7` would never match and the cache would silently grow unbounded. The script now probes the mount with a backdated touch + read; if atime does not advance, it falls back to `-mtime +7`.
- **Verify-failure propagation** in `npm-cache-prune.sh`. `npm cache verify`'s exit code is now captured via `PIPESTATUS` (the prior `| sed` pipe was swallowing it) and the script exits non-zero on failure.
- **Per-repo failure tracking** in `worktree-prune.sh`. A failing prune on one repo no longer masks the error; logs WARN and propagates non-zero exit overall.
- `set -uo pipefail` on both, with deliberate-tolerance lines marked `|| true`.
- HOME-reassignment comment explains why the `AGENT_HOME → HOME` chain exists.

## Tests

Both harnesses now cover the new behaviors:

- `kali/tests/test_npm_cache_prune.sh` — added Case 3 (verify exits non-zero, expects script exit=7 + WARN line) and Case 4 (lock guard).
- `kali/tests/test_worktree_prune.sh` — added a lock-guard case.

```
$ bash kali/tests/test_npm_cache_prune.sh
PASS
$ bash kali/tests/test_worktree_prune.sh
PASS
```

## Cross-references

- Original PR: #34
- Frank tracking: derio-net/frank#154 (Phase 3 of the vk-local OOM remediation plan)
- Frank PR: derio-net/frank#165

## Test plan

- [x] Both harness tests pass
- [ ] After merge: image-bumper opens auto-PR in derio-net/frank, deployment.yaml SHA bumps, ArgoCD syncs
- [ ] On-pod check after first weekly tick: `flock` is in PATH (yes — `util-linux` is a Debian Essential), and the new `*.lock` files appear under `/home/claude/.willikins-agent/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)