### PR TITLE
fix(paperclip-shell): propagate AGENT_GID at build time

### DIFF
--- a/agent-shell-base/Dockerfile
+++ b/agent-shell-base/Dockerfile
@@ -7,8 +7,10 @@ ARG AGENT_GID=1000
 ARG AGENT_HOME=/home/agent
 # HOME tracks AGENT_HOME so supervised processes (sshd, supercronic, cont-init scripts)
 # do not silently fall back to the parent image's /home/claude.
-ENV AGENT_USER=${AGENT_USER} AGENT_UID=${AGENT_UID} AGENT_HOME=${AGENT_HOME} \
-    HOME=${AGENT_HOME}
+# AGENT_GID is propagated alongside AGENT_UID so child images can reference
+# both at build time without re-declaring the ARG.
+ENV AGENT_USER=${AGENT_USER} AGENT_UID=${AGENT_UID} AGENT_GID=${AGENT_GID} \
+    AGENT_HOME=${AGENT_HOME} HOME=${AGENT_HOME}
 
 USER root
 

--- a/paperclip-shell/Dockerfile
+++ b/paperclip-shell/Dockerfile
@@ -1,8 +1,14 @@
 ARG BASE_SHA=latest
 FROM ghcr.io/derio-net/agent-shell-base:${BASE_SHA}
 
-# Inherit AGENT_USER=agent, AGENT_HOME=/home/agent, AGENT_UID/GID=1000 from
-# agent-shell-base — do not override. Fresh PV, no legacy identity to preserve.
+# Inherit AGENT_USER=agent, AGENT_HOME=/home/agent, AGENT_UID=1000 from
+# agent-shell-base via its ENV line — do not override.
+#
+# AGENT_GID is set as ARG (not ENV) in agent-shell-base, so it does not
+# propagate to child images. Re-declare it here so Docker substitutes it at
+# build time in the RUN below; without this, ${AGENT_GID} expands to empty
+# in /bin/sh and `install -d -o 1000 -g  -m 0755` fails (-m read as group).
+ARG AGENT_GID=1000
 
 USER root
 


### PR DESCRIPTION
## Summary

- **paperclip-shell/Dockerfile**: declare `ARG AGENT_GID=1000` so Docker substitutes it at build time. Without this, the `install -d -o \${AGENT_UID} -g \${AGENT_GID} ...` step fails — see *Root cause* below.
- **agent-shell-base/Dockerfile**: add `AGENT_GID=\${AGENT_GID}` to the existing ENV line so it propagates to all child images alongside AGENT_UID. Future children that reference `\${AGENT_GID}` will Just Work.

Unblocks Phase 2 of the paperclip-shell sidecar plan (derio-net/frank#176, blocked by closed-but-failed derio-net/frank#175).

## Root cause

The merge-time build of #46 failed on the paperclip-shell job:

```
[3/4] RUN install -d -o 1000 -g ${AGENT_GID} -m 0755       /var/log/cont-init.d ...
ERROR: process "/bin/sh -c install -d -o ${AGENT_UID} ..." did not complete successfully: exit code: 1
```

Note `-o 1000` (substituted) vs `-g \${AGENT_GID}` (unsubstituted) in the rendered command. agent-shell-base's ENV line propagates `AGENT_USER`, `AGENT_UID`, `AGENT_HOME`, and `HOME` — but not `AGENT_GID`, which is declared only as ARG. ARG does not propagate to child images. So Docker leaves `\${AGENT_GID}` literal, /bin/sh then expands it to the empty string (env var unset), and `install` reads the next flag (`-m`) as the group name → exit 1.

## Test plan

- [ ] `build-children (paperclip-shell, ...)` passes (the previously failing layer)
- [ ] `smoke-test-paperclip-shell` runs and passes (was skipped previously due to build failure)
- [ ] secure-agent-kali / vk-local builds remain green (the agent-shell-base ENV change is additive)
- [ ] `dispatch-frank` fires after all smoke tests succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)