### PR TITLE
docs(agent-shells): multi-harness shells standard + batch design spec

### DIFF
--- a/docs/standards/multi-harness-shells.md
+++ b/docs/standards/multi-harness-shells.md
@@ -1,0 +1,290 @@
+# Multi-Harness Shell Standard
+
+**Status:** Draft (living document)
+**Applies to:** any `*-shell` image in this repo that hosts one or more agent-CLI
+harnesses (`claude`, `codex`, `gemini`, `opencode`, `hermes`, future harnesses).
+**Does not apply to:** server images (`ruflo-server`, `vk-local`).
+
+## Purpose
+
+Multiple agent-CLI harnesses must be able to coexist in a single shell image
+and run against any repository, regardless of whether that repo is set up for
+one specific harness or none. Image rebuilds must not be required to update
+harnesses, skills, MCP servers, or extensions. Operator credentials must
+survive container restarts and image updates without re-running interactive
+login flows.
+
+This document is the contract that all `*-shell` images in this repo
+implement. Image-level specs reference this doc rather than re-stating it.
+
+## Scope
+
+- **In scope:** the agent user's `$HOME` layout, harness install/update
+  mechanism, auth credential storage, skill/MCP/extension persistence,
+  inventory schema extension, the per-harness contract for being a
+  well-behaved citizen.
+- **Out of scope:** specific upstream harness versions (pinned per image),
+  Frank-side pod manifests, RBAC, network policy, ingress, ESO mappings.
+
+## Architectural premise
+
+Everything that needs to survive a container restart or image update lives on
+the per-pod **home PV** at `$AGENT_HOME` (default `/home/agent`). Everything
+on the image rootfs is treated as immutable and reproducible from the
+Dockerfile. The split:
+
+| Concern | Lives in | Updated by | Survives restart? |
+|---|---|---|---|
+| OS packages, shell base, s6, tmux | image rootfs | image rebuild | n/a (re-created from image) |
+| Harness CLI **bootstrap shim** | image rootfs (`npm i -g …`) | image rebuild | n/a |
+| Harness CLI **current version** | `$HOME/.local/bin/` (self-update target) | `<agent> update` or inventory reconcile | yes |
+| Harness auth credentials | `$HOME/.<agent>/` or `$HOME/.config/<agent>/` | interactive `<agent> login` once | yes |
+| Skills / plugins | `$HOME/.<agent>/skills/`, `$HOME/.<agent>/plugins/` (per-harness) | inventory reconcile or operator | yes |
+| MCP server configs | `$HOME/.<agent>/mcp.json` (per-harness) | inventory reconcile or operator | yes |
+| MCP server binaries | usually `npx`/`uvx` transient; sometimes `$HOME/.local/bin/` | reconcile or operator | yes |
+| Per-repo agent config | inside the repo (`<repo>/.claude/…`) | the repo's own commits | yes (repo on PV) |
+| Per-user inventory state | `$HOME/.local/state/<image>-shell/` | reconcile | yes |
+
+The single rule that makes the whole thing coherent: **no harness state of any
+kind is stored on the image rootfs.** The rootfs is a starting template, not a
+record.
+
+## Persistence layout (`$HOME`)
+
+```
+$HOME/
+├── .local/
+│   ├── bin/                  # self-updated harness binaries, mise shims
+│   └── state/<image>-shell/  # inventory reconcile state, last-run logs
+├── .config/                  # XDG-Base-Dir per-harness configs that follow XDG
+│   ├── codex/                # auth.json, settings.json (TBD per upstream)
+│   ├── gemini/               # auth.json, settings.json (TBD per upstream)
+│   └── opencode/             # (TBD per upstream)
+├── .claude/                  # claude-code; canonical layout — see below
+│   ├── credentials.json
+│   ├── settings.json
+│   ├── plugins/
+│   ├── skills/
+│   ├── agents/
+│   └── mcp.json
+├── .hermes/                  # hermes agent state (TBD per upstream)
+├── .ssh/                     # operator SSH keys (provisioned by 01-pvc-dirs)
+└── repos/                    # cloned repos; per-repo configs live here
+```
+
+**`.claude/` is normative for claude-code** because that's what upstream
+expects and what `agent-base` already targets. The XDG-style `~/.config/`
+layout applies to harnesses whose upstreams follow XDG. Where upstream is
+ambiguous, the image-level spec records the chosen path; this doc does not
+override upstream.
+
+## Harness manifest
+
+Each `*-shell` image declares which harnesses it carries. For every
+harness, the image's README lists:
+
+1. **Bootstrap install** — the Dockerfile line that puts the CLI on PATH.
+2. **Self-update path** — where the CLI writes updates (`$HOME/.local/bin/`
+   preferred). If the upstream CLI has no self-update mechanism, install via
+   the inventory layer with an npm prefix of `$HOME/.npm-global` so updates
+   land on the PV.
+3. **Auth command** — the operator-run command that produces persistent
+   credentials (`claude login`, `codex login`, …).
+4. **Auth credential file(s)** — the path(s) on `$HOME` that prove the
+   harness is logged in, used by the MOTD detector below.
+5. **Update command** — the command run by `<image>-shell-reconcile` to
+   refresh the CLI to the inventory-pinned version (or latest).
+
+If an upstream CLI does not satisfy properties 2 or 3, the image-level spec
+must call out the gap and propose a workaround (typically: install via
+inventory into `$HOME/.npm-global`, or wrap with a daemon that holds an
+issued session).
+
+## Auth model — subscription, not API tokens
+
+For harnesses that ship a subscription/OAuth login flow (claude, codex,
+gemini, …) the standard mandates that flow over any API-key env-var
+mechanism. The implications:
+
+- The image **does not** carry an `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` /
+  similar env at build or runtime. No `EnvFrom` references such keys for
+  these harnesses on Frank.
+- First boot of a new pod is **interactive**: the operator SSHes in and runs
+  each `<agent> login` once. The OAuth browser flow lands its credential in
+  `$HOME` on the PV. From that point, restarts and image updates are
+  zero-touch.
+- For harnesses with no subscription/OAuth path (e.g., `hermes` today, which
+  is BYOK to an OpenAI-compatible endpoint), the image-level spec records
+  the exception and how its credentials are sourced. The Frank-side
+  manifest, not the image, owns those env vars.
+
+Cross-implication: a `*-shell` image carrying multiple subscription harnesses
+is only "ready" once every harness in its manifest has been logged in. The
+MOTD makes this state visible (see below).
+
+## Auth status MOTD
+
+Every `*-shell` image must ship an `/etc/profile.d/` drop-in that, on each
+SSH login, prints a per-harness auth status table:
+
+```
+Harness auth status:
+  ✓ claude     (~/.claude/credentials.json, age 4d)
+  ✓ codex      (~/.config/codex/auth.json, age 4d)
+  ✗ gemini     not logged in — run: gemini login
+  ✗ opencode   not logged in — run: opencode auth login
+```
+
+The detector reads only the credential file paths declared in the harness
+manifest. It is a presence check, not a freshness or validity check — the
+operator owns rotation.
+
+## Updates — image immutable, $HOME mutable
+
+Updates to harness CLIs, skills, MCP servers, and extensions never require an
+image rebuild. The three mechanisms:
+
+1. **CLI self-update** — preferred. `claude` does this natively; the standard
+   requires that every other harness either self-updates or be installed via
+   inventory into a PV-backed npm prefix.
+2. **Inventory reconcile** — the existing `<image>-shell-reconcile` script
+   (e.g., `paperclip-shell-reconcile`) runs the configmap-mounted
+   `inventory.yaml` against the PV. The schema is extended below to cover
+   harnesses, MCP servers, and skills.
+3. **Operator-driven install** — interactive `mise install`, `npm i`,
+   `claude plugin install`, etc., performed in an SSH session. Already
+   supported by the existing shell pattern.
+
+Image rebuilds are reserved for: changing the bootstrap shim itself, OS
+package upgrades, base-image bumps, security patches.
+
+## Inventory schema extension
+
+The existing `inventory.yaml` schema (paperclip-shell, ruflo-shell) is
+extended with three new top-level keys, all optional. Existing keys
+(`mise`, `npm-global`, `pipx`, `cargo`, `removed`) keep their semantics.
+
+```yaml
+# Existing keys (unchanged) ---------------------------------------------------
+mise:
+  - python@3.12
+  - node@20
+npm-global:
+  - "@anthropic-ai/claude-code"
+pipx:
+  - ruff
+cargo:
+  - ripgrep
+removed:
+  mise: []
+
+# New keys --------------------------------------------------------------------
+
+# Per-harness CLI pins. Reconcile invokes each harness's update command
+# (declared in the image's harness manifest). Setting a version pins; "latest"
+# floats.
+harnesses:
+  claude: latest
+  codex: latest
+  gemini: latest
+  opencode: 0.4.2
+
+# Per-harness MCP servers. Each entry is appended to that harness's mcp.json
+# during reconcile, idempotently (existing entries with the same name are
+# replaced, not duplicated).
+mcp-servers:
+  claude:
+    - name: context7
+      command: npx
+      args: ["-y", "@upstash/context7-mcp"]
+    - name: superpowers
+      command: npx
+      args: ["-y", "superpowers-mcp"]
+  codex:
+    - name: context7
+      command: npx
+      args: ["-y", "@upstash/context7-mcp"]
+  gemini: []
+  opencode: []
+
+# Per-harness skills/plugins. Reconcile clones (or pulls) git refs into the
+# harness's skills/plugins dir, or invokes the harness's own plugin command.
+skills:
+  claude:
+    - name: superpowers
+      source: git+https://github.com/<org>/superpowers
+      ref: main
+    - name: superpowers-for-vk
+      source: git+https://github.com/derio-net/superpowers-for-vk
+      ref: main
+  codex: []
+  gemini: []
+  opencode: []
+```
+
+Removal semantics mirror the existing `removed:` block — e.g.,
+`removed.harnesses`, `removed.mcp-servers.claude`, `removed.skills.claude`.
+
+Reconcile is **fail-open** for every new key, same as the existing keys: a
+broken install logs the failure, fires the Telegram notifier, and lets sshd
+come up anyway. Auth failures are not "installs" — they show up in the MOTD
+table as `✗ not logged in`, not as installer errors.
+
+## Skill / MCP / extension contract
+
+Each harness has its own loader for skills/plugins/MCP. The standard does
+**not** try to unify them — that's a per-harness UX concern, not an image
+concern. What the standard does require:
+
+1. **Everything per-harness lives under `$HOME`.** A user-scoped install for
+   harness X must not write outside that harness's PV-backed config dir.
+2. **Per-repo overrides win.** A repo with `<repo>/.claude/` overrides
+   `$HOME/.claude/` for that working directory — that's claude-code's own
+   behaviour, restated here so spec authors don't fight it.
+3. **Missing per-repo config is non-fatal.** A repo set up only for claude
+   (no `.codex/`, no `.gemini/`) must remain usable by codex and gemini,
+   which fall back to their `$HOME` defaults.
+4. **No cross-harness pollution.** The standard does not introduce shared
+   files like `~/.agent-skills/` that multiple harnesses must read.
+   Operators who want symlink-based sharing can do so manually; the image
+   does not mandate it.
+
+## Smoke testing
+
+CI smoke tests for any `*-shell` image must, at minimum:
+
+1. Boot under K8s-equivalent securityContext (`runAsUser: 1000`,
+   `cap-drop=ALL`, `no-new-privileges`) — existing pattern.
+2. Wait for sshd to come up via `/command/s6-svstat /run/service/sshd`.
+3. For every harness in the image's manifest, assert `<harness> --version`
+   runs as UID 1000.
+4. Run `<image>-shell-reconcile` against an empty inventory and assert
+   clean exit + MOTD drop-in present.
+
+CI **does not** assert auth status. Credentials are not available in CI;
+auth is a runtime concern proven the first time the operator SSHes in.
+
+## Adopting the standard in a new image
+
+Minimum requirements for a new `*-shell` image to claim compliance:
+
+- [ ] `FROM agent-shell-base` (directly or transitively).
+- [ ] No harness state on image rootfs — auth/skills/MCP all land in `$HOME`.
+- [ ] Each harness's bootstrap install satisfies the manifest properties
+      above (or the spec records the gap).
+- [ ] Inventory installer recognises the three new schema keys.
+- [ ] MOTD prints the auth-status table on SSH login.
+- [ ] CI smoke test asserts presence of every harness CLI.
+- [ ] README links to this doc and lists each harness's manifest entry.
+
+## Open questions tracked on this doc
+
+- Self-update behaviour of `codex`, `gemini`, `opencode` — to be confirmed
+  per upstream. If any lacks a self-update mechanism, this doc gains a
+  per-harness workaround section.
+- Whether `superpowers` (and similar) ship MCP servers, claude-code
+  plugins, or both, and how that distinction maps to the
+  `mcp-servers` vs `skills` inventory keys.
+- Process namespace sharing for the n8n sidecar use case — relevant to
+  how n8n invokes `claude -p` over the shared pod. Image-side concern is
+  zero; flagged here so the Frank-side manifest spec can address it.

