### PR TITLE
fix(ruflo-server,ruflo-shell): pre-create writable runtime dirs for UID 1000

### DIFF
--- a/ruflo-server/Dockerfile
+++ b/ruflo-server/Dockerfile
@@ -65,9 +65,14 @@ RUN npm install -g dotenv-cli \
  && rm -rf /var/lib/apt/lists/* \
  && userdel -r node \
  && useradd -m -u 1000 user \
- && mkdir -p /home/user/.npm \
- && chown -R 1000:1000 /home/user/.npm
+ && mkdir -p /home/user/.npm /app /app/db \
+ && chown -R 1000:1000 /home/user/.npm /app
 
+# /app needs to be writable to UID 1000: ruvocal's startup code path runs
+# `Database.init` which unconditionally `mkdir`s `/app/db` (regardless of
+# INCLUDE_DB), so the directory itself must be owned by user. Upstream's
+# Dockerfile gets this for free because their WORKDIR runs after `USER user`;
+# our multi-stage build creates /app while still root, so we chown above.
 WORKDIR /app
 COPY --from=source --chown=1000:1000 /src/ruflo/ruflo/src/ruvocal/.env /app/.env
 COPY --from=source --chown=1000:1000 /src/ruflo/ruflo/src/ruvocal/entrypoint.sh /app/entrypoint.sh

--- a/ruflo-shell/Dockerfile
+++ b/ruflo-shell/Dockerfile
@@ -8,7 +8,17 @@ USER root
 
 COPY --chown=root:root rootfs/ /
 
-RUN chmod +x \
+# Pre-create the dirs the inventory installer writes to. Under K8s
+# (runAsUser: 1000, cap-drop=ALL, allowPrivilegeEscalation: false) the agent
+# UID cannot create root-owned directories at runtime, and agent-shell-base
+# only chowns /run + /var/run. Without these, install-inventory.sh's tee +
+# motd write fail with EACCES inside cont-init.d. Mirrors paperclip-shell's
+# Dockerfile — kept in sync between the two shell images by convention.
+ARG AGENT_GID=1000
+RUN install -d -o ${AGENT_UID} -g ${AGENT_GID} -m 0755 \
+      /var/log/cont-init.d \
+      /var/lib/ruflo-shell \
+ && chmod +x \
       /etc/cont-init.d/40-shell-inventory \
       /etc/profile.d/40-ruflo-shell-paths.sh \
       /etc/profile.d/50-ruflo-shell-motd.sh \


### PR DESCRIPTION
## Summary

Tail of the four-PR chain to recover Phase 1 of derio-net/frank#184. CI run [25272469234](https://github.com/derio-net/agent-images/actions/runs/25272469234) finally got past the build phase but hit two smoke-test permission failures that would have replayed in production:

- **ruflo-server** — `Error: EACCES: permission denied, mkdir '/app/db'` (ruvocal's `Database.init` always tries to mkdir there, regardless of INCLUDE_DB; /app was root-owned).
- **ruflo-shell** — `mkdir: cannot create directory '/var/log/cont-init.d': Permission denied` and `/var/lib/ruflo-shell` ditto. paperclip-shell's Dockerfile pre-creates both with `install -d -o ${AGENT_UID}` — that line was lost when ruflo-shell was forked from paperclip-shell.

Both failures would have crash-looped the production pod (which also runs as UID 1000 with cap-drop=ALL).

## Diffs

- **ruflo-server**: chown /app to 1000:1000 in the runtime stage's apt RUN (pre-creates /app/db too, so the first request doesn't have to mkdir).
- **ruflo-shell**: re-introduce paperclip-shell's `install -d` block verbatim, with the same gotcha-comment paperclip-shell carries.

## Test plan

- [ ] CI builds both images.
- [ ] Both smoke tests pass.
- [ ] dispatch-frank fires (this is the gate; nothing reaches Frank until smoke goes green).
- [ ] Follow-up: bump apps/ruflo/manifests/deployment.yaml in derio-net/frank to the new SHA → ruflo pod reaches Healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)