### PR TITLE
docs(plan): v2 bridge cutover — sibling for derio-net/superpowers-for-vk#147

### DIFF
--- a/docs/superpowers/plans/2026-05-17-v2-bridge-cutover/01.yaml
+++ b/docs/superpowers/plans/2026-05-17-v2-bridge-cutover/01.yaml
@@ -1,0 +1,261 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Cutover — delete fat bridge, bump pin, point cron at wrapper, smoke test
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Pre-flight — confirm v2.2.0 is published
+  steps:
+  - id: P1.T1.S1
+    text: |-
+      Confirm `derio-net/superpowers-for-vk` has tagged v2.2.0:
+      ```
+      git ls-remote --tags https://github.com/derio-net/superpowers-for-vk.git \
+        | grep -E 'refs/tags/v2\.2\.0'
+      ```
+      If empty, STOP. Do not proceed. The cross-repo plan
+      (`2026-05-17-v2-bridge-rebuild`) must merge its Phase 6 first.
+
+      If present, capture the SHA for the commit message later:
+      ```
+      VK_VERSION_TAG=v2.2.0
+      VK_VERSION_SHA=$(git ls-remote --tags https://github.com/derio-net/superpowers-for-vk.git $VK_VERSION_TAG | awk '{print $1}')
+      echo "$VK_VERSION_SHA"
+      ```
+  - id: P1.T1.S2
+    text: |-
+      Smoke-test the wrapper logic locally before touching the image.
+
+      In a throwaway venv:
+      ```
+      python3 -m venv /tmp/vk-test
+      /tmp/vk-test/bin/pip install --no-cache-dir \
+          'vk @ git+https://github.com/derio-net/superpowers-for-vk@v2.2.0'
+      /tmp/vk-test/bin/python -m vk.bridge --dry-run
+      ```
+
+      Expected output:
+      ```
+      [bridge] - v2.2.0 - YYYY-MM-DD HH:MM:SS UTC - tick
+      vk.bridge: dry-run complete
+      ```
+
+      Exit 0. If anything else happens, file an issue against
+      `derio-net/superpowers-for-vk` and STOP.
+
+      Clean up: `rm -rf /tmp/vk-test`.
+- number: 2
+  title: Bump Dockerfile pin + remove legacy bridge files
+  steps:
+  - id: P1.T2.S1
+    text: |-
+      Edit `kali/Dockerfile`. Find the venv install line (around line 55-60):
+      ```dockerfile
+      RUN python3 -m venv /opt/vk-bridge-venv \
+          && /opt/vk-bridge-venv/bin/pip install --no-cache-dir \
+              'vk @ git+https://github.com/derio-net/superpowers-for-vk@v2.1.4'
+      ```
+
+      Change the pin from `v2.1.4` → `v2.2.0`.
+
+      If the Dockerfile has a `COPY scripts/vk-issue-bridge.py` line, delete
+      it.
+      If it has a `COPY scripts/vk_mcp_client.py` line, delete it.
+
+      Check via:
+      ```
+      grep -nE 'vk-issue-bridge|vk_mcp_client' kali/Dockerfile
+      ```
+      Expect no matches after the edit.
+  - id: P1.T2.S2
+    text: |-
+      Delete the legacy bridge scripts:
+      ```
+      git rm kali/scripts/vk-issue-bridge.py
+      git rm kali/scripts/vk_mcp_client.py
+      ```
+
+      If `kali/scripts/__pycache__/` contains compiled artifacts for these
+      files, delete them too — but they should be `.gitignore`d already;
+      check `git status` to confirm nothing unexpected is staged.
+  - id: P1.T2.S3
+    text: |-
+      Relocate the meaningful bridge tests.
+
+      Audit `kali/tests/`:
+      ```
+      ls kali/tests/test_vk_issue_bridge* kali/tests/test_vk_bridge_* 2>/dev/null
+      ```
+
+      For each such file, decide:
+      - If the test is a UNIT test of bridge logic (parsing, dispatch
+        sequencing, label transitions): **delete it from agent-images**;
+        the equivalent assertion was already ported to
+        `superpowers-for-vk/tests/unit/test_bridge_*.py` during the
+        cross-repo rebuild (Phases 2-5).
+      - If the test is genuinely about CONTAINER behavior (Dockerfile
+        layout, file presence, environment): KEEP and refit to test the
+        new layout.
+
+      Result: probably 1-2 files kept (container-specific), the rest
+      deleted with `git rm`.
+- number: 3
+  title: Point cron at the wrapper installed by install.sh --install-bridge
+  steps:
+  - id: P1.T3.S1
+    text: |-
+      Edit `kali/config-templates/crontab.txt`. Find the current bridge
+      line:
+      ```
+      */2 * * * * /opt/vk-bridge-venv/bin/python /opt/scripts/vk-issue-bridge.py >> __AGENT_HOME__/.willikins-agent/vk-bridge.log 2>&1
+      ```
+
+      Replace with:
+      ```
+      */2 * * * * /opt/vk-bridge/run.sh >> __AGENT_HOME__/.willikins-agent/vk-bridge.log 2>&1
+      ```
+
+      Tick frequency stays `*/2 * * * *` — unchanged from current.
+      Supercronic supports a sixth field for sub-minute scheduling if
+      ever needed later; the spec leaves cadence alone.
+  - id: P1.T3.S2
+    text: |-
+      Wire `install.sh --install-bridge` into container init.
+
+      Find the container-init script that runs at startup (likely under
+      `kali/etc/cont-init.d/` or wherever supercronic / supervisord is
+      configured). Add an idempotent invocation:
+
+      ```bash
+      # Install the vk-bridge wrapper if missing or outdated.
+      if [ ! -x /opt/vk-bridge/run.sh ]; then
+          /opt/vk-bridge-venv/bin/vk-install --install-bridge \
+              || curl -sSL https://raw.githubusercontent.com/derio-net/superpowers-for-vk/v2.2.0/scripts/install.sh \
+                 | bash -s -- --install-bridge
+      fi
+      ```
+
+      (Exact invocation depends on what `install.sh` exposes — read the
+      v2.2.0 source if in doubt.)
+
+      Verify by grepping init scripts for the existing crontab seeding
+      line; the wrapper install belongs in the same script, before the
+      crontab line is copied.
+- number: 4
+  title: F3 smoke test + version-bump-equivalent + PR
+  steps:
+  - id: P1.T4.S1
+    text: |-
+      Add `kali/tests/test_bridge_smoke.py`:
+      ```python
+      """Phase 6 / F3 — Kali container smoke test for the rebuilt bridge."""
+      import subprocess
+      import pytest
+
+      IMAGE = "ghcr.io/derio-net/agent-images-kali:dev"  # adjust to your CI tag
+
+
+      @pytest.mark.smoke
+      def test_python_m_vk_bridge_dry_run_in_container():
+          """
+          GIVEN the kali Docker image just built
+          WHEN  invoking `docker run --rm <kali-image> python -m vk.bridge --dry-run`
+          THEN  the process exits 0
+          AND   stdout contains 'vk.bridge: dry-run complete'
+          """
+          result = subprocess.run(
+              ["docker", "run", "--rm", IMAGE,
+               "/opt/vk-bridge-venv/bin/python", "-m", "vk.bridge", "--dry-run"],
+              capture_output=True, text=True, timeout=60,
+          )
+          assert result.returncode == 0, f"stderr: {result.stderr}"
+          assert "vk.bridge: dry-run complete" in result.stdout
+          # First log line must be the version banner per spec G5.
+          first_line = result.stdout.splitlines()[0]
+          assert first_line.startswith("[bridge] - v2.2.0 - ")
+      ```
+
+      If the CI doesn't run smoke tests by default (marker-gated), confirm
+      the CI workflow runs `pytest -m smoke` against the freshly-built
+      image. If not, add a workflow step.
+  - id: P1.T4.S2
+    text: |-
+      Build the image locally (or trigger CI):
+      ```
+      docker build -t agent-images-kali:dev kali/
+      pytest kali/tests/test_bridge_smoke.py -m smoke -v
+      ```
+
+      Expect: GREEN. If red, debug — common causes:
+      - Wrapper missing → `install.sh --install-bridge` never ran in init
+      - Pin mismatch → the venv has an old vk
+      - `npx`/`vibe-kanban-mcp` missing — Dockerfile must install Node;
+        verify the existing Node install step is still in the image
+
+      Once green, commit + push.
+  - id: P1.T4.S3
+    text: |-
+      Open PR: `feat(kali): cut over to v2.2.0 bridge — delete fat
+      scripts, bump pin, smoke test (cross-repo cutover for
+      derio-net/superpowers-for-vk#147)`.
+
+      Body must include:
+      - Reference: `derio-net/superpowers-for-vk#147` (tracking) and
+        `derio-net/superpowers-for-vk#150` (spec PR).
+      - Reference: `derio-net/superpowers-for-vk@v2.2.0` (the tag this
+        Dockerfile pin now points at).
+      - Note that this PR completes the cross-repo cutover; from this
+        point on, all bridge changes happen in `derio-net/superpowers-
+        for-vk` only.
+      - Lists deleted files: `kali/scripts/vk-issue-bridge.py` (1089 LOC),
+        `kali/scripts/vk_mcp_client.py` (194 LOC), and any unit tests
+        that moved to `superpowers-for-vk/tests/`.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T4.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T4.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T4.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-05-17-v2-bridge-cutover/_meta.yaml
+++ b/docs/superpowers/plans/2026-05-17-v2-bridge-cutover/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-05-17-v2-bridge-cutover
+spec: derio-net/superpowers-for-vk:docs/superpowers/specs/2026-05-17-v2-bridge-rebuild-design.md
+target_repo: derio-net/agent-images
+vk_version: '>=2.0.0,<3.0.0'
+created: '2026-05-17'

