### PR TITLE
plan(bridge): scaffold bridge → vk.bridge library integration

### DIFF
--- a/docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/01.yaml
+++ b/docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/01.yaml
@@ -1,0 +1,159 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Refactor vk-issue-bridge.py to import vk.bridge.tick
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Pin current behaviour with characterisation tests
+  steps:
+  - id: P1.T1.S1
+    text: |-
+      Capture today's bridge behaviour as the regression baseline
+
+      Before refactoring, the existing `kali/tests/test_vk_issue_bridge.py`
+      must pass against the current bridge. Run:
+      ```
+      cd kali && python -m pytest tests/test_vk_issue_bridge.py -x
+      ```
+      Expect: green. Record the pass count in commit body. These tests
+      are the safety net for the refactor.
+  - id: P1.T1.S2
+    text: |-
+      Add the missing end-to-end fixture
+
+      The existing tests stub `parse_issue_body` and `parse_dependencies`
+      directly. Add a new test that exercises the full main() loop
+      against fixture Issues + a stub VkMcpClient + a stub GhClient, and
+      asserts:
+        - One `vk-ready` Issue → one MCP card created + `vk-synced` label
+          applied
+        - A second Issue depending on the first (now closed) → also synced
+        - A third Issue depending on an OPEN predecessor → skipped, NOT
+          mistakenly synced
+
+      This is the contract the refactor must preserve. Run it against
+      the unrefactored bridge first — expect green.
+- number: 2
+  title: Add vk 2.1.0 as a dependency
+  steps:
+  - id: P1.T2.S1
+    text: |-
+      Pin vk in kali/scripts/pyproject.toml (or equivalent)
+
+      Find where the bridge's dependencies are declared. If there's no
+      pyproject in kali/scripts/, add a minimal one with:
+      ```
+      dependencies = ["vk>=2.1.0,<3.0.0"]
+      ```
+      Otherwise add the line to the existing manifest.
+
+      Verify: `pip install -e kali/scripts/` (or whichever path applies)
+      in a clean venv succeeds and `python -c "from vk import bridge"` works.
+  - id: P1.T2.S2
+    text: |-
+      Document the dep in the Kali Dockerfile
+
+      Audit `kali/Dockerfile` for where `vk` (or `superpowers-for-vk`)
+      gets installed today. If the bridge currently picks up vk via the
+      agent-shell-base baseline, add an explicit pip install line in
+      kali so the bridge's dep is self-contained:
+      ```
+      RUN pip install --no-cache-dir 'vk>=2.1.0,<3.0.0'
+      ```
+      Don't bump the FROM baseline yet — that's Phase 3 of this plan.
+- number: 3
+  title: Replace the hand-rolled loop with vk.bridge.tick
+  steps:
+  - id: P1.T3.S1
+    text: |-
+      Build a VkMcpClient adapter around the existing vk_mcp_client
+
+      In `kali/scripts/vk-issue-bridge.py`, add a small adapter class
+      that wraps the existing `VkMcpClient` (in `vk_mcp_client.py`) to
+      match the Protocol from `vk.bridge.VkMcpClient`:
+      ```python
+      class _McpAdapter:
+          def __init__(self, inner: VkMcpClient) -> None:
+              self._inner = inner
+          def create_card(self, *, title: str, body: str, issue_url: str) -> str:
+              return self._inner.create_card(title=title, body=body, issue_url=issue_url)
+          def update_card(self, *, card_id: str, status: str) -> None:
+              self._inner.update_card(card_id=card_id, status=status)
+      ```
+      Match the existing client's method signatures. If they don't line
+      up cleanly, adjust the adapter (NOT the existing client).
+  - id: P1.T3.S2
+    text: |-
+      Replace main() body with vk.bridge.discover_plans + tick
+
+      ```python
+      from vk import bridge as vk_bridge
+      from vk.ghclient import GhClient
+
+      def main() -> int:
+          gh = GhClient()  # wraps subprocess gh cli
+          mcp = _McpAdapter(VkMcpClient(VK_ORG_ID, VK_DERIO_OPS_PROJECT))
+          total = vk_bridge.TickResult()
+          for repo in discover_repos():
+              plans = vk_bridge.discover_plans(repo, gh)
+              for plan in plans:
+                  r = vk_bridge.tick(plan, gh, mcp)
+                  total = TickResult(
+                      synced=total.synced + r.synced,
+                      errors=total.errors + r.errors,
+                      skipped=total.skipped + r.skipped,
+                      failures=total.failures + r.failures,
+                  )
+          push_metric(total)
+          return 0 if total.errors == 0 else 1
+      ```
+      Delete the now-unused `parse_issue_body`, `parse_dependencies`,
+      and the inline reconciliation loop — they're all in vk now.
+  - id: P1.T3.S3
+    text: |-
+      Re-run the characterisation tests
+
+      The tests from P1.T1 must still pass with the refactored bridge.
+      Any failure is a contract regression — fix the refactor, NOT the
+      test. Run:
+      ```
+      cd kali && python -m pytest tests/ -x
+      ```
+      Expect: green, same count as P1.T1.S1.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/02.yaml
+++ b/docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/02.yaml
@@ -1,0 +1,66 @@
+schema_version: 2
+phase:
+  number: 2
+  title: End-to-end integration test against a real v2 plan
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Fixture plan with cross-phase deps
+  steps:
+  - id: P2.T1.S1
+    text: |-
+      Create a 2-phase fixture v2 plan
+
+      Under `kali/tests/fixtures/`, create a complete v2 plan folder
+      with Phase 1 (depends_on: []) and Phase 2 (depends_on: [1]). Both
+      agentic. Each phase has one task with one step. The point is to
+      exercise the renderer's phase→issue translation that v2.1.0 added.
+  - id: P2.T1.S2
+    text: |-
+      Stub the GitHub-side state
+
+      Build a fake GhState fixture where Phase 1's Issue exists (open,
+      labelled `vk-ready`) and Phase 2's Issue doesn't exist yet. Both
+      will be created by the tick. Assert that the body of Phase 2's
+      created Issue contains `- Blocked by #<Phase 1's issue number>`,
+      NOT `- Blocked by #1`.
+
+      This is the regression test that the renderer fix in v2.1.0
+      actually flows through to the bridge.
+- number: 2
+  title: Run the full tick against the fixture
+  steps:
+  - id: P2.T2.S1
+    text: |-
+      Add the integration test to the bridge's test suite
+
+      ```python
+      def test_bridge_dispatches_v2_plan_with_correct_issue_deps(tmp_path):
+          # Set up fixture repo, fixture plan, stub gh + mcp
+          # Run vk.bridge.discover_plans + tick
+          # Assert Phase 2's created Issue body has the correct dep ref
+      ```
+      Run, expect green if v2.1.0 is installed correctly. This test is
+      the protection against the original `#1`/`#issue_number` bug ever
+      regressing.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/03.yaml
+++ b/docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/03.yaml
@@ -1,0 +1,76 @@
+schema_version: 2
+phase:
+  number: 3
+  title: Bump secure-agent-kali baseline + roll pod
+  tag: manual
+  depends_on:
+  - 2
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Image bump
+  steps:
+  - id: P3.T1.S1
+    text: |-
+      Build + push secure-agent-kali with vk 2.1.0
+
+      After Phases 1+2 merge to main, the CI build of secure-agent-kali
+      will include the new bridge code + vk 2.1.0. Verify by checking
+      GHCR for the new tag matching the merge SHA, OR build locally:
+      ```
+      docker build -t secure-agent-kali:test kali/
+      docker run --rm secure-agent-kali:test python -c "from vk import bridge; print(bridge.__name__)"
+      ```
+      Expect: `vk.bridge`.
+- number: 2
+  title: Pod roll
+  steps:
+  - id: P3.T2.S1
+    text: |-
+      Update the secure-agent-pod manifest in frank
+
+      Bump the `secure-agent-kali` image tag in the relevant frank
+      manifest to the new SHA. ArgoCD will sync; the pod re-rolls and
+      the next 2-minute cron tick runs against the refactored bridge.
+
+      Verify by tailing pod logs:
+      ```
+      kubectl logs -n agents -l app=secure-agent-pod -c kali --tail=50 | grep -i bridge
+      ```
+      Expect log lines mentioning `vk.bridge.tick` (the refactored
+      main() should emit a startup line naming the function).
+- number: 3
+  title: Production smoke check
+  steps:
+  - id: P3.T3.S1
+    text: |-
+      Watch one full tick cycle
+
+      Wait ~3 minutes after the pod rolls, then:
+      ```
+      kubectl logs -n agents -l app=secure-agent-pod -c kali --since=5m
+      ```
+      Expect: a tick log with `TickResult(synced=N, errors=0, ...)`.
+
+      If `errors > 0`, capture the failure tuple in the plan's
+      completion note and decide whether to roll back to the prior
+      image or fix forward. Mark this manual phase complete with a
+      note: "production smoke: TickResult(synced=N, errors=M)".
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/_meta.yaml
+++ b/docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-05-12-bridge-vk-library-integration
+spec: docs/superpowers/specs/2026-05-06-vk-rebuild-state-machine-design.md
+target_repo: derio-net/agent-images
+vk_version: '>=2.0.0,<3.0.0'
+created: '2026-05-12'