--- a/docs/superpowers/specs/2026-05-12-agent-shells-batch-design.md
+++ b/docs/superpowers/specs/2026-05-12-agent-shells-batch-design.md
@@ -1,0 +1,274 @@
+# Agent Shells Batch: hermes-agent-shell, multi-agent-shell, infra-shell
+
+**Date:** 2026-05-12
+**Status:** Draft
+**Standard:** [docs/standards/multi-harness-shells.md](../../standards/multi-harness-shells.md)
+
+## Problem
+
+`agent-images` has SSH-able shells for one-harness use cases (`ruflo-shell`
+and `paperclip-shell` host `claude`; `secure-agent-kali` adds pentest +
+cluster tooling on top). It has no shells for the following three needs:
+
+1. A **hermes agent shell** — a dedicated pod-bound shell that runs the
+   `hermes` agent against the in-cluster LiteLLM gateway.
+2. A **multi-harness sidecar shell** for n8n (and future workflow engines)
+   so that workflow nodes can invoke `claude -p`, `codex`, `gemini`, or
+   `opencode` over a shared pod filesystem, using each agent's
+   subscription/OAuth auth rather than pasted API tokens.
+3. An **infra-shell** that carries the same multi-harness payload plus
+   cluster-admin tooling, intended to eventually replace
+   `secure-agent-kali`.
+
+Cookie-cuttering three shells without a shared standard would re-introduce
+the divergence the existing repo has tried to avoid. The companion
+[multi-harness shells standard](../../standards/multi-harness-shells.md)
+governs the cross-cutting concerns; this spec covers the three concrete
+images.
+
+## Solution
+
+Add one new intermediate base image plus three leaves:
+
+```
+agent-base
+└── agent-shell-base
+    ├── hermes-agent-shell         (new — hermes only, LiteLLM-wired)
+    └── multi-agent-shell          (new — claude+codex+gemini+opencode)
+        └── infra-shell            (new — multi-agent-shell + cluster admin)
+```
+
+`multi-agent-shell` is the load-bearing addition: it bakes the four
+subscription-auth harnesses, implements the multi-harness standard's
+manifest + MOTD + inventory-extension behaviour, and is consumed both
+directly (n8n sidecar) and transitively (infra-shell).
+
+`hermes-agent-shell` is a separate leaf off `agent-shell-base`, not off
+`multi-agent-shell`, because it is the one image in the batch that retains
+LiteLLM/`OPENAI_BASE_URL` wiring (hermes has no subscription auth flow
+today). Mixing it with the subscription-auth shells would muddle the
+standard's auth contract.
+
+## Per-image designs
+
+### `multi-agent-shell`
+
+`FROM ghcr.io/derio-net/agent-shell-base:${BASE_SHA}`.
+
+**Harnesses baked:** `claude`, `codex`, `gemini`, `opencode`. Each
+installed via `npm install -g` (image rootfs) as a bootstrap shim. Per the
+standard, the CLI is expected to self-update into `$HOME/.local/bin/` on
+first run. For any of the four that lacks a self-update mechanism, the
+image-level spec for that harness (TBD during implementation) prescribes
+inventory-driven install into `$HOME/.npm-global` instead.
+
+Note: `claude` is already installed by `agent-base/Dockerfile:40`; this
+image inherits it. The Dockerfile only needs to add `codex`, `gemini`,
+`opencode`.
+
+**Harness manifest entries** (per the standard):
+
+| Harness | Bootstrap | Auth command | Credential file | Update cmd |
+|---|---|---|---|---|
+| claude | `npm i -g @anthropic-ai/claude-code` (inherited) | `claude login` | `~/.claude/credentials.json` | `claude update` |
+| codex | `npm i -g @openai/codex` (TBD pkg name) | `codex login` (TBD) | `~/.config/codex/auth.json` (TBD) | TBD |
+| gemini | `npm i -g @google/gemini-cli` (TBD pkg name) | `gemini login` (TBD) | `~/.config/gemini/auth.json` (TBD) | TBD |
+| opencode | `npm i -g <pkg>` (TBD pkg name) | `opencode auth login` (TBD) | TBD | TBD |
+
+Every TBD in the table above is intentional — those values are upstream
+facts to be confirmed at implementation time, not architectural choices.
+The spec is correct as long as the standard's properties are satisfied;
+mis-pinning the package name doesn't change the design.
+
+**Inventory installer:**
+
+Mirrors `paperclip-shell`/`ruflo-shell` shape (`/etc/cont-init.d/40-shell-inventory`,
+`install-base-runtimes.sh`, `install-inventory.sh`, `notify-telegram.sh`,
+MOTD drop-in) **plus** the three new schema keys from the standard:
+`harnesses`, `mcp-servers`, `skills`.
+
+Per-image namespace: `/etc/multi-agent-shell/`, `/var/lib/multi-agent-shell/`,
+`/usr/local/lib/multi-agent-shell/`, `/usr/local/bin/multi-agent-shell-reconcile`.
+ConfigMap mount path on Frank: `/etc/multi-agent-shell/inventory.yaml`.
+
+**MOTD:**
+
+The auth-status table from the standard (presence check on each
+credential file) replaces the simpler "last reconcile" MOTD that
+paperclip-shell uses. The reconcile summary is still printed; the auth
+table is appended.
+
+**Runtime env:**
+
+Image carries no `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, or any other API
+token. Subscription/OAuth credentials live in `$HOME` on the PV. The
+Frank-side manifest's `env:` block is intentionally minimal for this
+image.
+
+**n8n consumer model:**
+
+n8n invokes harnesses by `exec`ing into this sidecar (either via
+`shareProcessNamespace: true` in the pod spec or via in-cluster `kubectl
+exec`, both Frank-side concerns). The image's contribution is:
+
+- All four CLIs on PATH at UID 1000.
+- A workspace volume mount point at `/workspace` (convention; the
+  Frank manifest binds the actual PVC).
+- sshd on 2222 for operator login (needed for first-boot `<agent> login`
+  flows).
+
+### `hermes-agent-shell`
+
+`FROM ghcr.io/derio-net/agent-shell-base:${BASE_SHA}`.
+
+**Harness baked:** `hermes` only. No claude/codex/gemini/opencode in this
+image — keeps the identity clean and the image small.
+
+**Harness manifest entry:**
+
+| Harness | Bootstrap | Auth | Credential | Update |
+|---|---|---|---|---|
+| hermes | TBD (npm/pip/binary) at pinned `HERMES_GIT_REF` | n/a — BYOK via env | n/a | inventory reconcile / image rebuild |
+
+Hermes is the documented exception to the standard's "no API tokens"
+contract: it has no subscription/OAuth flow today, so its inference auth
+is `OPENAI_BASE_URL` + `OPENAI_API_KEY` set by the Frank manifest, sourced
+via ESO from Infisical. The standard's auth-status MOTD shows hermes as
+`(BYOK — no login flow)` rather than `✓` or `✗`.
+
+**Runtime env (Frank-supplied):**
+
+| Env | Purpose | Source |
+|---|---|---|
+| `OPENAI_BASE_URL` | In-cluster LiteLLM | `http://litellm.litellm-system:4000/v1` |
+| `OPENAI_API_KEY` | LiteLLM key | ESO → Infisical |
+
+**Inventory installer:** same shape as paperclip-shell. Per-image
+namespace: `/etc/hermes-agent-shell/`, etc. The three new inventory keys
+from the standard are supported but expected to be sparse — `harnesses:
+hermes: latest` is the typical content.
+
+**Items deferred to implementation phase:**
+
+- Upstream hermes repo URL (encoded in Dockerfile, not a build arg).
+- Initial `HERMES_GIT_REF` SHA.
+- Install method (npm/pip/binary).
+- Whether hermes has its own service port or runs purely interactively.
+
+### `infra-shell`
+
+`FROM ghcr.io/derio-net/multi-agent-shell:${BASE_SHA}`.
+
+**Inherits:** the four subscription-auth harnesses, the multi-harness
+standard's full implementation, the inventory pattern, the auth-status
+MOTD.
+
+**Adds:** cluster-admin tooling — `kubectl`, `talosctl`, `omnictl` (the
+same set `secure-agent-kali` currently carries via its own Dockerfile).
+Per-image namespace: `/etc/infra-shell/`, `/var/lib/infra-shell/`, etc.
+
+**Does not add (intentional default):** the Kali pentest stack
+(`nmap`/`metasploit`/`burpsuite`/etc.) that `secure-agent-kali` carries.
+The default scope is **cluster ops + multi-agent CLIs**, not pentest. If
+pentest packages are needed on a given pod, they go through the inventory
+layer (`apt`-via-inventory is a small extension to the existing
+inventory installer, tracked as a follow-up in the standard's open
+questions).
+
+If on review the user prefers infra-shell to fully replace
+secure-agent-kali including its pentest payload, the change is mechanical
+— bake the same apt packages this Dockerfile, and rename the matrix entry.
+Calling this out so the choice is explicit, not a guess.
+
+**Migration from `secure-agent-kali`:**
+
+This batch does not delete `secure-agent-kali`. The CI matrix keeps
+building it until infra-shell has proven itself on Frank in the role
+secure-agent-kali plays today. Removal is a follow-up PR tracked in the
+Frank repo, not here.
+
+## CI integration (`.github/workflows/build.yaml`)
+
+Additive edits, no rewrites:
+
+1. **Add `build-multi-agent-shell`** as a parallel intermediate to
+   `build-shell-base` (both depend on `build-base`; `build-children`
+   depends on both). This mirrors how `build-shell-base` exists between
+   `build-base` and `build-children` today — `multi-agent-shell` plays the
+   same role for its descendants.
+
+   ```yaml
+   build-multi-agent-shell:
+     needs: build-shell-base
+     # … standard build-push, BASE_SHA=needs.build-shell-base.outputs.sha
+   ```
+
+2. **Add three matrix entries** under `build-children`:
+
+   ```yaml
+   - name: hermes-agent-shell
+     context: hermes-agent-shell
+     build_args: |
+       BASE_SHA=${{ needs.build-shell-base.outputs.sha }}
+   - name: multi-agent-shell
+     context: multi-agent-shell
+     build_args: |
+       BASE_SHA=${{ needs.build-shell-base.outputs.sha }}
+   - name: infra-shell
+     context: infra-shell
+     build_args: |
+       BASE_SHA=${{ needs.build-multi-agent-shell.outputs.sha }}
+   ```
+
+   `infra-shell` depends on `multi-agent-shell`'s SHA, not `shell-base`'s.
+
+3. **Add three smoke-test jobs** (`smoke-test-hermes-agent-shell`,
+   `smoke-test-multi-agent-shell`, `smoke-test-infra-shell`) mirroring
+   the existing per-image smoke tests. Each asserts, per the standard:
+
+   - sshd up under K8s-equivalent securityContext (existing pattern).
+   - Every harness in the image's manifest reports `--version` cleanly.
+   - `<image>-shell-reconcile` runs against an empty inventory with clean
+     exit and MOTD present.
+   - For `infra-shell`: also `kubectl version --client`, `talosctl
+     version --client`, `omnictl --version` (matches secure-agent-kali's
+     existing smoke).
+
+4. **Add the three new smoke jobs to `dispatch-frank.needs`** so a broken
+   shell can't reach Frank.
+
+5. **Do not yet remove `secure-agent-kali` from the matrix.** See migration
+   note above.
+
+## README updates
+
+Top-level `README.md` Images table gains three rows. Per-image READMEs are
+written per the standard's "Adopting the standard" checklist and link
+back to the standard doc.
+
+## Items deferred to implementation phase
+
+Tracked here so the plan author has the complete list:
+
+- Upstream package names and install commands for `codex`, `gemini`,
+  `opencode`, `hermes`.
+- Each harness's exact credential-file path (used by the MOTD detector).
+- Each harness's self-update mechanism vs. inventory-driven update.
+- The MCP servers and skills the user actually wants pre-listed in the
+  default inventory (the spec only defines schema; the data is operator
+  choice).
+- Whether `superpowers` / `superpowers-for-vk` / `openspec` / `context7`
+  ship as MCP servers, claude-code plugins/skills, or both, and the
+  mapping to inventory keys (also flagged in the standard's open
+  questions).
+
+## Scope
+
+- **In scope:** Three new image directories (Dockerfile + rootfs + README
+  per the standard's checklist), one new intermediate-base CI job, three
+  new matrix entries, three new smoke-test jobs, README + standard
+  cross-links.
+- **Out of scope:** Frank-side pod/service manifests for any of the three
+  images; ESO mappings; removal of `secure-agent-kali`; the actual list of
+  MCP servers and skills the operator pre-loads; cross-harness skill
+  unification.


### PR DESCRIPTION
## Summary

- Adds `docs/standards/multi-harness-shells.md` — the cross-cutting standard governing `$HOME` layout, harness install/update mechanism, auth-credential persistence on the home PV, inventory schema extensions (`harnesses`/`mcp-servers`/`skills` keys), MOTD auth-status requirements, and the per-harness compliance checklist for all `*-shell` images in this repo
- Adds `docs/superpowers/specs/2026-05-12-agent-shells-batch-design.md` — design spec for three new shell images built on top of the standard:
  - `hermes-agent-shell` — hermes-only, wired to the in-cluster LiteLLM gateway (BYOK exception)
  - `multi-agent-shell` — new intermediate base hosting claude + codex + gemini + opencode for n8n sidecar use cases
  - `infra-shell` — multi-agent-shell descendant with cluster-admin tooling; eventual replacement for `secure-agent-kali`

## Context

Prior agent-shells (`ruflo-shell`, `paperclip-shell`, `secure-agent-kali`) each cookie-cut their own harness layout. This standard establishes the contract before three new shells diverge the same way. Implementation plan (via `vk-plan`) is the next step after review.

## Test plan

- [x] Review standard for completeness of the $HOME layout spec, MOTD contract, and inventory schema extension
- [x] Review batch spec for correctness of the image inheritance tree and CI plan
- [ ] Flag any upstream package names for codex/gemini/opencode/hermes that need pinning decisions before implementation begins

🤖 Generated with [Claude Code](https://claude.com/claude-code)