### PR TITLE
ci(kali): run shell and Python tests, gate dispatch-frank

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,36 @@ env:
   OWNER: derio-net
 
 jobs:
+  test-kali:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      # vk_mcp_client reads these at import time. Tests don't talk to VK,
+      # but the import path fails if they're unset.
+      VK_ORG_ID: fake-org
+      VK_DERIO_OPS_PROJECT_ID: fake-project
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - name: Sync Python deps
+        run: uv sync --group dev
+      - name: Run kali shell tests
+        run: |
+          fail=0
+          for t in kali/tests/test_*.sh; do
+            echo "::group::$t"
+            bash "$t" || fail=1
+            echo "::endgroup::"
+          done
+          exit $fail
+      - name: Run kali Python tests
+        working-directory: kali
+        run: uv run pytest tests/ -v
+
   build-base:
     runs-on: ubuntu-latest
     outputs:
@@ -406,6 +436,7 @@ jobs:
 
   dispatch-frank:
     needs:
+      - test-kali
       - build-children
       - smoke-test-vk-local
       - smoke-test-secure-agent-kali

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,4 +5,10 @@ description = "Shared base image and per-pod child images for secure agent pods"
 requires-python = ">=3.11"
 
 [dependency-groups]
-dev = ["pytest>=8.0"]
+dev = [
+    "pytest>=8.0",
+    # vk is needed by kali/tests/test_vk_bridge_integration.py — pin to the
+    # same tag as kali/Dockerfile + kali/scripts/pyproject.toml so CI tests
+    # exercise the bridge against the version that ships in the image.
+    "vk @ git+https://github.com/derio-net/superpowers-for-vk@v2.1.4",
+]


### PR DESCRIPTION
## Summary

- Adds a **`test-kali`** job to `.github/workflows/build.yaml` that runs the shell suite (`kali/tests/test_*.sh`) and the Python suite (`uv run pytest kali/tests/`) on every push to main
- Wires `test-kali` into `dispatch-frank`'s `needs:` list so the agent-images-bumped event only fires when **both builds AND tests** pass — broken kali code can no longer reach prod via the frank dispatch
- Adds `vk` to `pyproject.toml`'s `dev` group, pinned to **v2.1.4** to match `kali/Dockerfile` and `kali/scripts/pyproject.toml` (keeps the test env exercising the same vk the image ships)

## Why

Until now `kali/tests/*` weren't run by CI at all — they were locally-validated only. That's exactly how the bridge plan landed Phase 1 with `--break-system-packages`, Phase 1's broken CI build went unnoticed for hours, the stale `~/.crontab` issue slipped past the smoke test, etc. CI tests are the obvious safety net for future change.

## Test plan

- [x] Local: `uv sync --group dev` resolves cleanly with `vk==2.1.4`
- [x] Local: `bash kali/tests/test_seed_config_crontab.sh` and the other shell tests pass on macOS dev box (modulo `test_wrap_claude.py::test_sigkill_leaves_envs_file` which is Linux-only — pdeathsig — and will pass on the runner)
- [x] Local: `cd kali && uv run pytest tests/ -v` runs 132+ tests, expect all green on Linux CI
- [ ] After merge: CI run shows `test-kali` job and shell/Python sub-steps green
- [ ] After merge: simulate a failure case (regress a test, push) → `dispatch-frank` is blocked
- [ ] After merge: confirm green main propagates as before

## Note

The Python suite assumes the bridge dependencies in `kali/scripts/pyproject.toml` resolve via root uv venv. If we later add bridge-specific deps that diverge from agent-images root, we may need to split into two `uv` projects with their own envs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)