--- a/docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/_prose.md
+++ b/docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/_prose.md
@@ -1,0 +1,59 @@
+# Bridge → `vk.bridge` Library Integration
+
+**Sibling of:** `derio-net/superpowers-for-vk` rework
+`docs/superpowers/plans/2026-05-09-vk-v2-library-rework-1/`
+
+**Why this exists.** The original vk-v2-library plan
+(`derio-net/superpowers-for-vk`) was scoped to a single repo and never
+shipped the `vk.bridge.*` library described in spec
+`2026-05-06-vk-rebuild-state-machine-design.md` lines 560-577. The
+bridge here at `kali/scripts/vk-issue-bridge.py` has been maintaining
+its own copies of `parse_issue_body`, `parse_dependencies`, and the
+reconcile loop.
+
+The sibling rework in superpowers-for-vk ships v2.1.0 with two changes:
+
+1. Renderer translates `- Blocked by #N` so `N` is a tracking Issue
+   number, not a phase number. (Today's bridge silently mis-gates
+   any v2 plan with cross-phase deps because phase number leaks
+   through.)
+2. New `vk.bridge` sub-package exposing `discover_plans()` and
+   `tick()`. The bridge becomes a thin wrapper.
+
+This plan refactors the live bridge to consume the new library and
+ships the image bump that rolls the pod onto it.
+
+## Architecture
+
+### Phase 1 — Refactor
+
+The bridge currently does ~600 lines of GH-Issue parsing + state
+machine work. After this phase it's down to a `main()` that
+discovers plans per repo and calls `vk.bridge.tick()`. The MCP
+client stays where it is — only an adapter is needed because
+`vk.bridge.VkMcpClient` is a Protocol the existing client should
+satisfy structurally.
+
+Characterisation tests at the start of Phase 1 lock in the current
+behaviour. The refactor must preserve every behaviour they assert.
+
+### Phase 2 — Integration test
+
+A real v2 plan fixture with cross-phase deps, dispatched through
+`vk.bridge.tick()` against a stub GhClient + stub MCP. Asserts
+that Phase 2's created Issue body has the correct `Blocked by #N`
+reference (using the predecessor's actual Issue number, not the
+phase number). This is the regression guard against the bug the
+v2.1.0 renderer fix addressed.
+
+### Phase 3 — Roll the pod
+
+Manual: build + push secure-agent-kali, bump the manifest in frank,
+watch one tick complete in production. Pass requires `errors=0`
+in the first post-roll tick's TickResult.
+
+## Dependencies
+
+This plan depends on v2.1.0 of `vk` being installable from
+GHCR / PyPI. Phase 1 starts after the superpowers-for-vk PR
+tags v2.1.0.


