### PR TITLE
fix(ruflo-server): patch upstream IIFE that fails Svelte 5 parsing

### DIFF
--- a/ruflo-server/Dockerfile
+++ b/ruflo-server/Dockerfile
@@ -20,6 +20,19 @@ RUN git init \
 # org name). The plan's Deployment Notes flagged this as a path correction;
 # this Dockerfile honours it: every COPY below uses
 # /src/ruflo/ruflo/src/ruvocal/... not /src/ruflo/src/ruvocal/...
+#
+# Patch upstream's ChatWindow.svelte: the pinned SHA introduces a
+# `let x = $derived<T>(() => { ... }())` IIFE that vite-plugin-svelte's
+# parser rejects with `js_parse_error` (the `<T>(()=>{...}())` shape
+# confuses generic-vs-comparison disambiguation). Convert to the
+# semantically-equivalent `$derived.by<T>(() => { ... })` form. Tracked
+# upstream as ruvnet/ruflo (no issue filed — apply locally for now).
+RUN sed -i \
+      -e 's/let lastAssistantToolNames = \$derived<string\[\]>(() => {/let lastAssistantToolNames = \$derived.by<string[]>(() => {/' \
+      -e '0,/^\t}());$/{s/^\t}());$/\t});/}' \
+      ruflo/src/ruvocal/src/lib/components/chat/ChatWindow.svelte \
+ && grep -q '\$derived.by<string\[\]>' ruflo/src/ruvocal/src/lib/components/chat/ChatWindow.svelte \
+ && ! grep -q '^\t}());$' ruflo/src/ruvocal/src/lib/components/chat/ChatWindow.svelte
 
 # --- builder: mirrors upstream `builder` stage in src/ruvocal/Dockerfile.
 #     Full node:24 (not slim) for the Svelte build's native deps.


### PR DESCRIPTION
## Summary

Follow-up to #51. The upstream pinned SHA (`9b16981`) introduces this pattern in \`ChatWindow.svelte:434\`:

\`\`\`ts
let lastAssistantToolNames = \$derived<string[]>(() => {
    ...
}());
\`\`\`

vite-plugin-svelte 5.0.3 rejects it with \`js_parse_error\` at column 46 — the \`<T>(() => {...}())\` shape is too ambiguous for the parser's generic-vs-comparison disambiguator. (Other \`\$derived<T>(...)\` calls in the same file parse fine; only the IIFE form fails.)

CI run [25272273908](https://github.com/derio-net/agent-images/actions/runs/25272273908):

\`\`\`
[vite-plugin-svelte] src/lib/components/chat/ChatWindow.svelte:434:46 Unexpected token
https://svelte.dev/e/js_parse_error
\`\`\`

This PR adds a \`sed\` step in the source stage that converts the IIFE to the semantically-equivalent \`\$derived.by<T>(...)\` form. The patch is **two lines** of substitution, verified by post-checks (\`grep -q\` / \`! grep -q\`) that fail loud if either line moves in a future re-vendor.

## Test plan

- [ ] Locally verified sed produces the expected diff (md5sum changes, line 434 + 448 update correctly).
- [ ] CI builds \`ruflo-server\` successfully on this branch.
- [ ] CI dispatches the agent-images-bumped event into derio-net/frank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)