### PR TITLE
docs(plan): scaffold spec-dispatch-bridge

### DIFF
--- a/docs/superpowers/plans/2026-05-14-spec-dispatch-bridge/01.yaml
+++ b/docs/superpowers/plans/2026-05-14-spec-dispatch-bridge/01.yaml
@@ -1,0 +1,350 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Bridge cron caller — spec dispatch loop
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Prerequisites — verify bridge has been migrated to vk library and v2.2.0
+    is installed
+  steps:
+  - id: P1.T1.S1
+    text: |-
+      Verify the bridge daemon at `kali/scripts/vk-issue-bridge.py`
+      imports from `vk` (specifically `vk.bridge.tick` and
+      `vk.bridge.discover_plans`). This work depends on the earlier
+      plan `2026-05-12-bridge-vk-library-integration` in this repo
+      having shipped — see `docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/`.
+
+      ```
+      grep -n "from vk" kali/scripts/vk-issue-bridge.py
+      ```
+
+      Expected output (after the bridge-vk-library-integration plan
+      ships):
+
+      ```
+      from vk.bridge import discover_plans, tick
+      from vk.ghclient import GhClient
+      from vk.real_ghclient import RealGhClient
+      ```
+
+      If those imports are absent, STOP. The bridge-vk-library-integration
+      plan must complete first. Communicate this to the operator and
+      do not proceed with Plan 2's steps until the prerequisite ships.
+  - id: P1.T1.S2
+    text: |-
+      Verify `vk` 2.2.0 (or higher) is installed in the bridge's
+      Python environment.
+
+      ```
+      grep "vk" pyproject.toml || true
+      grep -n "vk[>=]" kali/scripts/*.py 2>/dev/null | head -5
+      ```
+
+      Look for the dependency declaration — likely in a Dockerfile
+      (search the existing bridge-vk-library-integration plan's
+      phases for the exact location). Edit that declaration to
+      require `vk>=2.2.0,<3.0.0` (was `>=2.1.0,<3.0.0` in the
+      sibling plan's phase 1).
+
+      Then exercise the imports:
+
+      ```
+      python -c "from vk.spec import dispatch, SpecValidationError; from vk.bridge import discover_specs; print('ok')"
+      ```
+
+      Expected: prints `ok`. Any ImportError means the install
+      didn't pick up 2.2.0 — re-run the install in the bridge env.
+- number: 2
+  title: Add spec dispatch loop to the bridge's main cron caller
+  steps:
+  - id: P1.T2.S1
+    text: |-
+      Locate the cron caller entry point in
+      `kali/scripts/vk-issue-bridge.py`. Look for:
+
+      ```
+      grep -n "def main\|discover_plans\|tick(plan" kali/scripts/vk-issue-bridge.py
+      ```
+
+      Identify the loop that processes plans per repo. After the
+      sibling plan's migration, this should look like:
+
+      ```python
+      for repo in discover_repos():
+          for plan in discover_plans(repo, gh):
+              result = tick(plan, gh, vk_mcp)
+              ...
+      ```
+
+      We will add a **spec** loop placed BEFORE the plans loop
+      within the same per-repo iteration, per spec §5.2.
+  - id: P1.T2.S2
+    text: |-
+      Write a failing test for the spec dispatch behaviour in
+      `kali/tests/test_vk_issue_bridge.py`.
+
+      Add a test `test_main_loop_runs_spec_dispatch_before_plan_tick`
+      that:
+
+      - Monkeypatches `discover_repos` to return `["repo-a"]`.
+      - Monkeypatches `vk.bridge.discover_specs("derio-net/repo-a")` to
+        return a single fixture `SpecMeta` (build with `parse_spec`
+        against a tmp_path fixture spec containing one root plan).
+      - Monkeypatches `vk.spec.dispatch` to record calls into a list
+        and return a `SpecDispatchResult` with `dispatched=1`.
+      - Monkeypatches `discover_plans` to return the freshly-dispatched
+        plan (simulating the same-tick handoff).
+      - Monkeypatches `tick` to record calls into a list.
+      - Calls `main()` (or the per-tick function it wraps).
+
+      Assertions:
+
+      - `dispatch` was called once, before any `tick` call.
+      - `tick` was called once with the dispatched plan.
+      - The call order: `dispatch` → `tick` for the same repo.
+
+      Run: `uv run pytest kali/tests/test_vk_issue_bridge.py -x -q`
+      Expect: red — the spec dispatch loop doesn't exist yet.
+  - id: P1.T2.S3
+    text: |-
+      Add the spec dispatch loop in
+      `kali/scripts/vk-issue-bridge.py::main()` (or whichever
+      function processes per-repo).
+
+      Import additions at the top of the file (after the existing
+      `from vk.bridge import discover_plans, tick`):
+
+      ```python
+      from vk.bridge import discover_specs
+      from vk.spec import dispatch as spec_dispatch, SpecValidationError
+      ```
+
+      Inside the per-repo loop, BEFORE the existing plan loop:
+
+      ```python
+      for spec_meta in discover_specs(f"derio-net/{repo_name}"):
+          try:
+              spec_result = spec_dispatch(
+                  spec_meta, gh,
+                  yes=True,
+                  repo_root=_repo_checkout_root(f"derio-net/{repo_name}"),
+              )
+              accumulate_spec(spec_result)
+          except SpecValidationError as e:
+              log(f"[warn] bridge: spec {spec_meta.path} validation: {e}")
+          except Exception as e:
+              log(f"[error] bridge: dispatch raised on {spec_meta.path}: {e}")
+              accumulate_spec_failure(str(spec_meta.path), str(e))
+      ```
+
+      `accumulate_spec` and `accumulate_spec_failure` are added in
+      the next task. For now, stub them as no-ops to make the test
+      from S2 pass.
+
+      Re-run the test. Expect: green.
+- number: 3
+  title: SpecDispatchSummary accumulator + structured logging
+  steps:
+  - id: P1.T3.S1
+    text: |-
+      Write a test for the per-tick summary aggregator.
+
+      Add `test_spec_dispatch_summary_accumulates` to
+      `kali/tests/test_vk_issue_bridge.py`:
+
+      ```python
+      def test_spec_dispatch_summary_accumulates():
+          from vk_issue_bridge import SpecDispatchSummary, accumulate_spec
+          summary = SpecDispatchSummary()
+          # Build two fake SpecDispatchResult objects with mixed
+          # outcomes (some dispatched, some blocked, some failures).
+          # Call accumulate_spec(summary, result_a); accumulate_spec(summary, result_b).
+          # Assert summary fields match the totals.
+          ...
+      ```
+
+      Run pytest. Expect: red — `SpecDispatchSummary` and
+      `accumulate_spec` don't exist.
+  - id: P1.T3.S2
+    text: |-
+      Add `SpecDispatchSummary` dataclass + accumulator function to
+      `kali/scripts/vk-issue-bridge.py`. Place near other dataclasses.
+
+      ```python
+      @dataclass
+      class SpecDispatchSummary:
+          specs_walked: int = 0
+          plans_dispatched: int = 0
+          plans_already_dispatched: int = 0
+          plans_blocked: int = 0
+          errors: int = 0
+          failures: list[str] = field(default_factory=list)
+
+
+      def accumulate_spec(summary: SpecDispatchSummary,
+                          result: "SpecDispatchResult") -> None:
+          summary.specs_walked += 1
+          summary.plans_dispatched += result.dispatched
+          summary.plans_already_dispatched += result.already_dispatched
+          summary.plans_blocked += result.blocked
+          summary.errors += result.errors
+          summary.failures.extend(result.failures)
+
+
+      def accumulate_spec_failure(summary: SpecDispatchSummary,
+                                  spec_path: str, err: str) -> None:
+          summary.specs_walked += 1
+          summary.errors += 1
+          summary.failures.append(f"{spec_path}: {err}")
+      ```
+
+      Replace the stub calls in the main loop (T2.S3) with the real
+      ones, threading a `summary = SpecDispatchSummary()` through
+      the per-tick scope.
+
+      At the end of each tick, log:
+
+      ```python
+      log(f"[bridge] spec dispatch: walked={summary.specs_walked} "
+          f"dispatched={summary.plans_dispatched} "
+          f"already={summary.plans_already_dispatched} "
+          f"blocked={summary.plans_blocked} errors={summary.errors}")
+      for f in summary.failures:
+          log(f"[bridge] spec dispatch failure: {f}")
+      ```
+
+      Re-run tests. Expect green.
+- number: 4
+  title: Same-tick spec→plan handoff integration test
+  steps:
+  - id: P1.T4.S1
+    text: |-
+      Build an end-to-end test that exercises the full same-tick
+      handoff: spec dispatch creates a plan's issues, the SAME
+      iteration's `discover_plans` picks the plan up, and `tick`
+      syncs it to the VK board.
+
+      Append `test_same_tick_handoff_spec_to_plan_to_vk` to
+      `kali/tests/test_vk_issue_bridge.py`:
+
+      Setup:
+
+      - Tmp dir with a fixture spec that declares one root plan
+        (same-repo, target_repo equals the test repo).
+      - A `FakeGhClient` from the vk library tests (or a local
+        fake) seeded with no existing issues for the plan's phases.
+      - A `FakeVkMcpClient` that records `create_card` calls.
+      - Monkeypatch `discover_repos` → `["repo-a"]`.
+      - Monkeypatch `_repo_checkout_root` → the tmp dir.
+      - Place the plan folder under
+        `<tmp>/docs/superpowers/plans/<slug>/` and the spec under
+        `<tmp>/docs/superpowers/specs/<spec>.md`.
+
+      Run one tick (call the per-repo function once).
+
+      Assertions:
+
+      - The `FakeGhClient.create_issue_calls` list contains issue
+        creates for every phase of the plan (means `vk.spec.dispatch`
+        successfully ran).
+      - The `FakeVkMcpClient.create_card_calls` list contains a
+        card for the same plan's phases (means `discover_plans`
+        picked the plan up post-dispatch and `tick` synced it
+        — i.e., the spec-loop-before-plan-loop order works).
+      - The summary log line shows `dispatched=1`.
+
+      Run: `uv run pytest kali/tests/test_vk_issue_bridge.py::test_same_tick_handoff_spec_to_plan_to_vk -x -q`
+      Expect: green (if the implementation from T2/T3 is correct).
+      If red, debug the order/integration issue surfaced.
+- number: 5
+  title: Quality gates + open PR
+  steps:
+  - id: P1.T5.S1
+    text: |-
+      Run the bridge test suite and any agent-images-wide gates:
+
+      ```
+      uv run pytest kali/tests/ -x -q
+      python -m py_compile kali/scripts/vk-issue-bridge.py
+      ```
+
+      Verify there's no regression in existing bridge tests
+      (`test_guardrails_hook.py`, `test_vk_mcp_client.py`,
+      `test_wrap_claude.py`). The cron caller change should be
+      additive.
+  - id: P1.T5.S2
+    text: |-
+      Open the PR for Phase C.
+
+      ```
+      git checkout -b feat/spec-dispatch-bridge
+      git add kali/scripts/vk-issue-bridge.py kali/tests/test_vk_issue_bridge.py \
+              <any Dockerfile/pyproject.toml touched for the vk dep bump>
+      git status
+      git commit -m "feat(bridge): spec-level dispatch loop in cron caller
+
+      Adds vk.bridge.discover_specs + vk.spec.dispatch invocation to
+      the cron caller's per-repo iteration, placed before the existing
+      plan-tick loop so same-tick spec→plan handoff works (see
+      superpowers-for-vk spec §5.2). Bumps vk dep to >=2.2.0,<3.0.0
+      in whichever environment file declares it.
+
+      Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+      git push -u origin feat/spec-dispatch-bridge
+      gh pr create --title "feat(bridge): spec-level dispatch loop (phase C)" \
+                   --body "Phase C of spec-dispatch (see superpowers-for-vk docs/superpowers/specs/2026-05-13-spec-dispatch-design.md §7.1 Phase C). Depends on superpowers-for-vk 2.2.0 being installed in the bridge env."
+      ```
+
+      Wait for CI green. After merge, the bridge starts
+      auto-advancing the DAG for every spec across all managed
+      repos.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T4.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T5.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T5.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-14-spec-dispatch-bridge/01.yaml
+++ b/docs/superpowers/plans/2026-05-14-spec-dispatch-bridge/01.yaml
@@ -13,51 +13,60 @@ tasks:
   - id: P1.T1.S1
     text: |-
       Verify the bridge daemon at `kali/scripts/vk-issue-bridge.py`
