### PR TITLE
chore(kali,ci): simplify vk clone — repo is now public

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -115,11 +115,6 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image.name }}:${{ github.sha }}
             ${{ env.REGISTRY }}/${{ env.OWNER }}/${{ matrix.image.name }}:latest
           build-args: ${{ matrix.image.build_args }}
-          # gh_token: read access to private derio-net/superpowers-for-vk for
-          # the kali Dockerfile's pip-install of `vk`. Other matrix entries
-          # ignore the secret (their Dockerfiles don't mount it).
-          secrets: |
-            gh_token=${{ secrets.DISPATCH_PAT }}
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,scope=${{ matrix.image.name }},mode=max
 

--- a/kali/Dockerfile
+++ b/kali/Dockerfile
@@ -55,12 +55,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Pinned to a tag so image builds are reproducible; bumping vk = bumping this line.
 # --break-system-packages: Debian 12 marks the system Python externally-managed (PEP 668);
 # we accept that in this container because the bridge runs against the system interpreter.
-# gh_token: BuildKit secret with read access to derio-net/superpowers-for-vk (private).
-# Passed by .github/workflows/build.yaml; the token is consumed only for the git
-# clone and is never written to an image layer.
-RUN --mount=type=secret,id=gh_token,required=true \
-    pip install --no-cache-dir --break-system-packages \
-      "vk @ git+https://$(cat /run/secrets/gh_token)@github.com/derio-net/superpowers-for-vk@v2.1.4"
+RUN pip install --no-cache-dir --break-system-packages \
+      'vk @ git+https://github.com/derio-net/superpowers-for-vk@v2.1.4'
 
 # mosh requires a UTF-8 locale on both client and server
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8


### PR DESCRIPTION
## Summary

- `derio-net/superpowers-for-vk` was flipped to public visibility, so the BuildKit-secret + DISPATCH_PAT machinery added in #69 is no longer needed
- Reverts `kali/Dockerfile` to a plain anonymous `pip install vk @ git+https://...` and drops the `secrets:` block from the `build-children` matrix step

## Context

PR #69 added auth-via-BuildKit-secret because the build was failing with 403 cloning a private vk repo. With the repo public, the simpler form works and we shed an unused secret dependency.

## Test plan

- [ ] CI rebuild of `secure-agent-kali` on this PR's merge succeeds
- [ ] `secure-agent-kali:<sha>` lands in GHCR
- [ ] Unblocks Phase 3 of `2026-05-12-bridge-vk-library-integration`

🤖 Generated with [Claude Code](https://claude.com/claude-code)