### PR TITLE
fix(ruflo-server): repair RvfGridFSBucket GridFS shim for file uploads

### DIFF
--- a/docs/superpowers/specs/2026-04-13-dynamic-repo-discovery-design.md
+++ b/docs/superpowers/specs/2026-04-13-dynamic-repo-discovery-design.md
@@ -1,7 +1,24 @@
 # Dynamic Repo Discovery for vk-issue-bridge
 
 **Date:** 2026-04-13
-**Status:** Approved
+**Status:** Superseded — implemented by the v2 bridge rewrite (2026-05-27)
+
+> **Superseded.** This design predates the v2 bridge rewrite. The flat
+> `scripts/vk-issue-bridge.py` (and its hardcoded `KNOWN_REPOS` list) was
+> deleted from this repo in the bridge cutover (PR #85,
+> `2026-05-17-v2-bridge-cutover`). Dynamic repo discovery is now implemented
+> in the `vk.bridge` library in `derio-net/superpowers-for-vk`:
+>
+> - **Discovery:** `src/vk/bridge/cli.py` `_configured_repos()` scans
+>   `~/repos` for directories containing `.git` (sorted), with a
+>   `VK_BRIDGE_REPOS` env override for non-default checkout layouts.
+> - **Test:** `tests/unit/test_vk_bridge_discover.py`.
+> - **Observability:** `cli.py` logs `[bridge] configured repos: N found at …`
+>   each tick.
+>
+> All three deliverables below (discovery function, unit test, log line) are
+> satisfied, and the bridge is now PVC-resident (`uv tool install`), so adding
+> a repo never requires an image rebuild. No agent-images plan is needed.
 
 ## Problem
 


### PR DESCRIPTION
## Problem
Attaching an image (or tool-fetching a file by URL) in the Ruflo ChatUI 500s with `TypeError: upload.once is not a function`. ruvocal runs the RVF backend, whose `RvfGridFSBucket` only partially mimics Mongo's `GridFSBucket` — the chat-ui callers expect real streams/cursors.

## Fix
Patch `database/rvf.ts` so the shim honors the GridFS contract:
- `openUploadStream` → objectMode `Writable` (emits finish/error; coerces the `ArrayBuffer` `uploadFile.ts` casts to Buffer)
- `openDownloadStream` → `Readable.from`
- `find` → sync cursor with `next()` + `toArray()`

Fixes upload + read-back + copy-on-share in one file, **zero caller patches**. Bumps `RUFLO_GIT_REF` ca0a6fa→a6dd4ab (+154 upstream commits); the `wasm://` sed re-applies.

## Verification
- `git apply --check` passes against the pinned ref
- `node --test ruflo-server/test/rvf-gridfs-contract.test.mjs` — 3 tests pass
- All 5 call sites (uploadFile, downloadFile, conversation, share, export) compatible with the new shapes — no reliance on removed `.id`/`.toArray()`
- Build guards (`grep -q new Writable / Readable.from / next: async`) fail the build if the patch ever silently no-ops

Frank-side: derio-net/frank spec `2026-05-27--orch--ruflo-image-upload-fix-design`. Upstream PR to ruvnet/ruflo to follow.