### PR TITLE
fix(kali,ci): pip-install private vk via BuildKit secret

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -115,6 +115,11 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image.name }}:${{ github.sha }}
             ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image.name }}:latest
           build-args: ${{ matrix.image.build_args }}
+          # gh_token: read access to private derio-net/superpowers-for-vk for
+          # the kali Dockerfile's pip-install of `vk`. Other matrix entries
+          # ignore the secret (their Dockerfiles don't mount it).
+          secrets: |
+            gh_token=${{ secrets.DISPATCH_PAT }}
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,scope=${{ matrix.image.name }},mode=max
 

--- a/kali/Dockerfile
+++ b/kali/Dockerfile
@@ -55,8 +55,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Pinned to a tag so image builds are reproducible; bumping vk = bumping this line.
 # --break-system-packages: Debian 12 marks the system Python externally-managed (PEP 668);
 # we accept that in this container because the bridge runs against the system interpreter.
-RUN pip install --no-cache-dir --break-system-packages \
-      'vk @ git+https://github.com/derio-net/superpowers-for-vk@v2.1.0'
+# gh_token: BuildKit secret with read access to derio-net/superpowers-for-vk (private).
+# Passed by .github/workflows/build.yaml; the token is consumed only for the git
+# clone and is never written to an image layer.
+RUN --mount=type=secret,id=gh_token,required=true \
+    pip install --no-cache-dir --break-system-packages \
+      "vk @ git+https://$(cat /run/secrets/gh_token)@github.com/derio-net/superpowers-for-vk@v2.1.0"
 
 # mosh requires a UTF-8 locale on both client and server
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8

--- a/kali/Dockerfile
+++ b/kali/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # clone and is never written to an image layer.
 RUN --mount=type=secret,id=gh_token,required=true \
     pip install --no-cache-dir --break-system-packages \
-      "vk @ git+https://$(cat /run/secrets/gh_token)@github.com/derio-net/superpowers-for-vk@v2.1.0"
+      "vk @ git+https://$(cat /run/secrets/gh_token)@github.com/derio-net/superpowers-for-vk@v2.1.4"
 
 # mosh requires a UTF-8 locale on both client and server
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8

--- a/kali/scripts/pyproject.toml
+++ b/kali/scripts/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Cron-driven bridge that syncs vk-ready GitHub Issues to VibeKanban via vk.bridge.tick."
 requires-python = ">=3.11"
 dependencies = [
-    "vk @ git+https://github.com/derio-net/superpowers-for-vk@v2.1.0",
+    "vk @ git+https://github.com/derio-net/superpowers-for-vk@v2.1.4",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

- Phase 1's `kali/Dockerfile` started pip-installing `vk` directly from the **private** `derio-net/superpowers-for-vk` repo, but the CI build had no credentials. Both post-Phase-1 builds on main failed with `fatal: could not read Username for 'https://github.com'`.
- Pass `secrets.DISPATCH_PAT` to the `build-children` matrix as a BuildKit `gh_token` secret, mounted on the pip-install `RUN` in `kali/Dockerfile`. BuildKit secrets are tmpfs-mounted during the `RUN` only — the token does not end up in image layers or the build cache.
- Bump the vk pin from **v2.1.0 → v2.1.4**. v2.1.0 was the latest tag, but `superpowers-for-vk` `main` was 8 commits ahead with work labelled v2.1.1–v2.1.4 in commit messages (newly tagged for this bump). Notable: v2.1.4 adds `feat(apply): persist tracking_issue back to plan yaml after IssueCreate`, which closes the manual `vk plan edit` loop the bridge currently relies on.

## Context

Unblocker for Phase 3 of `2026-05-12-bridge-vk-library-integration` (image bump → pod roll → smoke check). Without this PR, no rebuilt `secure-agent-kali` image lands in GHCR.

## Test plan

- [x] Local bridge suite (132 tests) passes against `vk 2.1.4`
- [ ] CI build of `secure-agent-kali` succeeds on merge to main
- [ ] `secure-agent-kali:<sha>` lands in GHCR
- [ ] No token strings appear in `docker history` of the published image
- [ ] (Manual) `docker run --rm secure-agent-kali:<sha> python -c "from vk import bridge; print(bridge.__name__)"` → `vk.bridge`

🤖 Generated with [Claude Code](https://claude.com/claude-code)