### PR TITLE
fix(agent-shell-base): touch ~/.crontab on first boot to keep supercronic alive

### DIFF
--- a/agent-shell-base/etc/services.d/supercronic/run
+++ b/agent-shell-base/etc/services.d/supercronic/run
@@ -1,2 +1,11 @@
 #!/command/with-contenv bash
-exec supercronic "${AGENT_HOME}/.crontab"
+# Touch a fresh .crontab on first boot so supercronic doesn't crashloop on
+# a freshly-mounted home PVC. supercronic exits 1 if its crontab arg
+# doesn't exist; on a brand-new shell-home volume nothing has populated
+# ${AGENT_HOME} yet, so we'd hit "open ${AGENT_HOME}/.crontab: no such
+# file or directory" → exit 1 → s6 restart loop → 5-deaths-in-60s bail
+# (the gotcha at frank-gotchas.md:s6-crashloop-bail). Idempotent — once
+# the operator writes real entries to ~/.crontab the touch is a no-op.
+crontab="${AGENT_HOME}/.crontab"
+[ -f "$crontab" ] || touch "$crontab"
+exec supercronic "$crontab"


### PR DESCRIPTION
## Summary

When a child image (ruflo-shell, paperclip-shell once it deploys, secure-agent-kali on a fresh PV) starts with an empty \`\${AGENT_HOME}\` PVC, supercronic crashloops:

\`\`\`
fatal msg=\"open /home/agent/.crontab: no such file or directory\"
[s6] supercronic exited code=1 (signal=0)
\`\`\`

s6 restarts it, it dies again, and after 5 deaths in 60s the s6 crashloop bail kicks in (the gotcha noted in \`frank-gotchas.md\`). The \`40-skel\` cont-init step seeds dotfiles from \`/etc/skel\`, but \`.crontab\` isn't shipped there (intentionally — operator-supplied content).

Cheapest fix: have supercronic's \`run\` script \`touch\` an empty crontab on first invocation if the file doesn't exist. supercronic happily runs an empty crontab (zero entries, just waits). When the operator later puts real entries in \`~/.crontab\`, supercronic auto-reloads on file change (the existing gotcha at \`frank-gotchas.md\`, no service restart needed).

Idempotent: subsequent boots see the file already present, the touch is a no-op.

## Surfaced during

Ruflo Phase 3 first-deploy validation (derio-net/frank#184). paperclip-shell will hit the same issue once its sidecar deploys.

## Test plan

- [ ] CI rebuilds \`agent-shell-base\` and the four downstream child images.
- [ ] After Frank rolls the resulting agent-images SHA, \`kubectl exec deploy/ruflo -c ruflo-shell -- /command/s6-svstat /run/service/supercronic\` shows \`up\` instead of \`down (exitcode 1)\`.
- [ ] Operator can later write real entries to \`~/.crontab\` and supercronic picks them up without restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)