### PR TITLE
fix(kali): re-render image-managed crontab block on every boot

### DIFF
--- a/kali/config-templates/crontab.txt
+++ b/kali/config-templates/crontab.txt
@@ -1,5 +1,10 @@
 # crontab.txt — Secure agent pod scheduled tasks
-# Seeded to ~/.crontab on first boot. Scripts at /opt/scripts/ (image-baked, immutable).
+# Seeded to ~/.crontab on first boot. On every subsequent boot the init
+# script (etc/cont-init.d/50-seed-config) re-renders only the block
+# between the sentinels below — anything outside the sentinels is
+# preserved across pod rolls (chorebot block, operator one-shots, etc.).
+
+# >>> agent-images managed (regenerated on every boot — do not edit) >>>
 SHELL=/bin/bash
 PATH=/usr/local/bin:/usr/bin:/bin:__AGENT_HOME__/.local/bin
 PUSHGATEWAY_URL=http://pushgateway.monitoring.svc.cluster.local:9091
@@ -44,3 +49,4 @@ PUSHGATEWAY_URL=http://pushgateway.monitoring.svc.cluster.local:9091
 # gone (e.g. wiped from /var/tmp on pod restart). Heap residue per stale
 # worktree was ~17 MiB in the 2026-04-22 memprofile.
 30 4 * * * /opt/scripts/worktree-prune.sh >> __AGENT_HOME__/.willikins-agent/worktree-prune.log 2>&1
+# <<< agent-images managed <<<

--- a/kali/etc/cont-init.d/50-seed-config
+++ b/kali/etc/cont-init.d/50-seed-config
@@ -1,11 +1,52 @@
 #!/command/with-contenv bash
 # 50-seed-config — Seed kali config templates to PVC on first boot.
 # Idempotent: only copies when the target file is absent.
+#
+# Crontab is the exception: on every boot we re-render the block between
+# the `# >>> agent-images managed` sentinels in ~/.crontab so image-side
+# changes propagate without clobbering user-added lines (chorebot block,
+# operator one-shots, etc.). Pods born before the managed-block scheme
+# (no sentinels in ~/.crontab) are left alone — operators add the
+# sentinels manually once, then auto-rerender kicks in.
 set -e
 HOME="${AGENT_HOME:-$HOME}"
