### PR TITLE
fix(kali,base): port load-env + bashrc + gitconfig off /proc/1/environ onto s6 envdir

### DIFF
--- a/base/opt/agent-init.d/02-credential-migrate
+++ b/base/opt/agent-init.d/02-credential-migrate
@@ -1,14 +1,26 @@
 #!/bin/bash
-# 02-credential-migrate — Migrate legacy gitconfig credential helper to /proc/1/environ.
+# 02-credential-migrate — Migrate stale gitconfig credential helpers on the PVC
+# to the current /opt/gitconfig.
 #
-# The env-var-based helper only worked when the caller had sourced ~/.bashrc
-# (e.g. interactive ssh shells). It silently failed for VS Code's git
-# subprocess and cron jobs. The /proc/1/environ helper works regardless.
+# Two prior helper shapes have shipped:
+#   1. Legacy env-var reader: contained `password=$GITHUB_TOKEN`. Worked only
+#      when ~/.bashrc was sourced (interactive ssh), silently failed for
+#      VS Code git subprocesses and cron.
+#   2. /proc/1/environ reader: contained `/proc/1/environ`. Worked under tini,
+#      but stops being reliable under s6-overlay (PID 1 = s6-svscan does not
+#      forward K8s envFrom vars on every build).
+#
+# Current helper reads /run/s6/basedir/env/GITHUB_TOKEN (the s6 envdir, the
+# canonical s6 source). This script detects either prior shape on the PVC's
+# ~/.gitconfig and replaces it with the image's /opt/gitconfig.
 set -e
 HOME="${AGENT_HOME:-$HOME}"
 [ -f /opt/gitconfig ] || exit 0
 [ -f "$HOME/.gitconfig" ] || exit 0
 if grep -qF 'password=$GITHUB_TOKEN' "$HOME/.gitconfig"; then
-    echo "[agent-init] migrating git credential helper to /proc/1/environ reader"
+    echo "[agent-init] migrating git credential helper: legacy env-var → s6 envdir reader"
+    cp /opt/gitconfig "$HOME/.gitconfig"
+elif grep -qF '/proc/1/environ' "$HOME/.gitconfig"; then
+    echo "[agent-init] migrating git credential helper: /proc/1/environ → s6 envdir reader"
     cp /opt/gitconfig "$HOME/.gitconfig"
 fi

--- a/docs/superpowers/plans/2026-04-27--agents--restart-resilience.md
+++ b/docs/superpowers/plans/2026-04-27--agents--restart-resilience.md
@@ -3,6 +3,16 @@
 **Spec:** `derio-net/frank:docs/superpowers/specs/2026-04-27--agents--restart-resilience-design.md`
 **Status:** Complete
 
