### PR TITLE
chore(plan): writeback Phase 1 tracking_issue → #82

### DIFF
--- a/docs/superpowers/plans/2026-05-17-v2-bridge-cutover/01.yaml
+++ b/docs/superpowers/plans/2026-05-17-v2-bridge-cutover/01.yaml
@@ -4,7 +4,7 @@ phase:
   title: Cutover — delete fat bridge, bump pin, point cron at wrapper, smoke test
   tag: agentic
   depends_on: []
-  tracking_issue: null
+  tracking_issue: https://github.com/derio-net/agent-images/issues/82
 tasks:
 - number: 1
   title: Pre-flight — confirm v2.2.0 is published


### PR DESCRIPTION
## Summary

Writeback of \`tracking_issue: https://github.com/derio-net/agent-images/issues/82\` for Phase 1 of \`2026-05-17-v2-bridge-cutover\`. Set automatically by \`vk apply --yes\` on 2026-05-18 after the sfv-side cross-repo reachability gate fix (sfv#193) landed.

This unblocks the agent-images cutover dispatch.

## Background

The cutover plan was added 2026-05-17 to handle the cross-repo portion of the v2 bridge rebuild (deleting the fat bridge in agent-images, bumping the Dockerfile pin to v2.2.0, pointing cron at the new wrapper, smoke test). It couldn't be dispatched until two upstream pieces landed:

1. \`derio-net/superpowers-for-vk@v2.2.0\` tag (done via sfv PR #188 cutover merge)
2. The cross-repo reachability gate fix (sfv PR #193, merged today as v2.2.2)

## Urgency

Please merge ASAP — the bridge ticks every ~2 minutes and its checkout doesn't auto-refresh. Until this writeback lands on main + the operator pulls in the pod, the bridge could create duplicate Issues for the same phase. (Same shape of pattern that bit sfv #184/#185/#187/#189 earlier today; mitigation is just merge-fast.)

After merge: \`vk-ready\` on #82 → bridge dispatches the cutover workspace → agent does the work in agent-images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)