### PR TITLE
[derio-net/agent-images] 2026-05-12-bridge-vk-library-integration · Phase 2/3 · End-to-end integration test against a real v2 plan

### DIFF
--- a/docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/02.yaml
+++ b/docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/02.yaml
@@ -49,18 +49,21 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-14T21:07:43+00:00'
+      note: 'Created tests/fixtures/two-phase-cross-dep/ with 2-phase plan: Phase
+        1 (depends_on: [], tracking_issue #99) + Phase 2 (depends_on: [1], no tracking_issue).'
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-14T21:07:49+00:00'
+      note: 'Extended _FakeGh to capture create_issue calls; rendered Phase 2 body
+        asserted to contain ''- Blocked by #99'' and NOT ''- Blocked by #1''.'
     P2.T2.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-05-14T21:07:52+00:00'
+      note: 'test_bridge_dispatches_v2_plan_with_correct_issue_deps added in test_vk_bridge_integration.py;
+        full suite green: 132 passed (100 legacy + 18 integration + 14 mcp_client).'
   completion:
-    at: null
+    at: '2026-05-14T21:08:05+00:00'
     note: null
     observed_prs: []

--- a/kali/tests/fixtures/two-phase-cross-dep/01.yaml
+++ b/kali/tests/fixtures/two-phase-cross-dep/01.yaml
@@ -1,0 +1,24 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Phase 1 — foundation
+  tag: agentic
+  depends_on: []
+  tracking_issue: 'https://github.com/derio-net/agent-images/issues/99'
+tasks:
+- number: 1
+  title: Single task
+  steps:
+  - id: P1.T1.S1
+    text: |-
+      Do the thing
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/kali/tests/fixtures/two-phase-cross-dep/02.yaml
+++ b/kali/tests/fixtures/two-phase-cross-dep/02.yaml
@@ -1,0 +1,24 @@
+schema_version: 2
+phase:
+  number: 2
+  title: Phase 2 — blocked by phase 1
+  tag: agentic
+  depends_on: [1]
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Single task
+  steps:
+  - id: P2.T1.S1
+    text: |-
+      Do the thing
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/kali/tests/fixtures/two-phase-cross-dep/_meta.yaml
+++ b/kali/tests/fixtures/two-phase-cross-dep/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: two-phase-cross-dep
+spec: docs/superpowers/specs/fixture.md
+target_repo: derio-net/agent-images
+vk_version: '>=2.1.0,<3.0.0'
+created: '2026-05-14'

--- a/kali/tests/test_vk_bridge_integration.py
+++ b/kali/tests/test_vk_bridge_integration.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import importlib.util
 import os
+import shutil
 import sys
 import tempfile
 import textwrap
@@ -293,6 +294,7 @@ class _FakeGh:
     def __init__(self, view_responses: dict[tuple[str, int], dict]):
         self._view = view_responses
         self.label_edits: list[tuple[str, int, frozenset, frozenset]] = []
+        self.created_issues: list[dict] = []
 
     def view_issue(self, repo, number):
         return self._view.get((repo, number), {"state": "OPEN", "labels": []})
@@ -310,7 +312,10 @@ class _FakeGh:
         pass
 
     def create_issue(self, repo, *, title, body, labels):
-        return f"https://github.com/{repo}/issues/0"
+        self.created_issues.append(
+            {"repo": repo, "title": title, "body": body, "labels": list(labels)}
+        )
+        return f"https://github.com/{repo}/issues/{100 + len(self.created_issues)}"
 
     def ensure_labels(self, repo, labels):
         pass
@@ -466,4 +471,67 @@ def test_main_delineates_v2_plan_issues_from_legacy_path(monkeypatch):
     assert tick_calls == [fake_plan], "v2 plan must be ticked exactly once"
     assert [i.number for i in sync_calls] == [42], (
         "legacy sync_issue must be called for #42 only (not the v2-owned #61)"
+    )
+
+
+# ---------- cross-phase dependency rendering (v2.1.0 regression guard) ----------
+
+
+def _copy_fixture_plan(tmp_path: Path, fixture_name: str) -> Path:
+    """Copy a static plan fixture into a tmp checkout that VK_REPOS_DIR can scan."""
+    src = Path(__file__).parent / "fixtures" / fixture_name
+    dst = tmp_path / "agent-images" / "docs" / "superpowers" / "plans" / fixture_name
+    shutil.copytree(src, dst)
+    return dst
+
+
+def test_bridge_dispatches_v2_plan_with_correct_issue_deps(tmp_path, monkeypatch):
+    """End-to-end regression test for v2.1.0's renderer fix.
+
+    Phase 1's tracking Issue (#99) exists and is `vk-ready`. Phase 2 has no
+    tracking Issue yet — `tick` → `apply` must CREATE it, and the rendered
+    body must reference Phase 1's tracking-Issue number (`- Blocked by #99`),
+    NOT the raw phase number (`- Blocked by #1`). The latter was the v2.0.0
+    bug that v2.1.0 fixed; this test pins the fix all the way through the
+    bridge's library-delegation path.
+    """
+    from vk import bridge as vk_bridge
+
+    _copy_fixture_plan(tmp_path, "two-phase-cross-dep")
+    monkeypatch.setenv("VK_REPOS_DIR", str(tmp_path))
+
+    fake_gh = _FakeGh({
+        ("derio-net/agent-images", 99): {
+            "state": "OPEN",
+            "labels": ["vk-ready", "phase:1"],
+        }
+    })
+    mock_mcp = MagicMock()
+    mock_mcp.create_card.return_value = "card-uuid"
+
+    [plan] = vk_bridge.discover_plans("derio-net/agent-images", fake_gh)
+    assert [p.phase.number for p in plan.phases] == [1, 2]
+    assert tuple(plan.phases[1].phase.depends_on) == (1,)
+    assert plan.phases[1].phase.tracking_issue is None
+
+    result = vk_bridge.tick(plan, fake_gh, mock_mcp)
+
+    assert result.errors == 0, result.failures
+    assert result.synced == 1, "Phase 1 (vk-ready) should sync to VK"
+
+    phase2_creates = [
+        c for c in fake_gh.created_issues if "Phase 2/2" in c["title"]
+    ]
+    assert len(phase2_creates) == 1, (
+        f"expected exactly one create_issue for Phase 2, got "
+        f"{[c['title'] for c in fake_gh.created_issues]}"
+    )
+    phase2_body = phase2_creates[0]["body"]
+    assert "- Blocked by #99" in phase2_body, (
+        f"Phase 2 body must reference Phase 1's tracking Issue number (#99), "
+        f"got body:\n{phase2_body}"
+    )
+    assert "- Blocked by #1" not in phase2_body, (
+        f"Renderer leaked phase number into dep ref (v2.0.0 bug regressed); "
+        f"body:\n{phase2_body}"
     )


### PR DESCRIPTION
📦 Repo:   derio-net/agent-images
📋 Plan:   docs/superpowers/plans/2026-05-12-bridge-vk-library-integration
📐 Spec:   docs/superpowers/specs/2026-05-06-vk-rebuild-state-machine-design.md
🎯 Phase:  2/3 — End-to-end integration test against a real v2 plan [agentic]

**Goal (from plan):** Pin the v2.1.0 renderer fix — phases without a
tracking Issue must render `- Blocked by #<actual issue number>`, not
`- Blocked by #<phase number>` — end-to-end through the bridge's
library-delegation path.

---

## Summary

- Adds `kali/tests/fixtures/two-phase-cross-dep/` — a static 2-phase v2 plan with cross-phase deps (Phase 1 has tracking_issue #99, Phase 2 has `depends_on: [1]` and no tracking_issue)
- Adds `test_bridge_dispatches_v2_plan_with_correct_issue_deps` in `kali/tests/test_vk_bridge_integration.py` — drives real `vk.bridge.discover_plans` + `tick` against the fixture and asserts the rendered Phase 2 Issue body contains `- Blocked by #99`, NOT `- Blocked by #1`
- Extends `_FakeGh` to capture `create_issue` calls (mirroring how it already records `label_edits`)

## Why

v2.0.0 of the renderer mis-gated cross-phase deps by leaking the phase number through where the tracking Issue number was expected. v2.1.0 fixed it, but until this test the bridge had no end-to-end guard that the fix flowed all the way through `discover_plans → tick → apply → create_issue`. This phase locks the regression coverage in the bridge's own suite so the silent mis-gating cannot return.

## Test plan

- [x] New test passes — `test_bridge_dispatches_v2_plan_with_correct_issue_deps`
- [x] Full Python suite green: 132 passed (100 legacy `test_vk_issue_bridge` + 18 integration `test_vk_bridge_integration` + 14 `test_vk_mcp_client`)
- [x] No legacy test required changes (additive only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)