### PR TITLE
fix(kali): pin apt mirror to kali.download + capture stderr in bridge smoke test

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -235,7 +235,12 @@ jobs:
           # banner version must match the image's VK_BRIDGE_PIN — this is
           # what proves the init script reconciled to the pinned tag rather
           # than silently keeping a stale PVC install.
-          out=$(docker exec kali-smoke /home/claude/.local/bin/vk-bridge --dry-run)
+          # Capture stderr (2>&1): the v2 bridge (vk.bridge module) emits its
+          # banner + "dry-run complete" via logging, which goes to STDERR, not
+          # stdout. Without 2>&1 `out` is empty and the assertions below fail —
+          # this is what kept secure-agent-kali red on every build after the
+          # 2026-05-19 v2-bridge cutover.
+          out=$(docker exec kali-smoke /home/claude/.local/bin/vk-bridge --dry-run 2>&1)
           echo "$out"
           echo "$out" | head -1 | grep -qE '^\[bridge\] - v[0-9]+\.[0-9]+\.[0-9]+ - '
           echo "$out" | grep -q 'vk.bridge: dry-run complete'

--- a/kali/Dockerfile
+++ b/kali/Dockerfile
@@ -36,11 +36,17 @@ RUN sed -i "s|/home/agent|${AGENT_HOME}|g" /opt/sshd_config \
     && grep -q "${AGENT_HOME}" /opt/sshd_config
 
 # ── Kali archive + dist-upgrade (resolve bookworm→kali-rolling version conflicts) ──
+# Mirror: pin the official Cloudflare-backed CDN (kali.download), NOT the
+# http.kali.org redirector. http.kali.org round-robins to community mirrors
+# whose pool/ can lag their Packages index during fast rolling transitions
+# (e.g. the GCC-16 churn of 2026-05): the index advertises gcc-16-base
+# 16-20260322-1 but the .deb 404s, failing dist-upgrade. kali.download keeps
+# index↔pool consistent. See docs/runbooks/frank-gotchas (kali mirror skew).
 RUN apt-get update && apt-get install -y --no-install-recommends \
       lsb-release wget gnupg \
     && wget -qO - https://archive.kali.org/archive-key.asc \
       | gpg --dearmor -o /usr/share/keyrings/kali-archive-keyring.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/kali-archive-keyring.gpg] https://http.kali.org/kali kali-rolling main non-free contrib" \
+    && echo "deb [signed-by=/usr/share/keyrings/kali-archive-keyring.gpg] https://kali.download/kali kali-rolling main non-free contrib" \
       > /etc/apt/sources.list.d/kali.list \
     && apt-get update \
     && apt-get dist-upgrade -y \


### PR DESCRIPTION
## Why

`secure-agent-kali` has failed to publish a green build from `main` since the **2026-05-19 v2-bridge cutover**. The VK_BRIDGE_PIN v2.2.13 bump (commit 8d37956) surfaced it again. Two independent root causes, both confirmed:

### 1. apt mirror index↔pool skew (build failure)
`dist-upgrade` 404'd on packages the `Packages` index advertised but the pool lacked (e.g. `gcc-16-base 16-20260322-1` during the GCC-16 rolling transition). Cause: the repo used the `http.kali.org` redirector, which round-robins to community mirrors whose `pool/` can lag their index.

**Verified:** the exact deb that 404'd on `http.kali.org` returns **200** on `kali.download`; a full `apt-get dist-upgrade --download-only` against `kali.download` fetched all 162 packages with zero 404s. → pinned the repo to the official CDN.

### 2. bridge smoke test captured stdout only (smoke-test failure)
The v2 `vk.bridge` module emits its banner + `dry-run complete` via logging (**stderr**), but the smoke test captured stdout only (`out=$(... --dry-run)`) → empty → assertions failed under `set -eo pipefail`.

**Verified locally** against v2.2.13: `python -m vk.bridge --dry-run` exits 0, **stdout empty, banner on stderr**. → added `2>&1` to the capture.

## Verification
Full workflow dispatched on this branch — **all jobs green**, including `build-children (secure-agent-kali)`, `smoke-test-secure-agent-kali`, and `dispatch-frank`. Run: https://github.com/derio-net/agent-images/actions/runs/26410214591

🤖 Generated with [Claude Code](https://claude.com/claude-code)