### PR TITLE
feat: add ruflo-server and ruflo-shell images (re-land of PR #48)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,6 +89,13 @@ jobs:
             context: paperclip-shell
             build_args: |
               BASE_SHA=${{ needs.build-shell-base.outputs.sha }}
+          - name: ruflo-shell
+            context: ruflo-shell
+            build_args: |
+              BASE_SHA=${{ needs.build-shell-base.outputs.sha }}
+          - name: ruflo-server
+            context: ruflo-server
+            build_args: ""
     permissions:
       contents: read
       packages: write
@@ -263,8 +270,148 @@ jobs:
           docker logs paperclip-shell-smoke
           docker rm -f paperclip-shell-smoke
 
+  smoke-test-ruflo-shell:
+    needs: build-children
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      RUFLO_SHELL_IMAGE: ghcr.io/derio-net/ruflo-shell
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Smoke test — s6-overlay /init under K8s-equivalent securityContext
+        env:
+          IMAGE_SHA: ${{ github.sha }}
+        run: |
+          # Match the live ruflo-shell securityContext (runAsUser: 1000,
+          # cap-drop=ALL, no-new-privileges) so the s6-overlay preinit hits the
+          # same /run constraints it does in K8s.
+          mkdir -p /tmp/ruflo-shell-home /tmp/ruflo-shell-inventory
+          sudo chown 1000:1000 /tmp/ruflo-shell-home /tmp/ruflo-shell-inventory
+          # Empty inventory — first-deploy posture. The installer should report
+          # "0 installed" and exit clean, not block sshd.
+          echo '{}' | sudo tee /tmp/ruflo-shell-inventory/inventory.yaml >/dev/null
+          sudo chown 1000:1000 /tmp/ruflo-shell-inventory/inventory.yaml
+
+          docker run -d --name ruflo-shell-smoke \
+            --user 1000:1000 \
+            --cap-drop=ALL \
+            --security-opt=no-new-privileges \
+            -v /tmp/ruflo-shell-home:/home/agent \
+            -v /tmp/ruflo-shell-inventory:/etc/ruflo-shell:ro \
+            "${RUFLO_SHELL_IMAGE}:${IMAGE_SHA}"
+
+          # /init must reach stage 2 (sshd up). 30s budget mirrors paperclip smoke.
+          for i in $(seq 1 30); do
+            if docker exec ruflo-shell-smoke /command/s6-svstat /run/service/sshd 2>/dev/null | grep -q '^up'; then
+              echo "✓ s6-overlay started, sshd is up"
+              break
+            fi
+            sleep 1
+          done
+          if ! docker exec ruflo-shell-smoke /command/s6-svstat /run/service/sshd 2>/dev/null | grep -q '^up'; then
+            echo "✗ sshd never came up within 30s"
+            docker logs ruflo-shell-smoke
+            docker rm -f ruflo-shell-smoke
+            exit 1
+          fi
+
+          # Layer-1 managers must be on PATH and runnable as the agent UID.
+          docker exec ruflo-shell-smoke mise --version
+          docker exec ruflo-shell-smoke rustup --version
+          docker exec ruflo-shell-smoke pipx --version
+          docker exec ruflo-shell-smoke python3 --version
+
+          # claude-code is baked in — must be on PATH from a fresh SSH session.
+          docker exec ruflo-shell-smoke claude --version
+
+          # Inventory installer must exist on PATH and rerun cleanly with empty inventory.
+          docker exec ruflo-shell-smoke /usr/local/bin/ruflo-shell-reconcile
+
+          # Boot-time reconcile log must show the empty-inventory clean exit.
+          docker exec ruflo-shell-smoke cat /var/log/cont-init.d/40-shell-inventory.log
+
+          # MOTD drop-in must have been written and contain a recognizable summary.
+          docker exec ruflo-shell-smoke cat /var/lib/ruflo-shell/last-reconcile.motd
+
+          # Banner profile.d drop-in must be present (sourced by /etc/profile on
+          # SSH login; we only assert the file is in place and runnable here).
+          docker exec ruflo-shell-smoke test -x /etc/profile.d/60-ruflo-shell-banner.sh
+
+          docker logs ruflo-shell-smoke
+          docker rm -f ruflo-shell-smoke
+
+  smoke-test-ruflo-server:
+    needs: build-children
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      RUFLO_SERVER_IMAGE: ghcr.io/derio-net/ruflo-server
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Smoke test — ruvocal boots and binds port 3000
+        env:
+          IMAGE_SHA: ${{ github.sha }}
+        run: |
+          # Ruvocal connects to the database lazily on first request; the HTTP
+          # server binds 3000 at startup regardless of DB availability. Smoke
+          # test asserts: container stays running, port 3000 is reachable, and
+          # / returns any HTTP status (1xx-5xx — anything but no-conn).
+          # `curl -sS -o /dev/null -w "%{http_code}"` exits 0 even on
+          # connection-refused (it just writes "000" to stdout), so we drive
+          # the success/failure decision purely off the body, not curl's rc.
+          docker run -d --name ruflo-server-smoke \
+            --user 1000:1000 \
+            -p 13000:3000 \
+            "${RUFLO_SERVER_IMAGE}:${IMAGE_SHA}"
+
+          status=000
+          for i in $(seq 1 60); do
+            status=$(curl -sS -o /dev/null -w "%{http_code}" http://localhost:13000/ 2>/dev/null || echo "000")
+            if [[ "$status" =~ ^[1-5][0-9][0-9]$ ]]; then
+              echo "✓ ruvocal answered HTTP $status after ${i}s"
+              break
+            fi
+            sleep 1
+          done
+
+          if ! [[ "$status" =~ ^[1-5][0-9][0-9]$ ]]; then
+            echo "✗ ruvocal never bound port 3000 (last status: $status)"
+            docker logs ruflo-server-smoke
+            docker rm -f ruflo-server-smoke
+            exit 1
+          fi
+
+          # Container must still be running (didn't crash post-bind).
+          if ! docker inspect -f '{{.State.Running}}' ruflo-server-smoke | grep -q true; then
+            echo "✗ container exited after binding"
+            docker logs ruflo-server-smoke
+            docker rm -f ruflo-server-smoke
+            exit 1
+          fi
+
+          docker logs ruflo-server-smoke | tail -50
+          docker rm -f ruflo-server-smoke
+
   dispatch-frank:
-    needs: [build-children, smoke-test-vk-local, smoke-test-secure-agent-kali, smoke-test-paperclip-shell]
+    needs:
+      - build-children
+      - smoke-test-vk-local
+      - smoke-test-secure-agent-kali
+      - smoke-test-paperclip-shell
+      - smoke-test-ruflo-shell
+      - smoke-test-ruflo-server
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/ruflo-server/Dockerfile
+++ b/ruflo-server/Dockerfile
@@ -1,0 +1,80 @@
+# syntax=docker/dockerfile:1
+# Pinned to ruvnet/ruflo SHA — bump deliberately when re-vendoring.
+ARG RUFLO_GIT_REF=9b169814849b75bdee4b75e7d3d85a0db567802d
+
+# --- source: shallow-clone the upstream repo at the pinned SHA. Single source
+#     of truth for both the builder and runtime stages so we never drift.
+#     `git init` + `git fetch --depth 1 <SHA>` is the only shape that works for
+#     a SHA-pinned shallow clone (`git clone --depth 1 <url>` without a branch
+#     ref-spec doesn't accept arbitrary SHAs). Saves ~100 MB vs a full clone.
+#     node:24 ships git, so we don't need a separate alpine/git stage.
+FROM node:24 AS source
+ARG RUFLO_GIT_REF
+WORKDIR /src/ruflo
+RUN git init \
+ && git remote add origin https://github.com/ruvnet/ruflo.git \
+ && git fetch --depth 1 origin "${RUFLO_GIT_REF}" \
+ && git checkout FETCH_HEAD
+
+# --- builder: mirrors upstream `builder` stage in src/ruvocal/Dockerfile.
+#     Full node:24 (not slim) for the Svelte build's native deps.
+FROM node:24 AS builder
+WORKDIR /app
+COPY --from=source --chown=1000:1000 \
+     /src/ruflo/src/ruvocal/package.json \
+     /src/ruflo/src/ruvocal/package-lock.json \
+     ./
+ENV BODY_SIZE_LIMIT=15728640
+RUN --mount=type=cache,target=/app/.npm \
+    npm set cache /app/.npm \
+ && npm ci
+COPY --from=source --chown=1000:1000 /src/ruflo/src/ruvocal/ ./
+# `git config safe.directory /app` is mirrored from upstream's Dockerfile (their
+# build context is `src/ruvocal/` so they have no `.git` either — the line is a
+# defensive no-op for any sveltekit plugin that probes for git metadata).
+RUN git config --global --add safe.directory /app \
+ && npm run build
+
+# --- runtime: mirrors upstream `base` + `final` (INCLUDE_DB=false branch).
+#     The `local_db_true` Mongo install layer is intentionally omitted; ruvocal
+#     connects to an external database via DATABASE_URL (Postgres) or the legacy
+#     MONGO_URL env var (kept by upstream for backwards compat).
+FROM node:24-slim AS runtime
+RUN npm install -g dotenv-cli \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates curl dnsutils libcurl4 libgomp1 tini \
+ && rm -rf /var/lib/apt/lists/* \
+ && userdel -r node \
+ && useradd -m -u 1000 user \
+ && mkdir -p /home/user/.npm \
+ && chown -R 1000:1000 /home/user/.npm
+
+WORKDIR /app
+COPY --from=source --chown=1000:1000 /src/ruflo/src/ruvocal/.env /app/.env
+COPY --from=source --chown=1000:1000 /src/ruflo/src/ruvocal/entrypoint.sh /app/entrypoint.sh
+COPY --from=source --chown=1000:1000 /src/ruflo/src/ruvocal/package.json /app/package.json
+
+# Match the two seds upstream applies in its `base` stage so empty placeholder
+# values don't block .env.local overrides via `dotenv-cli -c`.
+RUN sed -i 's/^MODELS=$/# MODELS=/' /app/.env \
+ && sed -i 's/^TASK_MODEL=$/# TASK_MODEL=/' /app/.env \
+ && chmod +x /app/entrypoint.sh \
+ && touch /app/.env.local \
+ && chown 1000:1000 /app/.env.local /app/.env /app/entrypoint.sh /app/package.json
+
+COPY --from=builder --chown=1000:1000 /app/build /app/build
+COPY --from=builder --chown=1000:1000 /app/node_modules /app/node_modules
+
+# Mirror upstream's `ENV PATH=/home/user/.local/bin:$PATH` shape so we keep
+# /usr/local/sbin:/usr/sbin:/sbin from the inherited node-image PATH (some
+# native node modules call sbin tools at runtime).
+ENV HOME=/home/user \
+    PATH=/home/user/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin \
+    BODY_SIZE_LIMIT=15728640 \
+    INCLUDE_DB=false
+
+USER user
+EXPOSE 3000
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["/bin/bash", "-c", "/app/entrypoint.sh"]

--- a/ruflo-server/README.md
+++ b/ruflo-server/README.md
@@ -1,0 +1,67 @@
+# ruflo-server
+
+Container image for the ruvocal web UI + swarm orchestrator from
+[`ruvnet/ruflo`](https://github.com/ruvnet/ruflo) (the rebrand of `claude-flow`).
+Deployed on Frank as the long-lived service half of the `ruflo` pod, paired
+with [`ruflo-shell`](../ruflo-shell/) as an SSH-able sidecar.
+
+## Phase 1 finding (recorded in plan Deployment Notes)
+
+Between the spec date and this build, upstream ruvocal **migrated MongoDB →
+PostgreSQL** and switched to an OpenAI-compatible inference contract. The
+upstream `.env` now tags MongoDB env vars as `# Legacy MongoDB vars (unused —
+kept for reference)`, with `DATABASE_URL` (Postgres) and `OPENAI_BASE_URL` as
+the load-bearing settings. Frank's Phase 2 manifests therefore must:
+
+- Use `DATABASE_URL` (Postgres connection string) instead of `MONGO_URL`.
+- Provision `apps/ruflo-db/` as a Postgres workload (e.g., CloudNativePG)
+  rather than a MongoDB Helm chart.
+- Set `OPENAI_BASE_URL=http://litellm.litellm-system:4000/v1` (or similar)
+  so ruvocal's inference traffic routes through LiteLLM.
+
+See the plan's *Deployment Notes* table (P1.T2 row) in
+`docs/superpowers/plans/2026-05-02--orch--ruflo-pod.md` for the full deviation.
+
+## Build
+
+`Dockerfile` thin-wraps the upstream `ruflo/src/ruvocal/Dockerfile` at a pinned
+git SHA. The `INCLUDE_DB=false` build path is used unconditionally — the Mongo
+install layer is omitted from the final image. Database state lives in a
+separate sub-app (`apps/ruflo-db/` in `derio-net/frank`).
+
+| Build arg | Default | Notes |
+|---|---|---|
+| `RUFLO_GIT_REF` | pinned SHA | Bump deliberately to re-vendor upstream. CI does **not** float this; pinning is intentional so an upstream change can't silently land in our cluster. |
+
+## Runtime expectations
+
+The image runs `dotenv -e /app/.env -c -- node ... /app/build/index.js
+--host 0.0.0.0 --port 3000`. It honours these env vars (most via
+`.env.local`-style override; see upstream `.env` for the full list):
+
+| Env | Purpose | Source on Frank |
+|---|---|---|
+| `DATABASE_URL` | PostgreSQL connection string for ruvocal's persistent store | `apps/ruflo-db/` (Phase 2+) |
+| `OPENAI_BASE_URL` | OpenAI-compatible inference endpoint | LiteLLM gateway: `http://litellm.litellm-system:4000` |
+| `OPENAI_API_KEY` | Token for the inference endpoint | ESO → Infisical |
+| `OPENROUTER_API_KEY` | Direct OpenRouter access (broader catalog) | ESO → Infisical |
+| `EMAIL_RESEND_API_KEY` | Transactional email from agent runs | ESO → Infisical (shared with paperclip) |
+
+The legacy `MONGO_URL`/`MONGODB_URL` env vars are still honoured by upstream
+for backwards compatibility but are noted as unused in the upstream `.env`.
+
+The web UI listens on **3000/TCP**. Workspace data is expected at `/app` (the
+operator-facing `/workspace` mount in the pod spec is shared with `ruflo-shell`
+for ergonomic browsing — ruvocal itself writes its agent-run artefacts under
+`/app/build` and the DB volume).
+
+## Plan / spec
+
+- Spec: `docs/superpowers/specs/2026-05-02--orch--ruflo-pod-design.md` (`derio-net/frank`)
+- Plan: `docs/superpowers/plans/2026-05-02--orch--ruflo-pod.md` (`derio-net/frank`)
+
+## CI
+
+Built by `.github/workflows/build.yaml` on every push to `main`, tagged
+`ghcr.io/derio-net/ruflo-server:<sha>` and `:latest`. Smoke test verifies the
+container boots and listens on port 3000.

--- a/ruflo-shell/Dockerfile
+++ b/ruflo-shell/Dockerfile
@@ -1,0 +1,32 @@
+ARG BASE_SHA=latest
+FROM ghcr.io/derio-net/agent-shell-base:${BASE_SHA}
+
+# Inherit AGENT_USER=agent, AGENT_HOME=/home/agent, AGENT_UID/GID=1000 from
+# agent-shell-base — do not override. Fresh PV, no legacy identity to preserve.
+
+USER root
+
+COPY --chown=root:root rootfs/ /
+
+RUN chmod +x \
+      /etc/cont-init.d/40-shell-inventory \
+      /etc/profile.d/40-ruflo-shell-paths.sh \
+      /etc/profile.d/50-ruflo-shell-motd.sh \
+      /etc/profile.d/60-ruflo-shell-banner.sh \
+      /usr/local/lib/ruflo-shell/install-base-runtimes.sh \
+      /usr/local/lib/ruflo-shell/install-inventory.sh \
+      /usr/local/lib/ruflo-shell/notify-telegram.sh \
+      /usr/local/lib/ruflo-shell/lib.sh \
+ && /usr/local/lib/ruflo-shell/install-base-runtimes.sh \
+ && ln -sf /usr/local/lib/ruflo-shell/install-inventory.sh \
+           /usr/local/bin/ruflo-shell-reconcile
+
+# `claude` is already npm-installed globally by the great-grandparent image
+# (`agent-base/Dockerfile`, line 40 — `npm install -g @anthropic-ai/claude-code`).
+# The smoke test for this image asserts `claude --version` runs as the agent
+# UID, which catches any future agent-base regression that drops it.
+
+USER ${AGENT_USER}
+WORKDIR ${AGENT_HOME}
+EXPOSE 2222
+# ENTRYPOINT inherited from agent-shell-base: /init (s6-overlay)

--- a/ruflo-shell/README.md
+++ b/ruflo-shell/README.md
@@ -1,0 +1,95 @@
+# ruflo-shell
+
+SSH-able shell sidecar for the `ruflo` pod on Frank. Built `FROM
+agent-shell-base`, adds Layer-1 runtime managers (`mise`, `rustup`, `pipx`)
+and a declarative software inventory installer that runs at every container
+boot.
+
+The shell pairs with the [`ruflo-server`](../ruflo-server/) container in the
+same pod, sharing the `ruflo-workspace` PVC at `/workspace` while keeping its
+own home PVC at `/home/agent` for tools, dotfiles, and tmux-resurrect state.
+The upstream ruvocal build is **not modified** — `ruflo-server` evolves on the
+upstream's cadence; `ruflo-shell` evolves on this repo's cadence.
+
+`@anthropic-ai/claude-code` is baked into the image so the operator can
+immediately invoke `claude` against the in-cluster LiteLLM gateway from a
+fresh SSH session, before the Layer-2 inventory has run. `claude-flow` is
+**not** baked in — it lives in the inventory, where it can be bumped without
+rebuilding the image.
+
+## Layered install model
+
+| Layer | Source | Where it lands | When |
+|---|---|---|---|
+| 1 — Image baseline | this Dockerfile | image rootfs (immutable) | image build |
+| 2 — Inventory | mounted ConfigMap `inventory.yaml` | per-user PV under `$HOME` | every container boot via `cont-init.d/40-shell-inventory` |
+| 3 — Interactive | operator typing `mise install …`, `cargo install …` | per-user PV under `$HOME` | on demand inside the SSH session |
+
+Layer 2 is the load-bearing one for evolving the toolset. The installer is
+idempotent and **fail-open** — a single broken install logs the failure,
+fires a Telegram alert via `notify-telegram.sh`, and lets sshd come up
+anyway. The MOTD prints the last reconcile summary on every login.
+
+## Inventory file
+
+Mounted from `apps/ruflo/manifests/configmap-shell-inventory.yaml` (in
+`derio-net/frank`) at `/etc/ruflo-shell/inventory.yaml`:
+
+```yaml
+mise:
+  - python@3.12
+  - node@20
+  - rust@stable
+npm-global:
+  - claude-flow@alpha
+pipx:
+  - black
+  - ruff
+cargo:
+  - ripgrep
+  - eza
+removed:
+  mise: []
+  npm-global: []
+  pipx: []
+  cargo: []
+```
+
+Top-level keys are managers; entries under `removed.<manager>` are actively
+uninstalled. `npm-global` and `cargo` sections are skipped silently if the
+underlying runtime (node, rust toolchain) is not yet present — install via
+`mise` first.
+
+## Operator commands
+
+```bash
+# Re-run the inventory installer without restarting the pod
+ruflo-shell-reconcile
+
+# Read the last reconcile log
+cat /var/log/cont-init.d/40-shell-inventory.log
+
+# Read the MOTD that prints on every login
+cat /var/lib/ruflo-shell/last-reconcile.motd
+```
+
+## Build args
+
+| Arg | Default | Notes |
+|---|---|---|
+| `BASE_SHA` | `latest` | The `agent-shell-base` tag/SHA to inherit from. CI passes the SHA of the same workflow run. |
+
+`AGENT_USER`, `AGENT_HOME`, `AGENT_UID`, `AGENT_GID` are inherited from
+`agent-shell-base` (defaults: `agent`, `/home/agent`, `1000`, `1000`).
+
+## Telegram alerting
+
+Failures fire to `@agent_zero_cc_bot` via `FRANK_C2_TELEGRAM_BOT_TOKEN` +
+`FRANK_C2_TELEGRAM_CHAT_ID` env vars (mounted from the same Infisical-backed
+Secret used by Grafana and ArgoCD). If either env is empty the notifier
+exits silently — the alerting path is fail-open.
+
+## Plan / spec
+
+- Spec: `docs/superpowers/specs/2026-05-02--orch--ruflo-pod-design.md` (`derio-net/frank`)
+- Plan: `docs/superpowers/plans/2026-05-02--orch--ruflo-pod.md` (`derio-net/frank`)

--- a/ruflo-shell/rootfs/etc/cont-init.d/40-shell-inventory
+++ b/ruflo-shell/rootfs/etc/cont-init.d/40-shell-inventory
@@ -1,0 +1,4 @@
+#!/command/with-contenv bash
+# 40-shell-inventory — Reconcile the declarative software inventory on every
+# container boot. Idempotent and fail-open — never blocks sshd startup.
+exec /usr/local/lib/ruflo-shell/install-inventory.sh

--- a/ruflo-shell/rootfs/etc/profile.d/40-ruflo-shell-paths.sh
+++ b/ruflo-shell/rootfs/etc/profile.d/40-ruflo-shell-paths.sh
@@ -1,0 +1,24 @@
+# 40-ruflo-shell-paths.sh — Wire mise shims and cargo's bin dir into the
+# operator's interactive PATH. Both directories live under $HOME on the PVC,
+# so they survive image bumps but only exist after the inventory installer (or
+# the operator) has installed something via the corresponding manager.
+#
+# Activated for every login shell (and re-sourced by ~/.bashrc).
+
+case ":$PATH:" in
+    *":$HOME/.local/share/mise/shims:"*) ;;
+    *) PATH="$HOME/.local/share/mise/shims:$PATH" ;;
+esac
+
+case ":$PATH:" in
+    *":$HOME/.cargo/bin:"*) ;;
+    *) PATH="$HOME/.cargo/bin:$PATH" ;;
+esac
+
+# pipx puts user-installed entry points here.
+case ":$PATH:" in
+    *":$HOME/.local/bin:"*) ;;
+    *) PATH="$HOME/.local/bin:$PATH" ;;
+esac
+
+export PATH

--- a/ruflo-shell/rootfs/etc/profile.d/50-ruflo-shell-motd.sh
+++ b/ruflo-shell/rootfs/etc/profile.d/50-ruflo-shell-motd.sh
@@ -1,0 +1,15 @@
+# 50-ruflo-shell-motd.sh — Print the last reconcile summary on interactive
+# shell login. The s6-overlay sshd is built with UsePAM=no (see agent-shell-base
+# sshd_config), so pam_motd does not fire; profile.d is the simplest mechanism
+# that still works for both ssh and `kubectl exec -it ... bash -l`.
+#
+# Sourced by /etc/profile (interactive login shells) and by ~/.bashrc via the
+# default Debian skeleton. Quiet for non-interactive shells.
+
+[ -n "$PS1" ] || return 0
+
+_ruflo_shell_motd_file=/var/lib/ruflo-shell/last-reconcile.motd
+if [ -r "$_ruflo_shell_motd_file" ]; then
+    cat "$_ruflo_shell_motd_file"
+fi
+unset _ruflo_shell_motd_file

--- a/ruflo-shell/rootfs/etc/profile.d/60-ruflo-shell-banner.sh
+++ b/ruflo-shell/rootfs/etc/profile.d/60-ruflo-shell-banner.sh
@@ -1,0 +1,25 @@
+# 60-ruflo-shell-banner.sh — Set ruflo-specific env defaults and print an
+# operator-facing banner on SSH login. Sourced after the paths and motd
+# drop-ins so PATH and last-reconcile MOTD render first.
+#
+# LITELLM_BASE_URL is normally set by the pod's Deployment env (see
+# apps/ruflo/manifests/deployment.yaml). The default below keeps the env var
+# present in `kubectl exec` sessions where the Deployment env may not have
+# been propagated, and documents the expected gateway location.
+
+: "${LITELLM_BASE_URL:=http://litellm.litellm-system:4000}"
+export LITELLM_BASE_URL
+
+[ -n "$PS1" ] || return 0
+
+if [ -n "${SSH_CONNECTION:-}" ] && [ -z "${RUFLO_BANNER_SHOWN:-}" ]; then
+    cat <<'BANNER'
+─────────────────────────────────────────
+ ruflo-shell — operator side door for ruflo
+   /workspace             ← shared with ruvocal (read/write)
+   /home/agent            ← yours; persists across pod restarts
+   ruflo-shell-reconcile  ← apply inventory changes without restart
+─────────────────────────────────────────
+BANNER
+    export RUFLO_BANNER_SHOWN=1
+fi

--- a/ruflo-shell/rootfs/usr/local/lib/ruflo-shell/install-base-runtimes.sh
+++ b/ruflo-shell/rootfs/usr/local/lib/ruflo-shell/install-base-runtimes.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# install-base-runtimes.sh — Image-time install of the Layer-1 runtime managers.
+# These are slow-changing, baked into the image. Per-user state lives on the PVC.
+set -euo pipefail
+
+# Build dependencies the managers themselves need at install time.
+apt-get update
+apt-get install -y --no-install-recommends \
+    ca-certificates curl build-essential pkg-config libssl-dev \
+    python3 python3-pip python3-yaml pipx jq
+rm -rf /var/lib/apt/lists/*
+
+# mise — asdf-style multi-runtime version manager. System-wide binary;
+# per-user toolchains and shims under $HOME/.local/share/mise on the PV.
+curl -fsSL https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
+chmod +x /usr/local/bin/mise
+
+# rustup — system-wide binary; toolchains live under $HOME/.rustup on the PV.
+# --default-toolchain none keeps the image slim; the inventory installer pulls
+# toolchains via mise (rust@stable) or `rustup toolchain install` on demand.
+export RUSTUP_HOME=/usr/local/lib/rustup CARGO_HOME=/tmp/cargo-bootstrap
+mkdir -p "$RUSTUP_HOME" "$CARGO_HOME"
+curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
+  | sh -s -- -y --default-toolchain none --no-modify-path
+mv "$CARGO_HOME"/bin/rustup /usr/local/bin/rustup
+chmod +x /usr/local/bin/rustup
+rm -rf "$CARGO_HOME"
+
+# pipx came from apt above. Confirm.
+command -v pipx >/dev/null
+command -v mise >/dev/null
+command -v rustup >/dev/null
+command -v python3 >/dev/null

--- a/ruflo-shell/rootfs/usr/local/lib/ruflo-shell/install-inventory.sh
+++ b/ruflo-shell/rootfs/usr/local/lib/ruflo-shell/install-inventory.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# install-inventory.sh — Layer-2 inventory installer.
+#   * Idempotent: re-running with no changes is a quick no-op.
+#   * Fail-open: a single broken install logs and continues; never blocks sshd.
+#   * Source of truth: /etc/ruflo-shell/inventory.yaml (mounted ConfigMap).
+#   * On any failure, fires a Telegram alert via notify-telegram.sh.
+#
+# NOT `set -e` — failures are accumulated, not propagated.
+set -uo pipefail
+
+# shellcheck source=/dev/null
+. /usr/local/lib/ruflo-shell/lib.sh
+ruflo_shell_init_dirs
+
+INVENTORY="${INVENTORY:-/etc/ruflo-shell/inventory.yaml}"
+LOG="${RUFLO_SHELL_LOG_DIR}/40-shell-inventory.log"
+NOTIFY=/usr/local/lib/ruflo-shell/notify-telegram.sh
+
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== ruflo-shell-reconcile @ $(date -Iseconds) ==="
+
+# Make mise shims and the rustup-managed cargo bin visible for the npm-global
+# and cargo sections below. Prepended unconditionally; missing dirs are a
+# no-op until the relevant runtime is installed.
+export PATH="${HOME}/.local/share/mise/shims:${HOME}/.cargo/bin:${PATH}"
+
+if [[ ! -f "$INVENTORY" ]]; then
+    echo "WARN: $INVENTORY missing; nothing to do"
+    ruflo_shell_motd_write "⚠ ruflo-shell: inventory file missing"
+    exit 0
+fi
+
+declare -i installed=0 already=0 removed=0 failed=0
+declare -a failures=()
+
+run() {
+    local label="$1"
+    shift
+    if "$@"; then
+        echo "✓ $label"
+        return 0
+    else
+        local rc=$?
+        echo "✗ $label (rc=$rc)"
+        failures+=("$label")
+        failed+=1
+        return 1
+    fi
+}
+
+# Read a top-level list from inventory.yaml. Returns one item per line.
+yaml_list() {
+    python3 -c "
+import sys, yaml
+d = yaml.safe_load(open('$INVENTORY')) or {}
+for x in (d.get('$1') or []):
+    print(x)
+"
+}
+
+# Read a list under 'removed.<key>'. Returns one item per line.
+yaml_removed_list() {
+    python3 -c "
+import sys, yaml
+d = yaml.safe_load(open('$INVENTORY')) or {}
+for x in ((d.get('removed') or {}).get('$1') or []):
+    print(x)
+"
+}
+
+assert_manager() {
+    local cmd="$1"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "✗ manager '$cmd' missing from image; cannot reconcile its section"
+        failures+=("manager-missing:$cmd")
+        failed+=1
+        return 1
+    fi
+}
+
+# --- mise ---
+if assert_manager mise; then
+    while IFS= read -r tool; do
+        [[ -z "$tool" ]] && continue
+        if mise where "$tool" >/dev/null 2>&1; then
+            already+=1
+            echo "= mise $tool"
+            continue
+        fi
+        run "mise install $tool" mise install "$tool" && installed+=1
+    done < <(yaml_list mise)
+
+    while IFS= read -r tool; do
+        [[ -z "$tool" ]] && continue
+        run "mise uninstall $tool" mise uninstall "$tool" && removed+=1
+    done < <(yaml_removed_list mise)
+fi
+
+# --- npm-global --- (npm comes from a runtime managed by mise; skip section if missing)
+if command -v npm >/dev/null 2>&1; then
+    while IFS= read -r pkg; do
+        [[ -z "$pkg" ]] && continue
+        if npm ls -g "$pkg" --depth=0 >/dev/null 2>&1; then
+            already+=1
+            echo "= npm $pkg"
+            continue
+        fi
+        run "npm i -g $pkg" npm install -g "$pkg" && installed+=1
+    done < <(yaml_list npm-global)
+
+    while IFS= read -r pkg; do
+        [[ -z "$pkg" ]] && continue
+        run "npm rm -g $pkg" npm uninstall -g "$pkg" && removed+=1
+    done < <(yaml_removed_list npm-global)
+else
+    if [[ -n "$(yaml_list npm-global)" || -n "$(yaml_removed_list npm-global)" ]]; then
+        echo "= npm-global section declared but no npm on PATH (install node via mise first); skipping"
+    fi
+fi
+
+# --- pipx ---
+if assert_manager pipx; then
+    while IFS= read -r pkg; do
+        [[ -z "$pkg" ]] && continue
+        if pipx list --short 2>/dev/null | awk '{print $1}' | grep -qx "$pkg"; then
+            already+=1
+            echo "= pipx $pkg"
+            continue
+        fi
+        run "pipx install $pkg" pipx install "$pkg" && installed+=1
+    done < <(yaml_list pipx)
+
+    while IFS= read -r pkg; do
+        [[ -z "$pkg" ]] && continue
+        run "pipx uninstall $pkg" pipx uninstall "$pkg" && removed+=1
+    done < <(yaml_removed_list pipx)
+fi
+
+# --- cargo --- (cargo comes from rustup-installed toolchain on PV; skip if missing)
+if command -v cargo >/dev/null 2>&1; then
+    while IFS= read -r crate; do
+        [[ -z "$crate" ]] && continue
+        if cargo install --list 2>/dev/null | awk '/^[a-zA-Z0-9_-]+ /{print $1}' | grep -qx "$crate"; then
+            already+=1
+            echo "= cargo $crate"
+            continue
+        fi
+        run "cargo install $crate" cargo install "$crate" && installed+=1
+    done < <(yaml_list cargo)
+
+    while IFS= read -r crate; do
+        [[ -z "$crate" ]] && continue
+        run "cargo uninstall $crate" cargo uninstall "$crate" && removed+=1
+    done < <(yaml_removed_list cargo)
+else
+    if [[ -n "$(yaml_list cargo)" || -n "$(yaml_removed_list cargo)" ]]; then
+        echo "= cargo section declared but no cargo on PATH (run \`rustup toolchain install stable\` or \`mise install rust@stable\` first); skipping"
+    fi
+fi
+
+echo "=== summary: installed=$installed already=$already removed=$removed failed=$failed ==="
+
+if (( failed > 0 )); then
+    ruflo_shell_motd_write "$(printf '⚠ ruflo-shell: %d install(s) failed on last reconcile (%s)\n  See: %s' \
+        "$failed" "$(IFS=,; echo "${failures[*]}")" "$LOG")"
+    "$NOTIFY" \
+        "ruflo-shell: $failed install(s) failed on boot" \
+        "$(printf '%s\n' "${failures[@]}")" || true
+else
+    ruflo_shell_motd_write "$(printf '✓ ruflo-shell: %d installed, %d already present, %d removed @ %s' \
+        "$installed" "$already" "$removed" "$(date -Iseconds)")"
+fi
+
+exit 0  # always succeed — fail-open

--- a/ruflo-shell/rootfs/usr/local/lib/ruflo-shell/lib.sh
+++ b/ruflo-shell/rootfs/usr/local/lib/ruflo-shell/lib.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# lib.sh — shared helpers for ruflo-shell installer scripts.
+# Source from other scripts:
+#     # shellcheck source=/dev/null
+#     . /usr/local/lib/ruflo-shell/lib.sh
+
+RUFLO_SHELL_LOG_DIR="${RUFLO_SHELL_LOG_DIR:-/var/log/cont-init.d}"
+RUFLO_SHELL_STATE_DIR="${RUFLO_SHELL_STATE_DIR:-/var/lib/ruflo-shell}"
+RUFLO_SHELL_MOTD_FILE="${RUFLO_SHELL_STATE_DIR}/last-reconcile.motd"
+
+ruflo_shell_init_dirs() {
+    mkdir -p "$RUFLO_SHELL_LOG_DIR" "$RUFLO_SHELL_STATE_DIR"
+}
+
+ruflo_shell_motd_write() {
+    ruflo_shell_init_dirs
+    printf '%s\n' "$*" > "$RUFLO_SHELL_MOTD_FILE"
+}

--- a/ruflo-shell/rootfs/usr/local/lib/ruflo-shell/notify-telegram.sh
+++ b/ruflo-shell/rootfs/usr/local/lib/ruflo-shell/notify-telegram.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# notify-telegram.sh — Send a Telegram alert. Fail-silent if env is missing.
+# Usage: notify-telegram.sh "title" "detail body"
+#
+# Reads FRANK_C2_TELEGRAM_BOT_TOKEN + FRANK_C2_TELEGRAM_CHAT_ID from env
+# (mounted from the same Infisical-backed Secret used by Grafana/ArgoCD).
+set -uo pipefail
+
+TITLE="${1:-ruflo-shell alert}"
+DETAIL="${2:-}"
+
+: "${FRANK_C2_TELEGRAM_BOT_TOKEN:=}"
+: "${FRANK_C2_TELEGRAM_CHAT_ID:=}"
+if [[ -z "$FRANK_C2_TELEGRAM_BOT_TOKEN" || -z "$FRANK_C2_TELEGRAM_CHAT_ID" ]]; then
+    # Fail-silent: missing creds is not an installer-blocking condition.
+    exit 0
+fi
+
+POD="${HOSTNAME:-ruflo-shell}"
+TEXT=$(cat <<EOF
+${TITLE}
+
+${DETAIL}
+
+Pod: ${POD}
+Logs: kubectl logs ${POD} -c ruflo-shell
+EOF
+)
+
+curl -fsS --max-time 10 \
+    -X POST "https://api.telegram.org/bot${FRANK_C2_TELEGRAM_BOT_TOKEN}/sendMessage" \
+    --data-urlencode "chat_id=${FRANK_C2_TELEGRAM_CHAT_ID}" \
+    --data-urlencode "text=${TEXT}" >/dev/null || true


### PR DESCRIPTION
## Summary

PR #48 (\"orch--ruflo-pod · Phase 1/6 · Build ruflo-server and ruflo-shell images\") was opened with `baseRefName: feat/paperclip-shell` instead of `main`. When it was squash-merged at 21:59:33 on 2026-05-02, the resulting commit `7960ed1` landed on `feat/paperclip-shell` rather than `main`. The "Build agent images" workflow only triggers on push-to-main, so:

- Main never received `ruflo-server/` or `ruflo-shell/` directories.
- CI never built `ghcr.io/derio-net/ruflo-server:7960ed1...` or `ghcr.io/derio-net/ruflo-shell:7960ed1...`.
- The `ruflo` pod in Frank cluster has been in `ImagePullBackOff` since the Phase 2 manifests merged (frank PR #191).

This PR re-lands the original commit (`git cherry-pick 7960ed1`) onto `main` so the build workflow can pick it up. The diff is byte-identical to PR #48 — same 13 files, same 749 insertions.

## Diagnosis trace

```
21:47:57  push to refs/heads/main:                e5237286 → 3e3e5a2  (PR #49)
21:59:34  push to refs/heads/feat/paperclip-shell: 64e5a42  → 7960ed1  (PR #48 squash, wrong base)
21:59:36  delete refs/heads/feat/ruflo-server-and-shell
```

```
$ gh api /orgs/derio-net/packages/container/ruflo-server
{"message":"Package not found.","status":"404"}
```

## Test plan

- [ ] CI builds `ruflo-server` and `ruflo-shell` images successfully (including their smoke tests).
- [ ] CI dispatches the `agent-images-bumped` event into `derio-net/frank`.
- [ ] After merge, `gh api /orgs/derio-net/packages/container/ruflo-server` returns `{visibility:public}`.
- [ ] Follow-up PR in `derio-net/frank` will bump `apps/ruflo/manifests/deployment.yaml` to the new SHA.

Tracked in derio-net/frank#184 (Phase 3 validation, blocked on this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)