+> **Post-merge correction (2026-05-03):** the env-source mechanism described
+> in this plan as `/proc/1/environ` (lines ~52, 56, 62, 499) is no longer
+> accurate. Under s6-overlay, PID 1 is `s6-svscan`, which does not reliably
+> propagate K8s `envFrom` variables. The s6-overlay envdir at
+> `/run/s6/basedir/env/` is the canonical source and is now used by
+> `kali/config-templates/load-env.sh`. The legacy bashrc/gitconfig helpers
+> still reference `/proc/1/environ`; they currently happen to work on the
+> live pod but are tracked for follow-up cleanup. See the load-env-s6 PR
+> for details.
+
 **Type:** Foundation extension of the agent-images repo. Companion to the spec in `derio-net/frank` (linked above) and the [frank-side plan](https://github.com/derio-net/frank/blob/main/docs/superpowers/plans/2026-04-27--agents--restart-resilience.md) which handles the cluster-side work (notifications + cutover + verification).
 
 **Goal:** Build the image foundation that lets the secure-agent-pod (and the planned fleet of sibling agent pods) survive container restarts gracefully. Specifically: introduce `agent-shell-base` (s6-overlay v3 + supervised sshd/supercronic + tmux-resurrect/continuum + parameterized AGENT_USER/AGENT_HOME), migrate secure-agent-kali to use it, and give vk-local consistent first-boot setup without subjecting it to s6 (vibe-kanban stays a single-driver-process container under K8s supervision).

--- a/docs/superpowers/plans/2026-04-27--agents--restart-resilience.md
+++ b/docs/superpowers/plans/2026-04-27--agents--restart-resilience.md
@@ -8,10 +8,11 @@
 > accurate. Under s6-overlay, PID 1 is `s6-svscan`, which does not reliably
 > propagate K8s `envFrom` variables. The s6-overlay envdir at
 > `/run/s6/basedir/env/` is the canonical source and is now used by
-> `kali/config-templates/load-env.sh`. The legacy bashrc/gitconfig helpers
-> still reference `/proc/1/environ`; they currently happen to work on the
-> live pod but are tracked for follow-up cleanup. See the load-env-s6 PR
-> for details.
+> `kali/config-templates/load-env.sh`, `kali/config-templates/bashrc`, and
+> `kali/config-templates/gitconfig`. The shared
+> `base/opt/agent-init.d/02-credential-migrate` script detects the legacy
+> `/proc/1/environ` helper on PVC-resident gitconfigs and re-migrates to
+> the current shape. See the load-env-s6 PR for details.
 
 **Type:** Foundation extension of the agent-images repo. Companion to the spec in `derio-net/frank` (linked above) and the [frank-side plan](https://github.com/derio-net/frank/blob/main/docs/superpowers/plans/2026-04-27--agents--restart-resilience.md) which handles the cluster-side work (notifications + cutover + verification).
 

--- a/kali/Dockerfile
+++ b/kali/Dockerfile
@@ -77,8 +77,15 @@ COPY config-templates/settings.json /opt/settings.json
 COPY config-templates/gitconfig /opt/gitconfig
 
 # ── Cron env loader ──
-RUN printf '#!/bin/bash\nexport $(xargs -0 < /proc/1/environ)\n' > /opt/load-env.sh \
-    && chmod +x /opt/load-env.sh
+# Loads every env var written to the s6-overlay envdir. Each file under
+# /run/s6/basedir/env/ has name = env var, content = value (no trailing newline).
+# Replaces the legacy `/proc/1/environ` reader: under s6-overlay, PID 1 is
+# s6-svscan, which deliberately does not propagate the K8s envFrom-injected
+# variables that tini used to carry. The envdir is the documented, stable source.
+# Uses `printf -v` rather than `eval` because env values can contain shell
+# metacharacters (=, ", $, newlines).
+COPY config-templates/load-env.sh /opt/load-env.sh
+RUN chmod +x /opt/load-env.sh
 
 # ── Kali-specific cont-init.d: seed config templates on first boot ──
 COPY etc/cont-init.d/ /etc/cont-init.d/

--- a/kali/config-templates/bashrc
+++ b/kali/config-templates/bashrc
@@ -1,14 +1,25 @@
 # .bashrc — secure-agent-pod environment
-# Seeded to ~/.bashrc on first boot. Secrets injected via K8s envFrom.
+# Seeded to ~/.bashrc on first boot. Secrets injected via K8s envFrom and
+# materialized by /init into the s6-overlay envdir at /run/s6/basedir/env/.
 
-# Extract env vars from PID 1 (K8s injects into entrypoint, not SSH sessions)
-_env_from_pid1() { cat /proc/1/environ 2>/dev/null | tr '\0' '\n' | grep "^${1}=" | cut -d= -f2-; }
+# Read a single env var from the s6-overlay envdir. Each file under
+# /run/s6/basedir/env/ has name = env var, content = value (no meaningful
+# trailing newline — `$(< "$f")` strips at most one).
+#
+# Replaces the previous `/proc/1/environ` reader: under s6-overlay, PID 1 is
+# s6-svscan, which deliberately does not propagate K8s envFrom variables.
+# The envdir is the canonical s6 source.
+_env_from_s6() {
+    local f="/run/s6/basedir/env/$1"
+    [ -f "$f" ] || return 0
+    printf '%s' "$(< "$f")"
+}
 
-export GITHUB_TOKEN="${GITHUB_TOKEN:-$(_env_from_pid1 GITHUB_TOKEN)}"
-export TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-$(_env_from_pid1 TELEGRAM_BOT_TOKEN)}"
-export TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:-$(_env_from_pid1 TELEGRAM_CHAT_ID)}"
-export GRAFANA_API_KEY="${GRAFANA_API_KEY:-$(_env_from_pid1 GRAFANA_API_KEY)}"
-export GRAFANA_API_EDITOR_KEY="${GRAFANA_API_EDITOR_KEY:-$(_env_from_pid1 GRAFANA_API_EDITOR_KEY)}"
+export GITHUB_TOKEN="${GITHUB_TOKEN:-$(_env_from_s6 GITHUB_TOKEN)}"
+export TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-$(_env_from_s6 TELEGRAM_BOT_TOKEN)}"
+export TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:-$(_env_from_s6 TELEGRAM_CHAT_ID)}"
+export GRAFANA_API_KEY="${GRAFANA_API_KEY:-$(_env_from_s6 GRAFANA_API_KEY)}"
+export GRAFANA_API_EDITOR_KEY="${GRAFANA_API_EDITOR_KEY:-$(_env_from_s6 GRAFANA_API_EDITOR_KEY)}"
 
 export WILLIKINS_REPOS="${HOME}/repos/willikins:willikins"
 export PUSHGATEWAY_URL="http://pushgateway.monitoring.svc.cluster.local:9091"