--- a/docs/superpowers/plans/2026-05-17-v2-bridge-cutover/_prose.md
+++ b/docs/superpowers/plans/2026-05-17-v2-bridge-cutover/_prose.md
@@ -1,0 +1,60 @@
+# v2 bridge cutover — agent-images side
+
+**Spec (cross-repo):**
+`derio-net/superpowers-for-vk:docs/superpowers/specs/2026-05-17-v2-bridge-
+rebuild-design.md` (merged in
+[derio-net/superpowers-for-vk#150](https://github.com/derio-net/superpowers-for-vk/pull/150)).
+
+**Tracking issue:**
+[derio-net/superpowers-for-vk#147](https://github.com/derio-net/superpowers-for-vk/issues/147).
+
+## Cross-plan dependency
+
+This plan **cannot start** until
+`derio-net/superpowers-for-vk:docs/superpowers/plans/2026-05-17-v2-bridge-
+rebuild/` ships all six phases and the `v2.2.0` tag is published. Phase 6 of
+that plan is the gate.
+
+Operational check before starting:
+
+```bash
+git ls-remote --tags https://github.com/derio-net/superpowers-for-vk.git \
+  | grep -E 'refs/tags/v2\.2\.0'
+```
+
+If empty, this plan is blocked. Wait for the tag.
+
+## What this plan delivers
+
+One phase, four tasks. After this plan ships, the agent-images repo has:
+
+- **Deleted:** `kali/scripts/vk-issue-bridge.py` (1089 LOC) and
+  `kali/scripts/vk_mcp_client.py` (194 LOC).
+- **Modified:** `kali/Dockerfile` — venv install pin bumped from
+  `vk@v2.1.4` → `vk@v2.2.0`.
+- **Modified:** `kali/config-templates/crontab.txt` — bridge line points at
+  the wrapper installed by `vk install.sh --install-bridge`.
+- **Modified:** `kali/etc/cont-init.d/` (or wherever container init lives) —
+  invokes `install.sh --install-bridge` so the wrapper is present at
+  container start.
+- **Added:** `kali/tests/test_bridge_smoke.py` (F3) — `docker run` smoke
+  test for `python -m vk.bridge --dry-run`.
+
+PEP 668 venv pattern is unchanged. Node.js / npx / vibe-kanban still come
+from the container image. Only the Python bridge implementation moves.
+
+## Why single-phase
+
+The deletions, Dockerfile bump, crontab edit, and smoke test are tightly
+coupled. Splitting them would leave the image in a partially-broken state
+between PRs (e.g. legacy bridge deleted but cron still calls it). One PR is
+the safe atomic shape.
+
+## Out of scope
+
+- Changes to other kali scripts (audit, exercise, guardrails, push-heartbeat,
+  session-manager, wrap-claude) — unrelated.
+- Container init script overhaul. Touching it for `--install-bridge`
+  invocation only; broader refactor is a separate concern.
+- Pruning unused env vars from the kali Dockerfile (`VIBE_BACKEND_URL`,
+  `MAX_CONCURRENT`, etc. — those stay; the bridge still reads them).


### PR DESCRIPTION
## Summary

Single-phase cutover plan for the cross-repo v2 bridge rebuild specced at `derio-net/superpowers-for-vk:docs/superpowers/specs/2026-05-17-v2-bridge-rebuild-design.md`.

After this plan ships, `agent-images` has:

- **Deleted:** `kali/scripts/vk-issue-bridge.py` (1089 LOC) + `kali/scripts/vk_mcp_client.py` (194 LOC)
- **Modified:** `kali/Dockerfile` — venv install pin bumped `vk@v2.1.4` → `vk@v2.2.0`
- **Modified:** `kali/config-templates/crontab.txt` — bridge line points at the wrapper installed by `install.sh --install-bridge`
- **Modified:** container init — invokes `install.sh --install-bridge` so the wrapper is present at container start
- **Added:** `kali/tests/test_bridge_smoke.py` (spec capability F3) — `docker run` smoke test

PEP 668 venv pattern is unchanged. Node.js / npx / vibe-kanban still come from the container image. Only the Python bridge implementation moves to `vk.bridge.*`.

## Cross-plan dependency

**This plan cannot start until `derio-net/superpowers-for-vk` tags `v2.2.0`.** Task 1 pre-flight gate checks for the tag and refuses to proceed if missing. The Dockerfile pin in Task 2 references that exact tag.

Order:
1. `derio-net/superpowers-for-vk` ships its 6-phase rebuild plan (PR derio-net/superpowers-for-vk#151)
2. Phase 6 of that plan tags `v2.2.0`
3. This plan dispatches; cutover lands in one PR

## Refs

- Spec (cross-repo): [derio-net/superpowers-for-vk#150](https://github.com/derio-net/superpowers-for-vk/pull/150)
- Tracking (cross-repo): [derio-net/superpowers-for-vk#147](https://github.com/derio-net/superpowers-for-vk/issues/147)
- Sibling plan: [derio-net/superpowers-for-vk#151](https://github.com/derio-net/superpowers-for-vk/pull/151)

## Test plan

- [ ] Reviewer reads `_prose.md` for cross-plan dependency / pre-flight gate
- [ ] Reviewer spot-checks `01.yaml` Task 1 — pre-flight refuses to proceed without `v2.2.0` tag
- [ ] Reviewer confirms the smoke test in Task 4 covers the spec's F3 capability

🤖 Generated with [Claude Code](https://claude.com/claude-code)