### PR TITLE
docs(spec): mark dynamic-repo-discovery superseded by v2 bridge rewrite

### DIFF
--- a/docs/superpowers/specs/2026-04-13-dynamic-repo-discovery-design.md
+++ b/docs/superpowers/specs/2026-04-13-dynamic-repo-discovery-design.md
@@ -1,7 +1,24 @@
 # Dynamic Repo Discovery for vk-issue-bridge
 
 **Date:** 2026-04-13
-**Status:** Approved
+**Status:** Superseded — implemented by the v2 bridge rewrite (2026-05-27)
+
+> **Superseded.** This design predates the v2 bridge rewrite. The flat
+> `scripts/vk-issue-bridge.py` (and its hardcoded `KNOWN_REPOS` list) was
+> deleted from this repo in the bridge cutover (PR #85,
+> `2026-05-17-v2-bridge-cutover`). Dynamic repo discovery is now implemented
+> in the `vk.bridge` library in `derio-net/superpowers-for-vk`:
+>
+> - **Discovery:** `src/vk/bridge/cli.py` `_configured_repos()` scans
+>   `~/repos` for directories containing `.git` (sorted), with a
+>   `VK_BRIDGE_REPOS` env override for non-default checkout layouts.
+> - **Test:** `tests/unit/test_vk_bridge_discover.py`.
+> - **Observability:** `cli.py` logs `[bridge] configured repos: N found at …`
+>   each tick.
+>
+> All three deliverables below (discovery function, unit test, log line) are
+> satisfied, and the bridge is now PVC-resident (`uv tool install`), so adding
+> a repo never requires an image rebuild. No agent-images plan is needed.
 
 ## Problem
 


### PR DESCRIPTION
## Summary

The `2026-04-13-dynamic-repo-discovery-design` spec is **already implemented** — by the v2 bridge rewrite, not by a plan tracked against it. Marking it `Superseded` with pointers to the live implementation.

## Why no plan

The spec targeted `scripts/vk-issue-bridge.py` + its hardcoded `KNOWN_REPOS` list. That file was **deleted from this repo** in the v2 bridge cutover (#85, `2026-05-17-v2-bridge-cutover`). The bridge now lives in the `vk.bridge` library in `derio-net/superpowers-for-vk`, where every deliverable the spec asked for exists:

| Spec deliverable | Implementation (superpowers-for-vk) |
|---|---|
| `discover_repos()` scanning `~/repos` for git dirs | `src/vk/bridge/cli.py` `_configured_repos()` (+ `VK_BRIDGE_REPOS` override) |
| Unit test (mixed git/non-git/files) | `tests/unit/test_vk_bridge_discover.py` |
| Observability log line | `cli.py` — `[bridge] configured repos: N found at …` |
| No image rebuild to add a repo | Bridge is now PVC-resident (`uv tool install`) |

## Effect

- Spec status `Approved` → `Superseded`, with an explanatory note block at the top.
- The `dynamic-repo-discovery` row in `vk spec status --all` stays `0/0` (intentionally — no plan), now correctly explained rather than looking like un-started work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)