--- a/kali/config-templates/gitconfig
+++ b/kali/config-templates/gitconfig
@@ -2,4 +2,4 @@
 	email = clawdia-ai-assistant@gmail.com
 	name = Clawdia
 [credential]
-	helper = "!f() { echo \"username=clawdia-ai-assistant\"; echo \"password=$(tr '\\0' '\\n' < /proc/1/environ | sed -n 's/^GITHUB_TOKEN=//p')\"; }; f"
+	helper = "!f() { echo \"username=clawdia-ai-assistant\"; printf 'password=%s\\n' \"$(< /run/s6/basedir/env/GITHUB_TOKEN)\"; }; f"

--- a/kali/config-templates/load-env.sh
+++ b/kali/config-templates/load-env.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# load-env.sh — populate the calling shell with the secure-agent-pod's
+# Kubernetes-injected environment variables.
+#
+# Source: /run/s6/basedir/env/ (the s6-overlay envdir). Each file under that
+# directory has name = env var, content = value, with no trailing newline.
+#
+# Why an envdir and not /proc/1/environ: under s6-overlay, PID 1 is s6-svscan,
+# which deliberately does not carry the K8s envFrom-injected variables that
+# tini used to. The envdir is the canonical s6 source and is populated by
+# /init at container start.
+#
+# Why `printf -v` and not `eval` / `export $(...)`: env values can contain
+# shell metacharacters (=, ", $, newlines). Literal assignment is the only
+# safe choice.
+set -a
+for f in /run/s6/basedir/env/*; do
+  [ -f "$f" ] || continue
+  name="$(basename "$f")"
+  value="$(< "$f")"
+  printf -v "$name" '%s' "$value"
+  export "$name"
+done
+set +a

--- a/kali/tests/test_bashrc_env.sh
+++ b/kali/tests/test_bashrc_env.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# test_bashrc_env.sh — harness for kali/config-templates/bashrc.
+#
+# Verifies that a fresh non-login shell sourcing the bashrc template reads
+# secrets from the s6-overlay envdir at /run/s6/basedir/env/ (not
+# /proc/1/environ). Runs against a temp envdir so it doesn't depend on a
+# live s6-overlay install or real pod secrets.
+#
+# Reports lengths and sha256 only — never plaintext values.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BASHRC="$SCRIPT_DIR/config-templates/bashrc"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Mirror the live envdir layout into a fixture and rewrite the bashrc to
+# point at it. The bashrc references /run/s6/basedir/env/ in exactly one
+# place (`_env_from_s6`).
+FIXTURE_ENVDIR="$TMP/envdir"
+mkdir -p "$FIXTURE_ENVDIR"
+sed "s|/run/s6/basedir/env|$FIXTURE_ENVDIR|g" "$BASHRC" > "$TMP/bashrc"
+
+# s6-overlay writes a trailing newline after the value. Mimic that so the
+# test exercises the same `$(< file)` newline-stripping the live shell does.
+printf 'fake-github-token-value\n' > "$FIXTURE_ENVDIR/GITHUB_TOKEN"
+printf 'fake-telegram-bot-token\n' > "$FIXTURE_ENVDIR/TELEGRAM_BOT_TOKEN"
+printf '12345\n'                    > "$FIXTURE_ENVDIR/TELEGRAM_CHAT_ID"
+printf 'fake-grafana-key\n'         > "$FIXTURE_ENVDIR/GRAFANA_API_KEY"
+printf 'fake-grafana-editor\n'      > "$FIXTURE_ENVDIR/GRAFANA_API_EDITOR_KEY"
+
+cat > "$TMP/runner.sh" <<'RUNNER'
+#!/usr/bin/env bash
+set -euo pipefail
+# shellcheck disable=SC1090
+. "$1"
+emit() {
+    local name="$1" val
+    val="${!name-}"
+    printf '%s_LEN=%d\n' "$name" "${#val}"
+    printf '%s_SHA=%s\n' "$name" "$(printf '%s' "$val" | sha256sum | cut -d' ' -f1)"
+}
+emit GITHUB_TOKEN
+emit TELEGRAM_BOT_TOKEN
+emit TELEGRAM_CHAT_ID
+emit GRAFANA_API_KEY
+emit GRAFANA_API_EDITOR_KEY
+printf 'WILLIKINS_REPOS=%s\n' "$WILLIKINS_REPOS"
+printf 'PUSHGATEWAY_URL=%s\n' "$PUSHGATEWAY_URL"
+case ":$PATH:" in
+    *":$HOME/.local/bin:"*) printf 'PATH_HAS_LOCAL_BIN=yes\n' ;;
+    *)                      printf 'PATH_HAS_LOCAL_BIN=no\n'  ;;
+esac
+RUNNER
+
+# `env -i` strips every var, including the ones the bashrc tries to honor
+# via ${VAR:-…}. That's the strictest form of "fresh shell" — proves the
+# envdir is the actual source on a cold start.
+OUT="$(env -i HOME="$TMP" PATH=/usr/bin:/bin bash "$TMP/runner.sh" "$TMP/bashrc")"
+
+expect() {
+    local label="$1" expected="$2"
+    if ! grep -qx "$label=$expected" <<< "$OUT"; then
+        printf 'FAIL: %s\n  expected: %s\n  got:\n%s\n' "$label" "$expected" "$OUT" >&2
+        exit 1
+    fi
+}
+
+sha() { printf '%s' "$1" | sha256sum | cut -d' ' -f1; }
+
+# Each fixture file ends with \n; `$(< file)` strips exactly one newline.
+expect GITHUB_TOKEN_LEN 23
+expect GITHUB_TOKEN_SHA "$(sha 'fake-github-token-value')"
+expect TELEGRAM_BOT_TOKEN_LEN 23
+expect TELEGRAM_BOT_TOKEN_SHA "$(sha 'fake-telegram-bot-token')"
+expect TELEGRAM_CHAT_ID_LEN 5
+expect TELEGRAM_CHAT_ID_SHA "$(sha '12345')"
+expect GRAFANA_API_KEY_LEN 16
+expect GRAFANA_API_KEY_SHA "$(sha 'fake-grafana-key')"
+expect GRAFANA_API_EDITOR_KEY_LEN 19
+expect GRAFANA_API_EDITOR_KEY_SHA "$(sha 'fake-grafana-editor')"
+
+expect WILLIKINS_REPOS "$TMP/repos/willikins:willikins"
+expect PUSHGATEWAY_URL 'http://pushgateway.monitoring.svc.cluster.local:9091'
+expect PATH_HAS_LOCAL_BIN yes
+
+# Negative test: no executable line in bashrc still reads /proc/1/environ.
+# Comments are allowed (the historical context is useful).
+if grep -nE '^[^#]*\b/proc/1/environ' "$BASHRC"; then
+    printf 'FAIL: bashrc has an executable reference to /proc/1/environ\n' >&2
+    exit 1
+fi
+
+echo "PASS: bashrc loads all secrets from the s6-overlay envdir (lengths + SHA verified)."

--- a/kali/tests/test_credential_migrate.sh
+++ b/kali/tests/test_credential_migrate.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# test_credential_migrate.sh — harness for base/opt/agent-init.d/02-credential-migrate.
+#
+# The script lives in base/ and is shared across all agent-images children.
+# It runs on every boot from agent-init.d, detects stale gitconfig credential
+# helpers on the persistent volume, and re-copies the image's /opt/gitconfig.
+#
+# Two prior helper shapes need migrating:
+#   - Legacy:   contains `password=$GITHUB_TOKEN`
+#   - tini-era: contains `/proc/1/environ`
+# Current helper reads /run/s6/basedir/env/GITHUB_TOKEN.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$REPO_ROOT/base/opt/agent-init.d/02-credential-migrate"
+[ -x "$SCRIPT" ] || chmod +x "$SCRIPT"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+run_case() {
+    local label="$1" existing_gitconfig="$2" expect_migrated="$3"
+    local agent_home="$TMP/$label"
+    mkdir -p "$agent_home"
+    printf '%s\n' "$existing_gitconfig" > "$agent_home/.gitconfig"
+    local sha_before
+    sha_before="$(sha256sum "$agent_home/.gitconfig" | cut -d' ' -f1)"
+
+    # Stage a "current" /opt/gitconfig the script can copy from.
+    local fake_opt="$TMP/$label-opt"
+    mkdir -p "$fake_opt"
+    cat > "$fake_opt/gitconfig" <<'GIT'
+[user]
+	email = clawdia-ai-assistant@gmail.com
+	name = Clawdia
+[credential]
+	helper = "!f() { echo username=clawdia-ai-assistant; printf 'password=%s\\n' \"$(< /run/s6/basedir/env/GITHUB_TOKEN)\"; }; f"
+GIT
+
+    # Sandbox /opt by running with a script-local PATH prefix that swaps the
+    # path. Easiest cross-platform approach: copy the script and rewrite the
+    # /opt/gitconfig path before exec.
+    sed "s|/opt/gitconfig|$fake_opt/gitconfig|g" "$SCRIPT" > "$TMP/$label.sh"
+    chmod +x "$TMP/$label.sh"
+
+    AGENT_HOME="$agent_home" HOME="$agent_home" bash "$TMP/$label.sh" >"$TMP/$label.log" 2>&1
+
+    local sha_after
+    sha_after="$(sha256sum "$agent_home/.gitconfig" | cut -d' ' -f1)"
+    local sha_target
+    sha_target="$(sha256sum "$fake_opt/gitconfig" | cut -d' ' -f1)"
+
+    case "$expect_migrated" in
+        yes)
+            if [ "$sha_after" = "$sha_before" ]; then
+                printf 'FAIL [%s]: gitconfig was NOT migrated but should have been\n' "$label" >&2
+                cat "$TMP/$label.log" >&2
+                exit 1
+            fi
+            if [ "$sha_after" != "$sha_target" ]; then
+                printf 'FAIL [%s]: post-migration gitconfig does not match /opt/gitconfig\n' "$label" >&2
+                exit 1
+            fi
+            ;;
+        no)
+            if [ "$sha_after" != "$sha_before" ]; then
+                printf 'FAIL [%s]: gitconfig was migrated but should NOT have been\n' "$label" >&2
+                cat "$TMP/$label.log" >&2
+                exit 1
+            fi
+            ;;
+    esac
+    printf 'OK   [%s] expect_migrated=%s\n' "$label" "$expect_migrated"
+}
+
+# Case 1: legacy env-var helper — must migrate.
+run_case legacy_envvar '[credential]
+	helper = "!f() { echo username=clawdia-ai-assistant; echo password=$GITHUB_TOKEN; }; f"' yes
+
+# Case 2: /proc/1/environ helper — must migrate.
+run_case proc_environ '[credential]
+	helper = "!f() { echo username=clawdia-ai-assistant; echo \"password=$(tr \"\\0\" \"\\n\" < /proc/1/environ | sed -n \"s/^GITHUB_TOKEN=//p\")\"; }; f"' yes
+
+# Case 3: already on the s6 envdir — must NOT migrate.
+run_case s6_envdir '[credential]
+	helper = "!f() { echo username=clawdia-ai-assistant; printf '"'"'password=%s\\n'"'"' \"$(< /run/s6/basedir/env/GITHUB_TOKEN)\"; }; f"' no
+
+# Case 4: unrelated user gitconfig (no GitHub credential helper) — must NOT migrate.
+run_case unrelated '[user]
+	name = Some Other Identity' no
+
+echo "PASS: 02-credential-migrate detects both legacy + /proc/1/environ helpers and skips current/unrelated configs."

--- a/kali/tests/test_gitconfig_credential_helper.sh
+++ b/kali/tests/test_gitconfig_credential_helper.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# test_gitconfig_credential_helper.sh — harness for kali/config-templates/gitconfig.
+#
+# The credential helper is the only path that runs in non-interactive
+# subprocesses (VS Code git, supercronic cron jobs) where ~/.bashrc is not
+# sourced. It must read GITHUB_TOKEN from the s6-overlay envdir directly
+# and emit the git credential protocol shape:
+#     username=<value>
+#     password=<value>
+#
+# Critically, the helper must NOT include the trailing newline that s6
+# writes to envdir files. A `password=<token>\n` line followed by the
+# extra envdir newline produces `password=<token>` and `password=` (empty)
+# — git takes the last-seen value, breaks auth.
+#
+# Reports lengths and sha256 only — never plaintext values.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+GITCONFIG="$SCRIPT_DIR/config-templates/gitconfig"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FIXTURE_ENVDIR="$TMP/envdir"
+mkdir -p "$FIXTURE_ENVDIR"
+
+# Token with shell-metachar bytes (=, ", $) plus a trailing newline matching
+# what s6 actually writes. NOT a newline embedded in the value — git's
+# credential protocol uses newline as a key/value terminator and rejects
+# embedded newlines, so we don't simulate that case.
+printf 'tok=value "with" $meta\n' > "$FIXTURE_ENVDIR/GITHUB_TOKEN"
+
+# Materialize the gitconfig with the envdir path rewritten.
+sed "s|/run/s6/basedir/env|$FIXTURE_ENVDIR|g" "$GITCONFIG" > "$TMP/gitconfig"
+
+# Extract and execute the helper directly. We don't shell out to git here
+# because CI may not have git's credential subsystem reachable; we exercise
+# the shell function git would invoke.
+HELPER="$(git config --file "$TMP/gitconfig" credential.helper)"
+case "$HELPER" in
+    !*) HELPER="${HELPER#!}" ;;
+    *) printf 'FAIL: helper does not start with "!" (got %q)\n' "$HELPER" >&2; exit 1 ;;
+esac
+
+OUT="$(env -i HOME="$TMP" PATH=/usr/bin:/bin bash -c "$HELPER")"
+
+# Expected wire format:
+#   username=clawdia-ai-assistant
+#   password=tok=value "with" $meta
+expected_username="username=clawdia-ai-assistant"
+expected_password='password=tok=value "with" $meta'
+
+USERNAME_LINE="$(grep '^username=' <<< "$OUT" || true)"
+PASSWORD_LINE="$(grep '^password=' <<< "$OUT" || true)"
+
+if [ "$USERNAME_LINE" != "$expected_username" ]; then
+    printf 'FAIL: username line mismatch\n  expected: %s\n  got:      %s\n' "$expected_username" "$USERNAME_LINE" >&2
+    exit 1
+fi
+
+# Compare via SHA so a regression doesn't echo the (potentially secret) value.
+got_pw_sha="$(printf '%s' "$PASSWORD_LINE" | sha256sum | cut -d' ' -f1)"
+exp_pw_sha="$(printf '%s' "$expected_password" | sha256sum | cut -d' ' -f1)"
+if [ "$got_pw_sha" != "$exp_pw_sha" ]; then
+    printf 'FAIL: password line sha mismatch\n  expected_sha: %s (len=%d)\n  got_sha:      %s (len=%d)\n' \
+        "$exp_pw_sha" "${#expected_password}" "$got_pw_sha" "${#PASSWORD_LINE}" >&2
+    exit 1
+fi
+
+# The helper must emit exactly two non-empty lines (username + password).
+# A naive `cat /run/s6/...` would smuggle the envdir's trailing newline into
+# the password value, producing a third empty line that breaks git's parser.
+# Capture into a file so we see real terminator structure (command
+# substitution would otherwise strip trailing newlines).
+env -i HOME="$TMP" PATH=/usr/bin:/bin bash -c "$HELPER" > "$TMP/helper-out"
+TOTAL_LINES="$(wc -l < "$TMP/helper-out")"
+NONEMPTY_LINES="$(grep -c . "$TMP/helper-out" || true)"
+if [ "$TOTAL_LINES" -ne 2 ] || [ "$NONEMPTY_LINES" -ne 2 ]; then
+    printf 'FAIL: expected 2 newline-terminated non-empty lines, got total=%d nonempty=%d\n' \
+        "$TOTAL_LINES" "$NONEMPTY_LINES" >&2
+    exit 1
+fi
+
+# Negative test: gitconfig must not still mention /proc/1/environ.
+if grep -q '/proc/1/environ' "$GITCONFIG"; then
+    printf 'FAIL: gitconfig still references /proc/1/environ\n' >&2
+    exit 1
+fi
+
+echo "PASS: gitconfig credential helper emits well-formed wire output, no trailing-newline leak."

--- a/kali/tests/test_load_env.sh
+++ b/kali/tests/test_load_env.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# test_load_env.sh — harness for kali/config-templates/load-env.sh
+#
+# Verifies that load-env.sh reads the s6-overlay envdir and exports values
+# with byte-identical fidelity, including values containing shell
+# metacharacters (=, ", $, newline) that an `eval`-based loader would mangle.
+#
+# Runs against a temp envdir, so it does not depend on a live s6-overlay
+# install or the secure-agent-pod's real secrets.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/config-templates/load-env.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+[ -x "$SCRIPT" ] || chmod +x "$SCRIPT"
+
+# The script hard-codes /run/s6/basedir/env/. To test without root, we copy
+# the script into TMP and rewrite the path to a fixture envdir.
+FIXTURE_ENVDIR="$TMP/envdir"
+mkdir -p "$FIXTURE_ENVDIR"
+sed "s|/run/s6/basedir/env|$FIXTURE_ENVDIR|g" "$SCRIPT" > "$TMP/load-env.sh"
+chmod +x "$TMP/load-env.sh"
+
+# Fixture 1: simple value.
+printf 'simple-value' > "$FIXTURE_ENVDIR/SIMPLE_VAR"
+
+# Fixture 2: value with =, ", $, and an embedded newline. Exactly the shapes
+# that break naive `export $(...)` and `eval` loaders.
+printf 'a=b "c" $d\nsecond-line' > "$FIXTURE_ENVDIR/COMPLEX_VAR"
+
+# Fixture 3: empty file is allowed and should produce an empty export.
+: > "$FIXTURE_ENVDIR/EMPTY_VAR"
+
+# Fixture 4: a stray subdirectory must be skipped, not exported.
+mkdir "$FIXTURE_ENVDIR/SHOULD_BE_SKIPPED_DIR"
+
+# Source in a fresh shell and emit lengths + a SHA so we never print the
+# (potentially secret) values themselves. Compare against expected hashes.
+cat > "$TMP/runner.sh" <<'RUNNER'
+#!/usr/bin/env bash
+set -euo pipefail
+. "$1"
+printf 'SIMPLE_VAR_LEN=%d\n' "${#SIMPLE_VAR}"
+printf 'SIMPLE_VAR_SHA=%s\n' "$(printf '%s' "$SIMPLE_VAR" | sha256sum | cut -d' ' -f1)"
+printf 'COMPLEX_VAR_LEN=%d\n' "${#COMPLEX_VAR}"
+printf 'COMPLEX_VAR_SHA=%s\n' "$(printf '%s' "$COMPLEX_VAR" | sha256sum | cut -d' ' -f1)"
+printf 'EMPTY_VAR_LEN=%d\n' "${#EMPTY_VAR}"
+if [ -n "${SHOULD_BE_SKIPPED_DIR:-}" ]; then
+    printf 'STRAY_DIR_EXPORTED=yes\n'
+else
+    printf 'STRAY_DIR_EXPORTED=no\n'
+fi
+RUNNER
+chmod +x "$TMP/runner.sh"
+
+OUT="$(env -i HOME="$TMP" PATH="$PATH" bash "$TMP/runner.sh" "$TMP/load-env.sh")"
+
+expect() {
+    local label="$1" expected="$2"
+    if ! grep -qx "$label=$expected" <<< "$OUT"; then
+        printf 'FAIL: %s\n  expected: %s\n  got:\n%s\n' "$label" "$expected" "$OUT" >&2
+        exit 1
+    fi
+}
+
+# SIMPLE_VAR: "simple-value" → 12 bytes, sha256 = …
+expect SIMPLE_VAR_LEN 12
+expect SIMPLE_VAR_SHA "$(printf '%s' 'simple-value' | sha256sum | cut -d' ' -f1)"
+
+# COMPLEX_VAR: 'a=b "c" $d\nsecond-line' → 22 bytes
+expect COMPLEX_VAR_LEN 22
+expect COMPLEX_VAR_SHA "$(printf '%s' 'a=b "c" $d
+second-line' | sha256sum | cut -d' ' -f1)"
+
+expect EMPTY_VAR_LEN 0
+expect STRAY_DIR_EXPORTED no
+
+echo "PASS: load-env.sh round-trips all fixture envdir entries (byte-identical)."


### PR DESCRIPTION
## Summary

Under tini, `/proc/1/environ` carried K8s `envFrom`-injected variables, so several places in the kali image read it directly: `/opt/load-env.sh` (cron loader), `~/.bashrc` (interactive shell), and the gitconfig credential helper (non-interactive git subprocesses). The 2026-04-27 restart-resilience cutover moved kali onto `s6-overlay`, where PID 1 is `s6-svscan` and does not reliably forward envFrom vars. The documented and stable s6 source is the envdir at `/run/s6/basedir/env/`.

A chorebot deployment on 2026-05-03 surfaced the regression (`NOTION_TOKEN` empty). On the live pod some code paths still see `/proc/1/environ` populated because `/init` is currently forwarding env into `s6-svscan`, but this is build-dependent — it has already burned us once and will again.

This PR ports **all four** code paths in the kali image off `/proc/1/environ` onto the s6 envdir, in a single rollout (one image, one blast radius):

- **`kali/config-templates/load-env.sh`** (new file, was a Dockerfile RUN heredoc) — bulk loader using `printf -v` over the envdir. Safe against values with `=`, `"`, `$`, newlines.
- **`kali/config-templates/bashrc`** — `_env_from_pid1` → `_env_from_s6`. All five secrets (`GITHUB_TOKEN`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`, `GRAFANA_API_KEY`, `GRAFANA_API_EDITOR_KEY`) move uniformly. `$(< "$f")` strips exactly one trailing newline, which matches s6's on-disk shape.
- **`kali/config-templates/gitconfig`** — credential helper reads `/run/s6/basedir/env/GITHUB_TOKEN` directly (works without `~/.bashrc` sourced — VS Code git, supercronic). Uses `printf 'password=%s\n'` rather than `cat` so the envdir's trailing newline does not smuggle into git's credential protocol.
- **`base/opt/agent-init.d/02-credential-migrate`** — extends the existing migration to detect the tini-era `/proc/1/environ` helper on PVC-resident gitconfigs and re-copy `/opt/gitconfig` in either case.

## Tests (all four pass locally)

- `kali/tests/test_load_env.sh` — simple/complex/empty/stray-subdir fixtures; byte-identical via SHA + length.
- `kali/tests/test_bashrc_env.sh` — `env -i` fresh shell + fixture envdir; all five secrets export correctly, PATH/WILLIKINS_REPOS set, no executable line still references `/proc/1/environ`.
- `kali/tests/test_gitconfig_credential_helper.sh` — extracts helper from gitconfig, runs it; exactly 2 non-empty lines, no trailing-newline leak, shell-metachar safe.
- `kali/tests/test_credential_migrate.sh` — 4 cases: legacy env-var (migrate), `/proc/1/environ` (migrate), already-on-envdir (no-op), unrelated gitconfig (no-op).

All tests print lengths + SHA256 only — no plaintext token values.

## Live-pod sanity (this branch, run inside the secure-agent-pod)

In `env -i` (no inherited env), sourcing each new template populated:

- `load-env.sh` → 144 vars total, `NOTION_TOKEN` 50 bytes (`ntn_` prefix), `GITHUB_TOKEN` 40 bytes (`ghp_`), `CHORES_BOT_TOKEN` 46 bytes
- `bashrc` → `GITHUB_TOKEN` 40 bytes (`ghp_`), `TELEGRAM_BOT_TOKEN` 46 bytes, etc.
- `gitconfig` helper → exactly 2 lines (`username=clawdia-ai-assistant\npassword=<token>\n`), no third empty line

Length/prefix only — no plaintext printed.

## Sibling-image scope

Re-grepped `paperclip-shell`, `ruflo-shell`, `ruflo-server`, `vk-local`, `agent-shell-base` for `/proc/1/environ` and `load-env`. **All clean — kali only.** The shared change in `base/opt/agent-init.d/02-credential-migrate` benefits all children that inherit from `base` but is harmless on configs that don't have a credential helper at all.

## Blast radius of rollout

Image change. Activating this requires a fresh build and `kubectl rollout restart deploy/secure-agent-pod`, which terminates any open mosh/ssh sessions. Bumper PR will land separately in `derio-net/frank`. **Do not merge until Ioannis is ready to coordinate the rollout** — he keeps a persistent session.

## Out of scope

- Notion data-sources migration (separate spec)
- npm cache eviction (separate spec)
- Archiving the restart-resilience plan (now `Status: Complete`; archival is a deliberate operator action)

## Test plan

- [ ] CI builds kali + agent-base green
- [ ] All four `kali/tests/test_*.sh` pass in CI
- [ ] After merge: trigger image rebuild, frank bumper PR, coordinate rollout window with Ioannis
- [ ] Post-rollout: `kubectl exec` into pod, `bash -c '. /opt/load-env.sh && echo "${NOTION_TOKEN:0:4} (${#NOTION_TOKEN} bytes)"'` — should print `ntn_ (50 bytes)`. Same check on `bashrc` (fresh ssh login). Run `git ls-remote https://github.com/derio-net/agent-images` from the pod (no creds passed) — should authenticate via the gitconfig helper.