-# Substitute __AGENT_HOME__ placeholder in crontab (PATH line, log redirections).
-[ -f "$HOME/.crontab" ]              || sed "s|__AGENT_HOME__|${HOME}|g" /opt/crontab > "$HOME/.crontab"
-[ -f "$HOME/.load-env.sh" ]          || cp /opt/load-env.sh "$HOME/.load-env.sh"
-[ -f "$HOME/.bashrc" ]               || cp /opt/bashrc "$HOME/.bashrc"
-[ -f "$HOME/.claude/settings.json" ] || { mkdir -p "$HOME/.claude"; cp /opt/settings.json "$HOME/.claude/settings.json"; }
-[ -f "$HOME/.gitconfig" ]            || cp /opt/gitconfig "$HOME/.gitconfig"
+# OPT_DIR points at the seeded image config — overridable from tests so
+# they can drive this script against a temp tree instead of real /opt.
+OPT_DIR="${OPT_DIR:-/opt}"
+
+render_crontab() {
+    local target="$HOME/.crontab"
+    local tmpl
+    tmpl="$(sed "s|__AGENT_HOME__|${HOME}|g" "${OPT_DIR}/crontab")"
+    if [ ! -f "$target" ]; then
+        printf '%s\n' "$tmpl" > "$target"
+        return
+    fi
+    if ! grep -q '^# >>> agent-images managed' "$target"; then
+        return  # legacy file, no sentinels — leave for operator to migrate
+    fi
+    printf '%s\n' "$tmpl" > "$target.tmpl.$$"
+    awk -v tmpl="$target.tmpl.$$" '
+        /^# >>> agent-images managed/ {
+            emit = 0
+            while ((getline line < tmpl) > 0) {
+                if (line ~ /^# >>> agent-images managed/) emit = 1
+                if (emit) print line
+                if (line ~ /^# <<< agent-images managed/) { emit = 0; break }
+            }
+            close(tmpl)
+            in_block = 1
+            next
+        }
+        /^# <<< agent-images managed/ { in_block = 0; next }
+        !in_block { print }
+    ' "$target" > "$target.new.$$"
+    mv "$target.new.$$" "$target"
+    rm -f "$target.tmpl.$$"
+}
+
+render_crontab
+[ -f "$HOME/.load-env.sh" ]          || cp "${OPT_DIR}/load-env.sh" "$HOME/.load-env.sh"
+[ -f "$HOME/.bashrc" ]               || cp "${OPT_DIR}/bashrc" "$HOME/.bashrc"
+[ -f "$HOME/.claude/settings.json" ] || { mkdir -p "$HOME/.claude"; cp "${OPT_DIR}/settings.json" "$HOME/.claude/settings.json"; }
+[ -f "$HOME/.gitconfig" ]            || cp "${OPT_DIR}/gitconfig" "$HOME/.gitconfig"

--- a/kali/tests/test_seed_config_crontab.sh
+++ b/kali/tests/test_seed_config_crontab.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# test_seed_config_crontab.sh — harness for etc/cont-init.d/50-seed-config
+# crontab re-render logic. Covers three cases:
+#   1. First boot: no ~/.crontab → full template is rendered.
+#   2. Re-render: ~/.crontab has sentinels → managed block is replaced,
+#      user-added lines outside the block are preserved.
+#   3. Legacy: ~/.crontab without sentinels → left untouched.
+#
+# Drives the script via OPT_DIR (pointing at a tmp tree of stub files)
+# so it runs portably on macOS dev workstations and Linux CI alike.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/etc/cont-init.d/50-seed-config"
+TEMPLATE="$SCRIPT_DIR/config-templates/crontab.txt"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Seed stub /opt content the script copies / reads from.
+OPT="$TMP/opt"
+mkdir -p "$OPT"
+cp "$TEMPLATE" "$OPT/crontab"
+printf 'stub\n' > "$OPT/load-env.sh"
+printf 'stub\n' > "$OPT/bashrc"
+printf '{}\n'   > "$OPT/settings.json"
+printf '[stub]\n' > "$OPT/gitconfig"
+
+# Wrap the s6 shebang for portable invocation.
+SCRIPT_COPY="$TMP/50-seed-config"
+{ echo '#!/usr/bin/env bash'; tail -n +2 "$SCRIPT"; } > "$SCRIPT_COPY"
+chmod +x "$SCRIPT_COPY"
+
+run_init() {
+    local home="$1"
+    OPT_DIR="$OPT" HOME="$home" AGENT_HOME="$home" bash "$SCRIPT_COPY"
+}
+
+# ---- Case 1: first boot ----
+H1="$TMP/case1"
+mkdir -p "$H1"
+run_init "$H1"
+test -f "$H1/.crontab"                              || { echo "case1: ~/.crontab not created"; exit 1; }
+grep -q '^# >>> agent-images managed' "$H1/.crontab" || { echo "case1: begin sentinel missing"; exit 1; }
+grep -q '^# <<< agent-images managed' "$H1/.crontab" || { echo "case1: end sentinel missing"; exit 1; }
+grep -q "$H1/.local/bin"               "$H1/.crontab" || { echo "case1: __AGENT_HOME__ not substituted"; exit 1; }
+grep -q 'vk-issue-bridge.py'           "$H1/.crontab" || { echo "case1: bridge line missing"; exit 1; }
+echo "case1: first-boot render OK"
+
+# ---- Case 2: re-render with sentinels + preserved user content ----
+H2="$TMP/case2"
+mkdir -p "$H2"
+cat > "$H2/.crontab" <<'EOF'
+# user header — preserved
+STALE_VAR=old-value
+# >>> agent-images managed (regenerated on every boot — do not edit) >>>
+SHELL=/bin/sh
+PATH=/old/path
+# old stale cron line — should be replaced
+*/99 * * * * /opt/scripts/STALE.sh
+# <<< agent-images managed <<<
+# >>> chorebot (managed externally) >>>
+0 4 * * * cd ~/repos/willikins/scripts/chorebot && python send-morning.py
+# <<< chorebot <<<
+# operator one-shot — preserved
+0 9 1 1 * /home/agent/one-shot.sh
+EOF
+run_init "$H2"
+grep -q '^# user header — preserved'          "$H2/.crontab" || { echo "case2: pre-sentinel user line lost"; exit 1; }
+grep -q '^STALE_VAR=old-value'                 "$H2/.crontab" || { echo "case2: pre-sentinel env override lost"; exit 1; }
+! grep -q '/opt/scripts/STALE.sh'              "$H2/.crontab" || { echo "case2: stale managed line not replaced"; exit 1; }
+! grep -q '^PATH=/old/path'                    "$H2/.crontab" || { echo "case2: stale managed env not replaced"; exit 1; }
+grep -q 'vk-issue-bridge.py'                   "$H2/.crontab" || { echo "case2: fresh managed bridge line missing"; exit 1; }
+grep -q "$H2/.local/bin"                       "$H2/.crontab" || { echo "case2: __AGENT_HOME__ not substituted in re-render"; exit 1; }
+grep -q '^# >>> chorebot'                      "$H2/.crontab" || { echo "case2: chorebot block lost"; exit 1; }
+grep -q 'one-shot.sh'                          "$H2/.crontab" || { echo "case2: operator one-shot lost"; exit 1; }
+[ "$(grep -c '^# >>> agent-images managed' "$H2/.crontab")" = "1" ] || { echo "case2: managed block not unique"; exit 1; }
+echo "case2: re-render-with-sentinels OK"
+
+# ---- Case 3: legacy ~/.crontab without sentinels is left alone ----
+H3="$TMP/case3"
+mkdir -p "$H3"
+cat > "$H3/.crontab" <<'EOF'
+SHELL=/bin/bash
+PATH=/legacy/path
+*/2 * * * * /legacy/path/bridge.py >> /legacy/log 2>&1
+EOF
+BEFORE="$(shasum -a 256 "$H3/.crontab" 2>/dev/null || sha256sum "$H3/.crontab")"
+run_init "$H3"
+AFTER="$(shasum -a 256 "$H3/.crontab" 2>/dev/null || sha256sum "$H3/.crontab")"
+[ "${BEFORE%% *}" = "${AFTER%% *}" ] || { echo "case3: legacy ~/.crontab mutated unexpectedly"; exit 1; }
+echo "case3: legacy-file-leave-alone OK"
+
+echo "all tests passed"


### PR DESCRIPTION
## Summary

- Adds sentinels (`# >>> agent-images managed` / `# <<< agent-images managed`) around the image-managed cron lines in `kali/config-templates/crontab.txt`
- Updates `kali/etc/cont-init.d/50-seed-config` to **replace just the managed block** in `~/.crontab` on every boot, instead of only rendering once on first boot
- Pods born before the managed-block scheme (no sentinels in `~/.crontab`) are left untouched — backwards-compatible, operators add the sentinels manually once and auto-rerender kicks in
- Adds `kali/tests/test_seed_config_crontab.sh` covering all three cases: first-boot full render, re-render-with-sentinels preserving user content, legacy-file-leave-alone

## Why

Discovered while diagnosing why Phase 3 of `2026-05-12-bridge-vk-library-integration` left the bridge silently running the legacy per-Issue path even after a fresh pod roll on the new image.

Root cause: `[ -f "$HOME/.crontab" ] || sed ... > "$HOME/.crontab"` is a "render once" guard. The home PV preserves `~/.crontab` across pod rolls, so the May-5-rendered file pinned a stale `*/2 * * * * /home/claude/repos/agent-images/kali/scripts/vk-issue-bridge.py` invocation forever. Subsequent images that moved the bridge to `/opt/scripts/` + venv interpreter never took effect in production — the pod was on the right image but cron was firing the wrong line.

The managed-block pattern lets image-side template changes propagate to existing pods on each roll, while preserving user/agent-managed entries (chorebot, operator one-shots, user env overrides above the block).

## Compatibility

- **New pods**: born with sentinels in `~/.crontab`, get re-renders on every roll going forward.
- **Existing pods**: their `~/.crontab` doesn't have sentinels, so the init script skips re-render. Operators can opt-in by wrapping the relevant lines with the sentinel markers — next pod roll picks them up. This was a deliberate choice (vs. forcing a migration that would clobber user state like the chorebot block).
- The bridge live-patch already applied on the running pod doesn't conflict with this change.

## Test plan

- [x] `bash kali/tests/test_seed_config_crontab.sh` passes locally (all three cases green)
- [x] First-boot case: full template rendered, both sentinels present, `__AGENT_HOME__` substituted
- [x] Re-render case: managed block replaced, user content above and below preserved
- [x] Legacy case: file without sentinels is byte-for-byte untouched
- [ ] After merge: next pod roll picks up the new template; existing pods that have manually added sentinels start receiving image-side changes

## Out of scope

- `kali/tests/*.sh` aren't run in CI — pre-existing gap. Test was validated locally; would be a follow-up to add a shell-test job to `.github/workflows/build.yaml`.
- Cleanup of the ~25-per-tick `'plan:YYYY-MM-DD' not found` errors the v2 path surfaces against orphaned VK card label refs — separate task per the bridge plan completion note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)