-      imports from `vk` (specifically `vk.bridge.tick` and
-      `vk.bridge.discover_plans`). This work depends on the earlier
-      plan `2026-05-12-bridge-vk-library-integration` in this repo
-      having shipped — see `docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/`.
+      imports from `vk`. This work depends on the earlier plan
+      `2026-05-12-bridge-vk-library-integration` having shipped — and
+      it has (closed 2026-05-15 in commit `dbcbc70`).
 
       ```
-      grep -n "from vk" kali/scripts/vk-issue-bridge.py
+      grep -n "from vk\|vk_bridge" kali/scripts/vk-issue-bridge.py
       ```
 
-      Expected output (after the bridge-vk-library-integration plan
-      ships):
+      Expected (the migrated bridge uses an aliased module import plus
+      module-level aliases for the two functions it calls):
 
       ```
-      from vk.bridge import discover_plans, tick
-      from vk.ghclient import GhClient
+      from vk import bridge as vk_bridge
       from vk.real_ghclient import RealGhClient
+      _DISCOVER_PLANS = vk_bridge.discover_plans
+      _TICK = vk_bridge.tick
       ```
 
       If those imports are absent, STOP. The bridge-vk-library-integration
-      plan must complete first. Communicate this to the operator and
-      do not proceed with Plan 2's steps until the prerequisite ships.
+      plan must complete first. Communicate this to the operator and do
+      not proceed with Plan 2's steps until the prerequisite ships.
   - id: P1.T1.S2
     text: |-
       Verify `vk` 2.2.0 (or higher) is installed in the bridge's
       Python environment.
 
