### PR TITLE
fix(plans): correct migrated plan metadata (target_repo, spec ref, vk_version)

### DIFF
--- a/docs/superpowers/archived-plans/2026-04-14-bridge-fail-loud-and-blocker-preamble/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-14-bridge-fail-loud-and-blocker-preamble/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-14-bridge-fail-loud-and-blocker-preamble
-spec: docs/superpowers/specs/2026-04-14-archive-and-unified-descriptions-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+spec: derio-net/superpowers-for-vk:docs/superpowers/specs/2026-04-14-archive-and-unified-descriptions-design.md
+target_repo: derio-net/agent-images
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-14'

--- a/docs/superpowers/archived-plans/2026-04-18-persistent-agent-reliability/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-18-persistent-agent-reliability/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-18-persistent-agent-reliability
 spec: docs/superpowers/specs/2026-04-18-persistent-agent-reliability-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/agent-images
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-18'

--- a/docs/superpowers/archived-plans/2026-04-20-parallel-dispatch-dag-bridge-audit/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-20-parallel-dispatch-dag-bridge-audit/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-20-parallel-dispatch-dag-bridge-audit
 spec: null
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/agent-images
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-20'

--- a/docs/superpowers/archived-plans/2026-04-22-silent-reconnect-phantoms/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-22-silent-reconnect-phantoms/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-22-silent-reconnect-phantoms
 spec: docs/superpowers/specs/2026-04-22-silent-reconnect-phantoms-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/agent-images
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-22'

--- a/docs/superpowers/archived-plans/2026-04-22-vk-bridge-warn-patterns/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-22-vk-bridge-warn-patterns/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-22-vk-bridge-warn-patterns
 spec: docs/superpowers/specs/2026-04-18-persistent-agent-reliability-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/agent-images
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-22'

--- a/docs/superpowers/archived-plans/2026-04-22-vk-local-memory-profile/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-22-vk-local-memory-profile/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-22-vk-local-memory-profile
 spec: docs/superpowers/specs/2026-04-18-persistent-agent-reliability-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/agent-images
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-22'

--- a/docs/superpowers/archived-plans/2026-04-23-bridge-robustness-fixes/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-23-bridge-robustness-fixes/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-23-bridge-robustness-fixes
 spec: null
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/agent-images
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-23'

--- a/docs/superpowers/archived-plans/2026-04-27--agents--restart-resilience/_meta.yaml
+++ b/docs/superpowers/archived-plans/2026-04-27--agents--restart-resilience/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-27--agents--restart-resilience
 spec: derio-net/frank:docs/superpowers/specs/2026-04-27--agents--restart-resilience-design.md
-target_repo: derio-net/superpowers-for-vk
-vk_version: '>=1.0.0,<3.0.0'
+target_repo: derio-net/agent-images
+vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-27'


### PR DESCRIPTION
All 8 archived plans carried `target_repo: derio-net/superpowers-for-vk` — a v1→v2 migration bug (the migrator defaulted to the plugin's own repo, fixed in superpowers-for-vk#247 / `vk 2.2.12`). Per ownership (plan + work live in agent-images: bridge code and agent-pod images), all → **`derio-net/agent-images`**.

Also:
- `2026-04-14-bridge-fail-loud-and-blocker-preamble`: `spec` used a local-form path to a file that actually lives in superpowers-for-vk → `vk apply`'s reachability gate would treat it as same-repo and flag the plan unreachable. Rewrote to the canonical cross-repo form `derio-net/superpowers-for-vk:docs/...` (notation gap tracked in superpowers-for-vk#248).
- Aligned all loose `vk_version: >=1.0.0,<3.0.0` → `>=2.0.0,<3.0.0`.

All 8 plans pass `vk plan self-review`. Found via the post-2.2.12 cross-repo scan; sibling to #245/#246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)