### PR TITLE
[derio-net/agent-images] silent-reconnect-phantoms · Phase 2/3 · 48h soak

### DIFF
--- a/docs/superpowers/plans/2026-04-22-silent-reconnect-phantoms.md
+++ b/docs/superpowers/plans/2026-04-22-silent-reconnect-phantoms.md
@@ -5,7 +5,9 @@
 > **For dispatch:** Use vk-dispatch to create Issues from this plan.
 
 **Spec:** `docs/superpowers/specs/2026-04-22-silent-reconnect-phantoms-design.md`
-**Status:** Not Started
+**Status:** Complete (Phase 1 + Phase 2)
+
+> **Phase 2 outcome (50 h soak, 2026-05-02 → 2026-05-05):** reaper code deployed and running every 5 min across three pod incarnations; 0 PIDs died in window so the DELETE path stayed uncalibrated. Phase 1's known mid-life env_id rotation gap was directly observed (Pod A, env_019R → env_017n same PID, ≥1 phantom leaked). Recommend Phase 3 to close the rotation case. Soak detail: [issue #31 T+50 h comment](https://github.com/derio-net/agent-images/issues/31#issuecomment-4379897123).
 
 **Goal:** Close the phantom-session leak surfaced by the 2026-04-18 persistent-agent-reliability T+48h soak (17 phantoms: ~11 silent-reconnects + ~6 OOMKills) by adding a client-driven orphan-env reaper invoked inline from `kali/scripts/session-manager.sh` on each 5-minute tick.
 

--- a/kali/scripts/wrap-claude.py
+++ b/kali/scripts/wrap-claude.py
@@ -110,11 +110,20 @@ def main() -> int:
                 continue
             m = ENV_RE.search(line)
             if m:
-                envs_file.write_text(json.dumps({
+                # Atomic write: temp + rename. Path.write_text truncates then
+                # writes, so a reader that hits the truncate window sees an
+                # empty file. The reaper observed exactly this race during the
+                # Phase 2 soak (T+24h checkpoint, 2026-05-03 16:00:00):
+                # `[reap] skip: no env_id in .../envs/willikins.json`. os.replace
+                # is atomic on POSIX so the file is either old-content or
+                # full-new-content, never partial.
+                tmp = envs_file.with_suffix(envs_file.suffix + ".tmp")
+                tmp.write_text(json.dumps({
                     "env_id": m.group(0),
                     "pid": child.pid,
                     "started_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
                 }))
+                os.replace(tmp, envs_file)
                 seen_env = True
 
     t = threading.Thread(target=tail_output, daemon=True)


### PR DESCRIPTION
📦 Repo:   derio-net/agent-images
📋 Plan:   docs/superpowers/plans/2026-04-22-silent-reconnect-phantoms.md
📐 Spec:   docs/superpowers/specs/2026-04-22-silent-reconnect-phantoms-design.md
🎯 Phase:  2/3 — 48h soak [manual]
🔗 Issue:  https://github.com/derio-net/agent-images/issues/31

**Goal (from plan):** Close the phantom-session leak surfaced by the 2026-04-18 persistent-agent-reliability T+48h soak (17 phantoms: ~11 silent-reconnects + ~6 OOMKills) by adding a client-driven orphan-env reaper invoked inline from `kali/scripts/session-manager.sh` on each 5-minute tick.

---

## Summary

Closes Phase 2 (the soak) of `silent-reconnect-phantoms`. Two changes bundled:

1. **Plan Status** moves to `Complete (Phase 1 + Phase 2)` with a one-line outcome paragraph and link to the [T+50 h soak comment](https://github.com/derio-net/agent-images/issues/31#issuecomment-4379897123).
2. **Atomic envs-file write** in `wrap-claude.py` (~10 LoC) — closes the only logged event the reaper produced during the entire soak: a read-landing-in-truncate-window race causing `skip: no env_id`.

## Soak outcome (50 h, three pod incarnations)

| Window | Pod | Image | Notes |
|---|---|---|---|
| T+0 → T+13 h | Pod A `67cddc9d8-xlsz4` | `68b0239` (#45) | env_id rotation observed: `019R...` → `017n...` mid-process. Phase 1's known limitation, ≥1 phantom leaked. |
| T+13 h → T+28 h | Pod B `6bd88478f5-cbj6k` | `3e3e5a2` (#49) | Stable; single env_id; pod ended in roll. |
| T+13 h → T+50 h | Pod C `c976f9946-rqdqc` | `8ce6999` (#55) | 42 h single env_id, single wrapper, no events. |

**Reaper performance over 50 h:** ~600 invocations, 0 DELETE attempts, 0 errors, 1 logged event (the truncate-window race this PR fixes). The DELETE code path stayed uncalibrated because no PID died in window — operationally good news. Acceptance against the original spec criterion ("≥ OOMKill-portion ~6/17 reduction") cannot be measured, but no OOMKills occurred either.

## Atomic-write fix

The reaper hit this on 2026-05-03 16:00:00:

```
[reap] skip: no env_id in /home/claude/.willikins-agent/envs/willikins.json
```

`Path.write_text(...)` truncates before writing. A reader landing in that window sees an empty file. The reaper's logic skips the file rather than acting on stale data — correct behaviour, but it costs us a 5-min cycle. With `tempfile + os.replace`, readers always see either the old-complete or new-complete file. Existing 3 wrap-claude tests pass unchanged.

## Out-of-scope follow-ups (not in this PR)

- **Phase 3 plan/spec** for mid-life env_id rotation handling (see issue #31 comment for proposed options a/b).
- **Empty PID-file race** in `session-manager.sh` (observed only in Pod B's 14-min broken-cron window, did not recur). Should be its own tracking issue.
- **Local-supercronic pattern** for future soaks: frank#156 demonstrated this works far more reliably than remote claude.ai routines for periodic kubectl/gh-driven checkpoints.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)