### PR TITLE
fix(kali): install vk in dedicated venv (not system Python)

### DIFF
--- a/kali/Dockerfile
+++ b/kali/Dockerfile
@@ -53,10 +53,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # ── vk library (consumed by /opt/scripts/vk-issue-bridge.py via `from vk import bridge`) ──
 # Pinned to a tag so image builds are reproducible; bumping vk = bumping this line.
-# --break-system-packages: Debian 12 marks the system Python externally-managed (PEP 668);
-# we accept that in this container because the bridge runs against the system interpreter.
-RUN pip install --no-cache-dir --break-system-packages \
-      'vk @ git+https://github.com/derio-net/superpowers-for-vk@v2.1.4'
+# Installed into a dedicated venv so vk's deps (typer pulls a newer click)
+# don't collide with Debian's apt-managed python3-click (PEP 668).
+# The crontab invokes /opt/vk-bridge-venv/bin/python explicitly.
+RUN python3 -m venv /opt/vk-bridge-venv \
+    && /opt/vk-bridge-venv/bin/pip install --no-cache-dir \
+        'vk @ git+https://github.com/derio-net/superpowers-for-vk@v2.1.4'
 
 # mosh requires a UTF-8 locale on both client and server
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8

--- a/kali/config-templates/crontab.txt
+++ b/kali/config-templates/crontab.txt
@@ -23,7 +23,9 @@ PUSHGATEWAY_URL=http://pushgateway.monitoring.svc.cluster.local:9091
 0 14 * * 0,1,5,6 /opt/scripts/exercise-cron.sh standing; /opt/scripts/push-next-expected.sh exercise_reminder exercise-cron.sh 2>/dev/null
 
 # VK Issue Bridge — sync vk-ready GitHub Issues to VK workspaces (every 2 min)
-*/2 * * * * /opt/scripts/vk-issue-bridge.py >> __AGENT_HOME__/.willikins-agent/vk-bridge.log 2>&1
+# Use the dedicated venv's interpreter so `from vk import bridge` resolves
+# without colliding with Debian's apt-managed Python packages.
+*/2 * * * * /opt/vk-bridge-venv/bin/python /opt/scripts/vk-issue-bridge.py >> __AGENT_HOME__/.willikins-agent/vk-bridge.log 2>&1
 
 # Log rotation (hourly)
 7 * * * * /opt/scripts/rotate-logs.sh >> __AGENT_HOME__/.willikins-agent/logrotate.log 2>&1


### PR DESCRIPTION
## Summary

- Replace the `pip install --break-system-packages 'vk @ git+...'` with a dedicated venv at `/opt/vk-bridge-venv`
- Update the crontab to invoke the bridge via `/opt/vk-bridge-venv/bin/python /opt/scripts/vk-issue-bridge.py`

## Why

Phase 1's `--break-system-packages` install passes for the `vk` package itself but fails when pip tries to upgrade `click` (vk → typer → click>=8.2). Debian's apt-installed `python3-click` has no `RECORD` file, so pip refuses to uninstall it:

```
× Cannot uninstall click 8.1.8
╰─> The package's contents are unknown: no RECORD file was found for click.
hint: The package was installed by debian.
```

The plan's original prescription (`pip install --no-cache-dir 'vk>=2.1.0,<3.0.0'`) didn't include `--break-system-packages` — that flag was added during Phase 1 implementation as a workaround for PEP 668, but it conflicts with Debian's apt-managed Python packages. A dedicated venv sidesteps both issues: vk + deps live in isolation, the system Python is untouched.

## Test plan

- [x] Bridge suite locally: 132/132 pass (venv path is container-only; importlib-based tests are unaffected)
- [ ] CI build of `secure-agent-kali` on this PR's merge succeeds
- [ ] `secure-agent-kali:<sha>` lands in GHCR
- [ ] (Manual after roll) `docker run --rm secure-agent-kali:<sha> /opt/vk-bridge-venv/bin/python -c "from vk import bridge; print(bridge.__name__)"` → `vk.bridge`
- [ ] (Manual after roll) `kubectl logs -n agents -l app=secure-agent-pod -c kali --since=5m` shows a `TickResult(...)` line from the venv interpreter

🤖 Generated with [Claude Code](https://claude.com/claude-code)