### PR TITLE
fix(ruflo-server): correct upstream COPY paths (src/ruvocal → ruflo/src/ruvocal)

### DIFF
--- a/ruflo-server/Dockerfile
+++ b/ruflo-server/Dockerfile
@@ -15,20 +15,25 @@ RUN git init \
  && git remote add origin https://github.com/ruvnet/ruflo.git \
  && git fetch --depth 1 origin "${RUFLO_GIT_REF}" \
  && git checkout FETCH_HEAD
+# Upstream's tree has the actual sveltekit app at `ruflo/src/ruvocal/`
+# (note the extra leading `ruflo/` — the repo's top-level dir mirrors the
+# org name). The plan's Deployment Notes flagged this as a path correction;
+# this Dockerfile honours it: every COPY below uses
+# /src/ruflo/ruflo/src/ruvocal/... not /src/ruflo/src/ruvocal/...
 
 # --- builder: mirrors upstream `builder` stage in src/ruvocal/Dockerfile.
 #     Full node:24 (not slim) for the Svelte build's native deps.
 FROM node:24 AS builder
 WORKDIR /app
 COPY --from=source --chown=1000:1000 \
-     /src/ruflo/src/ruvocal/package.json \
-     /src/ruflo/src/ruvocal/package-lock.json \
+     /src/ruflo/ruflo/src/ruvocal/package.json \
+     /src/ruflo/ruflo/src/ruvocal/package-lock.json \
      ./
 ENV BODY_SIZE_LIMIT=15728640
 RUN --mount=type=cache,target=/app/.npm \
     npm set cache /app/.npm \
  && npm ci
-COPY --from=source --chown=1000:1000 /src/ruflo/src/ruvocal/ ./
+COPY --from=source --chown=1000:1000 /src/ruflo/ruflo/src/ruvocal/ ./
 # `git config safe.directory /app` is mirrored from upstream's Dockerfile (their
 # build context is `src/ruvocal/` so they have no `.git` either — the line is a
 # defensive no-op for any sveltekit plugin that probes for git metadata).
@@ -51,9 +56,9 @@ RUN npm install -g dotenv-cli \
  && chown -R 1000:1000 /home/user/.npm
 
 WORKDIR /app
-COPY --from=source --chown=1000:1000 /src/ruflo/src/ruvocal/.env /app/.env
-COPY --from=source --chown=1000:1000 /src/ruflo/src/ruvocal/entrypoint.sh /app/entrypoint.sh
-COPY --from=source --chown=1000:1000 /src/ruflo/src/ruvocal/package.json /app/package.json
+COPY --from=source --chown=1000:1000 /src/ruflo/ruflo/src/ruvocal/.env /app/.env
+COPY --from=source --chown=1000:1000 /src/ruflo/ruflo/src/ruvocal/entrypoint.sh /app/entrypoint.sh
+COPY --from=source --chown=1000:1000 /src/ruflo/ruflo/src/ruvocal/package.json /app/package.json
 
 # Match the two seds upstream applies in its `base` stage so empty placeholder
 # values don't block .env.local overrides via `dotenv-cli -c`.


### PR DESCRIPTION
## Summary

Follow-up to PR #50. CI run [25272202183](https://github.com/derio-net/agent-images/actions/runs/25272202183) failed with:

\`\`\`
failed to compute cache key: failed to calculate checksum of ref
...: \"/src/ruflo/src/ruvocal/package.json\": not found
\`\`\`

Upstream's tree has the sveltekit app at \`ruflo/src/ruvocal/\` (with an extra leading \`ruflo/\` directory mirroring the org name) — not \`src/ruvocal/\`. The plan's Deployment Notes flagged this as a path-correction finding at Phase 1 time, but the Dockerfile's COPY paths still used the wrong form. This PR fixes the six COPY references and adds a comment block so the next re-vendor doesn't re-discover the same quirk.

## Test plan

- [ ] CI builds \`ruflo-server\` successfully.
- [ ] CI then runs \`ruflo-shell\` build (which depends on the same job).
- [ ] Frank gets the agent-images-bumped repository_dispatch event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)