-      ```
-      grep "vk" pyproject.toml || true
-      grep -n "vk[>=]" kali/scripts/*.py 2>/dev/null | head -5
-      ```
-
-      Look for the dependency declaration — likely in a Dockerfile
-      (search the existing bridge-vk-library-integration plan's
-      phases for the exact location). Edit that declaration to
-      require `vk>=2.2.0,<3.0.0` (was `>=2.1.0,<3.0.0` in the
-      sibling plan's phase 1).
-
-      Then exercise the imports:
+      The bridge installs vk via a git-tag-pinned `pip install` in
+      `base/Dockerfile`. Locate the line:
 
       ```
-      python -c "from vk.spec import dispatch, SpecValidationError; from vk.bridge import discover_specs; print('ok')"
+      grep -n "superpowers-for-vk@v" base/Dockerfile
       ```
 
-      Expected: prints `ok`. Any ImportError means the install
-      didn't pick up 2.2.0 — re-run the install in the bridge env.
+      Expected (pre-bump):
+
+      ```
+      'vk @ git+https://github.com/derio-net/superpowers-for-vk@v2.1.4'
+      ```
+
+      Bump the tag from `@v2.1.4` to `@v2.2.0`. Use the Edit tool to
+      modify just that one git-tag suffix in `base/Dockerfile`. Do not
+      change the install mechanics (venv path, no-cache-dir, etc.) —
+      only the tag.
+
+      To verify the bumped install works inside the rebuilt image,
+      exercise the new imports:
+
+      ```
+      /opt/vk-bridge-venv/bin/python -c "from vk.spec import dispatch, SpecValidationError; from vk import bridge as vk_bridge; print(vk_bridge.discover_specs)"
+      ```
+
+      Expected: prints `<function discover_specs at 0x…>`. Any
+      ImportError means the install didn't pick up 2.2.0 — rebuild the
+      base image or re-run the venv install.
 - number: 2
   title: Add spec dispatch loop to the bridge's main cron caller
   steps:
@@ -115,35 +124,45 @@ tasks:
       `kali/scripts/vk-issue-bridge.py::main()` (or whichever
       function processes per-repo).
 
-      Import additions at the top of the file (after the existing
-      `from vk.bridge import discover_plans, tick`):
+      The bridge already imports `vk` aliased (line 24:
+      `from vk import bridge as vk_bridge`) and pre-binds the two
+      functions it uses (lines 30-31: `_DISCOVER_PLANS = vk_bridge.discover_plans`,
+      `_TICK = vk_bridge.tick`). **Match this style.** Add one new
+      module-level binding plus the spec import near those existing
+      lines:
 
       ```python
-      from vk.bridge import discover_specs
-      from vk.spec import dispatch as spec_dispatch, SpecValidationError
+      from vk import spec as vk_spec    # new: paired with `from vk import bridge as vk_bridge`
+      _DISCOVER_SPECS = vk_bridge.discover_specs
+      _SPEC_DISPATCH = vk_spec.dispatch
+      _SPEC_VALIDATION_ERROR = vk_spec.SpecValidationError
       ```
 
       Inside the per-repo loop, BEFORE the existing plan loop:
 
       ```python
-      for spec_meta in discover_specs(f"derio-net/{repo_name}"):
+      for spec_meta in _DISCOVER_SPECS(f"derio-net/{repo_name}"):
           try:
-              spec_result = spec_dispatch(
+              spec_result = _SPEC_DISPATCH(
                   spec_meta, gh,
                   yes=True,
                   repo_root=_repo_checkout_root(f"derio-net/{repo_name}"),
               )
-              accumulate_spec(spec_result)
-          except SpecValidationError as e:
+              accumulate_spec(summary, spec_result)
+          except _SPEC_VALIDATION_ERROR as e:
               log(f"[warn] bridge: spec {spec_meta.path} validation: {e}")
-          except Exception as e:
+          except Exception as e:  # noqa: BLE001 — bridge keeps running
               log(f"[error] bridge: dispatch raised on {spec_meta.path}: {e}")
-              accumulate_spec_failure(str(spec_meta.path), str(e))
+              accumulate_spec_failure(summary, str(spec_meta.path), str(e))
       ```
 
       `accumulate_spec` and `accumulate_spec_failure` are added in
-      the next task. For now, stub them as no-ops to make the test
-      from S2 pass.
+      the next task with `summary` as their first positional arg. For
+      now stub them as `def accumulate_spec(s, r): pass` etc. so the
+      test from S2 passes.
+
+      `_repo_checkout_root` already exists in the bridge module from
+      the earlier vk-library integration — reuse it.
 
       Re-run the test. Expect: green.
 - number: 3

--- a/docs/superpowers/plans/2026-05-14-spec-dispatch-bridge/_meta.yaml
+++ b/docs/superpowers/plans/2026-05-14-spec-dispatch-bridge/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-05-14-spec-dispatch-bridge
+spec: docs/superpowers/specs/2026-05-13-spec-dispatch-design.md
+target_repo: derio-net/agent-images
+vk_version: '>=2.0.0,<3.0.0'
+created: '2026-05-14'

--- a/docs/superpowers/plans/2026-05-14-spec-dispatch-bridge/_prose.md
+++ b/docs/superpowers/plans/2026-05-14-spec-dispatch-bridge/_prose.md
@@ -1,0 +1,87 @@
+# Plan — spec-dispatch-bridge (agent-images)
+
+## What this plan delivers
+
+The bridge cron caller change that makes the live VK bridge auto-advance
+spec-level plan DAGs every tick. Sibling plan to
+`2026-05-14-spec-dispatch` in superpowers-for-vk; together they implement
+the spec at
+`docs/superpowers/specs/2026-05-13-spec-dispatch-design.md` (which lives
+in superpowers-for-vk).
+
+Single phase, one PR — adds a `vk.bridge.discover_specs(repo)` →
+`vk.spec.dispatch(spec, gh)` loop to the per-repo iteration in
+`kali/scripts/vk-issue-bridge.py::main()`, placed BEFORE the existing
+plan-tick loop so same-tick spec→plan handoff works (the spec dispatches
+a plan's issues; the same iteration's `discover_plans` picks them up).
+
+## Success criteria
+
+After this plan ships:
+
+- The bridge cron tick logs a `[bridge] spec dispatch: walked=… dispatched=…
+  already=… blocked=… errors=…` summary line per tick.
+- A spec whose root plan was complete on the previous tick gets its
+  downstream plans dispatched on the next tick (issues created in the
+  correct target repos via `gh issue create --repo <X>`).
+- A spec whose Depends-on grammar is invalid logs a warning and the
+  bridge continues to other specs / plans without crashing.
+- A spec whose cross-repo plan files 404 logs the failure into the
+  summary's `failures` list; the rest of the tick continues.
+- Existing bridge behaviour (per-plan tick, vk-ready → vk-synced
+  projection, MCP card sync) is unchanged.
+
+## Prerequisites (load-bearing)
+
+This plan **depends on two upstream artifacts** that are not in this
+spec's table because they live elsewhere:
+
+1. **`2026-05-12-bridge-vk-library-integration` plan** (this repo,
+   `docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/`).
+   Migrates the bridge daemon to use `vk.bridge.tick` and
+   `vk.bridge.discover_plans`. Today the bridge imports nothing from
+   the `vk` package — it does its own gh subprocess wrapping. The first
+   task in this plan (`P1.T1`) explicitly checks the migration has
+   happened; if not, the agent STOPS and reports to the operator.
+
+2. **superpowers-for-vk v2.2.0 installed in the bridge env.** The
+   sibling plan `2026-05-14-spec-dispatch` releases v2.2.0 with the
+   new `vk.spec.dispatch`, `vk.bridge.discover_specs`, and
+   `GhClient.read_repo_file` surfaces this plan uses. The spec
+   table's `Depends on` column for this plan therefore lists
+   `2026-05-14-spec-dispatch`.
+
+Both prerequisites must be live before any code work in this plan
+begins. The first task validates them with grep + a short import smoke
+test.
+
+## What this plan does NOT deliver
+
+- The library and CLI surface (lives in the sibling plan
+  `2026-05-14-spec-dispatch`).
+- A bridge-side cache for cross-repo gh contents reads. The spec §2.3
+  deferred this until quota becomes real; no caching in v1.
+- Replacement of the bridge daemon's own gh subprocess wrappers with
+  `GhClient`. Out of scope — that work belongs to the
+  `bridge-vk-library-integration` plan above.
+
+## Sequencing within agent-images
+
+Single phase. The 5 tasks proceed top-to-bottom:
+
+1. Verify prerequisites (no code changes).
+2. Add the spec dispatch loop to the main per-repo iteration, with a
+   failing test gating each step.
+3. Add the `SpecDispatchSummary` accumulator and structured logging.
+4. End-to-end integration test for the same-tick handoff.
+5. Quality gates + PR.
+
+## Cross-cutting principles preserved
+
+- **No new state files in the bridge.** The summary lives in memory
+  per tick; no `.bridge_state.json` or similar.
+- **Fail-loud, isolate per spec.** A `SpecValidationError` from any
+  one spec logs a warning and doesn't abort the loop; other specs
+  and the plan-tick layer continue.
+- **Shared primitive.** The bridge calls the same `vk.spec.dispatch()`
+  function `vk spec apply` calls — no bridge-specific wrapper.

--- a/docs/superpowers/plans/2026-05-14-spec-dispatch-bridge/_prose.md
+++ b/docs/superpowers/plans/2026-05-14-spec-dispatch-bridge/_prose.md
@@ -31,24 +31,25 @@ After this plan ships:
 - Existing bridge behaviour (per-plan tick, vk-ready → vk-synced
   projection, MCP card sync) is unchanged.
 
-## Prerequisites (load-bearing)
+## Prerequisites
 
 This plan **depends on two upstream artifacts** that are not in this
 spec's table because they live elsewhere:
 
-1. **`2026-05-12-bridge-vk-library-integration` plan** (this repo,
-   `docs/superpowers/plans/2026-05-12-bridge-vk-library-integration/`).
-   Migrates the bridge daemon to use `vk.bridge.tick` and
-   `vk.bridge.discover_plans`. Today the bridge imports nothing from
-   the `vk` package — it does its own gh subprocess wrapping. The first
-   task in this plan (`P1.T1`) explicitly checks the migration has
-   happened; if not, the agent STOPS and reports to the operator.
+1. **`2026-05-12-bridge-vk-library-integration` plan** (this repo).
+   ✅ **Shipped** — Phase 3 closed 2026-05-15 in commit `dbcbc70`.
+   The bridge daemon now imports `from vk import bridge as vk_bridge`
+   and pre-binds `_DISCOVER_PLANS`/`_TICK` at module scope (see
+   `kali/scripts/vk-issue-bridge.py:24-31`). `P1.T1.S1` of this plan
+   re-greps to confirm before proceeding.
 
-2. **superpowers-for-vk v2.2.0 installed in the bridge env.** The
-   sibling plan `2026-05-14-spec-dispatch` releases v2.2.0 with the
-   new `vk.spec.dispatch`, `vk.bridge.discover_specs`, and
-   `GhClient.read_repo_file` surfaces this plan uses. The spec
-   table's `Depends on` column for this plan therefore lists
+2. **superpowers-for-vk v2.2.0 installed in the bridge env.**
+   ⏳ **Pending** — sibling plan `2026-05-14-spec-dispatch` (in
+   `derio-net/superpowers-for-vk`) ships v2.2.0 with `vk.spec.dispatch`,
+   `vk.bridge.discover_specs`, and `GhClient.read_repo_file`. The
+   bridge env's current `vk` install is `git+...@v2.1.4` per
+   `base/Dockerfile`; `P1.T1.S2` bumps the tag to `@v2.2.0`. The spec
+   table's `Depends on` column for this plan lists
    `2026-05-14-spec-dispatch`.
 
 Both prerequisites must be live before any code work in this plan


### PR DESCRIPTION
## Summary

Sibling plan to [`derio-net/superpowers-for-vk#131`](https://github.com/derio-net/superpowers-for-vk/pull/131). Scaffolds Plan 2 (`docs/superpowers/plans/2026-05-14-spec-dispatch-bridge/`) for the bridge cron caller integration described in superpowers-for-vk's spec §5.2 / §7.1 Phase C.

- One phase, 5 tasks, 10 steps.
- Adds `vk.bridge.discover_specs` + `vk.spec.dispatch` loop to `kali/scripts/vk-issue-bridge.py`'s main per-repo iteration, placed **before** the existing plan-tick loop so same-tick spec→plan handoff works.
- Adds `SpecDispatchSummary` accumulator + structured logging.
- Includes an end-to-end integration test for the same-tick handoff.

## Prerequisites (already satisfied on main)

- ✅ `2026-05-12-bridge-vk-library-integration` plan shipped (commit `dbcbc70` closed Phase 3 on 2026-05-15). Bridge now imports `from vk import bridge as vk_bridge`. Plan 2's `P1.T1.S1` grep check passes naturally.
- ⏳ superpowers-for-vk v2.2.0 — not yet released. The plan's `P1.T1.S2` bumps the bridge env's `vk` constraint to `>=2.2.0,<3.0.0`. Plan 1 Phase 2 (in PR #131's rollout) ships v2.2.0.

## Test plan

- [x] `vk plan self-review docs/superpowers/plans/2026-05-14-spec-dispatch-bridge/` — passes
- [ ] **Review:** scan Plan 2 phase steps for accuracy against the live bridge structure
- [ ] **Hold for execution** until superpowers-for-vk Plan 1 Phase 2 merges and v2.2.0 is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)