### PR DESCRIPTION
## Summary

Plan scaffolding only — no code changes. Cross-repo sibling of the [vk-v2-library-rework-1 plan in superpowers-for-vk](https://github.com/derio-net/superpowers-for-vk/pulls). Refactors `kali/scripts/vk-issue-bridge.py` to consume the new `vk.bridge.*` library that the sibling rework ships in v2.1.0.

## Why

The bridge currently maintains ~600 lines of GH-Issue parsing + state machine code. Spec `2026-05-06-vk-rebuild-state-machine-design.md` §"Bridge integration — `vk.bridge.*`" describes this code as the library `vk.bridge.discover_plans()` + `vk.bridge.tick()` — i.e. the bridge should be a thin wrapper around `vk`. The original vk-v2-library plan was scoped to superpowers-for-vk only and never made the library, so the bridge has been duplicating logic.

The sibling rework also fixes a silent mis-gating bug in the v2 renderer (phase numbers leaking through as Issue numbers in `- Blocked by #N`). Phase 2 of this plan adds the regression guard.

## Phases

| # | Title | Tag | Tasks/Steps |
|---|---|---|---|
| 1 | Refactor vk-issue-bridge.py → import `vk.bridge.tick` | agentic | 3 / 7 |
| 2 | End-to-end integration test with cross-phase deps | agentic | 2 / 3 |
| 3 | Bump secure-agent-kali baseline + roll pod | manual | 3 / 3 |

## Ordering

Phase 1 starts after the sibling rework tags v2.1.0 in superpowers-for-vk. Phase 1 Task 2 bumps `vk` to `>=2.1.0,<3.0.0` as a kali dep (today's `vk_version` constraint in `_meta.yaml` is `>=2.0.0,<3.0.0` only because the current installed vk is 2.0.4 — a one-line constraint bump happens in Phase 1).

## Test plan

- [ ] `vk plan self-review docs/superpowers/plans/2026-05-12-bridge-vk-library-integration` returns clean
- [ ] Plan structure matches the sibling rework's Phase 2 expectations (`vk.bridge.tick` signature)
- [ ] Phase 3 manual completion note format documented (`TickResult(synced=N, errors=M)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)