### PR TITLE
fix(ruflo-server): repair RvfGridFSBucket GridFS shim for file uploads

### DIFF
--- a/ruflo-server/Dockerfile
+++ b/ruflo-server/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 # Pinned to ruvnet/ruflo SHA — bump deliberately when re-vendoring.
-ARG RUFLO_GIT_REF=ca0a6fa5cb1678b5c57c9289bc09a036f7308c61
+ARG RUFLO_GIT_REF=a6dd4ab3d527fbba3e7202741c9479315cc56a0b
 
 # --- source: shallow-clone the upstream repo at the pinned SHA. Single source
 #     of truth for both the builder and runtime stages so we never drift.
@@ -63,6 +63,30 @@ RUN sed -i \
       -e 's|const hostname = url\.hostname\.toLowerCase();|if (url.protocol === "wasm:") return true;\n\t\tconst hostname = url.hostname.toLowerCase();|' \
       ruflo/src/ruvocal/src/lib/server/urlSafety.ts \
  && grep -q 'protocol === "wasm:"' ruflo/src/ruvocal/src/lib/server/urlSafety.ts
+
+# Repair the RvfGridFSBucket GridFS shim so file upload/download/copy work
+# against the RVF backend.
+#
+# ruvocal is hardcoded to the RVF storage backend, whose RvfGridFSBucket only
+# *mimics* MongoDB's GridFSBucket API — incompletely. The Mongo-era chat-ui
+# callers expect real streams/cursors:
+#   - uploadFile.ts  : upload.once("finish"/"error", …)  → needs a Writable
+#                      (and passes an ArrayBuffer, which a default Writable
+#                      rejects — the objectMode shim coerces it)
+#   - downloadFile.ts: openDownloadStream(...).on("data"/"end"/"error")  → needs
+#                      a Readable; bucket.find(...).next()  → needs a sync cursor
+#   - conversation.ts: openDownloadStream(...).pipe(uploadStream)  → needs both
+# The upstream shim returns plain objects, so every file upload 500s with
+# `TypeError: upload.once is not a function` and reads/copies fail too. The patch
+# makes the shim faithfully honor the GridFS contract (real Writable via
+# objectMode, real Readable via Readable.from, sync find cursor). Verified to
+# apply cleanly at this pinned RUFLO_GIT_REF; the grep guards fail the build if
+# the patch silently no-ops after a future bump. Filed upstream as ruvnet/ruflo#TBD.
+COPY patches/rvf-gridfs-parity.patch /tmp/rvf-gridfs-parity.patch
+RUN git apply /tmp/rvf-gridfs-parity.patch \
+ && grep -q 'new Writable'  ruflo/src/ruvocal/src/lib/server/database/rvf.ts \
+ && grep -q 'Readable.from' ruflo/src/ruvocal/src/lib/server/database/rvf.ts \
+ && grep -q 'next: async'   ruflo/src/ruvocal/src/lib/server/database/rvf.ts
 
 # --- builder: mirrors upstream `builder` stage in src/ruvocal/Dockerfile.
 #     Full node:24 (not slim) for the Svelte build's native deps.

--- a/ruflo-server/patches/rvf-gridfs-parity.patch
+++ b/ruflo-server/patches/rvf-gridfs-parity.patch
@@ -1,0 +1,115 @@
+--- a/ruflo/src/ruvocal/src/lib/server/database/rvf.ts
++++ b/ruflo/src/ruvocal/src/lib/server/database/rvf.ts
+@@ -16,6 +16,7 @@
+ import { randomUUID } from "crypto";
+ import { readFileSync, writeFileSync, existsSync, mkdirSync } from "fs";
+ import { dirname } from "path";
++import { Readable, Writable } from "stream";
+ 
+ // ---------------------------------------------------------------------------
+ // ObjectId compatibility
+@@ -1022,41 +1023,52 @@
+ 		options?: { metadata?: Record<string, unknown>; contentType?: string }
+ 	) {
+ 		const id = randomUUID();
+-		const chunks: string[] = [];
+-
+-		return {
+-			id: new ObjectId(id),
+-			write(chunk: Buffer | string) {
+-				chunks.push(
+-					typeof chunk === "string" ? chunk : chunk.toString("base64")
+-				);
++		const chunks: Buffer[] = [];
++		const files = this.files;
++
++		// objectMode so callers may pass ArrayBuffer/Uint8Array/Buffer/string
++		// (uploadFile.ts hands us an ArrayBuffer cast to Buffer).
++		const stream = new Writable({
++			objectMode: true,
++			write(chunk, _enc, cb) {
++				try {
++					chunks.push(
++						typeof chunk === "string" ? Buffer.from(chunk) : Buffer.from(chunk as ArrayBufferLike)
++					);
++					cb();
++				} catch (e) {
++					cb(e as Error);
++				}
+ 			},
+-			end: async () => {
+-				const data = chunks.join("");
+-				this.files.set(id, {
+-					_id: id,
+-					filename,
+-					contentType: options?.contentType ?? "application/octet-stream",
+-					length: data.length,
+-					data,
+-					metadata: options?.metadata ?? {},
+-					createdAt: new Date(),
+-				});
+-				scheduleSave();
++			final(cb) {
++				try {
++					const data = Buffer.concat(chunks).toString("base64");
++					files.set(id, {
++						_id: id,
++						filename,
++						contentType: options?.contentType ?? "application/octet-stream",
++						length: data.length,
++						data,
++						metadata: options?.metadata ?? {},
++						createdAt: new Date(),
++					});
++					scheduleSave();
++					cb();
++				} catch (e) {
++					cb(e as Error);
++				}
+ 			},
+-		};
++		});
++		(stream as unknown as { id: ObjectId }).id = new ObjectId(id);
++		return stream;
+ 	}
+ 
+ 	openDownloadStream(id: ObjectId | string) {
+ 		const fileId = typeof id === "string" ? id : id.toString();
+-		const files = this.files;
+-		return {
+-			async toArray(): Promise<Buffer[]> {
+-				const file = files.get(fileId);
+-				if (!file) throw new Error("File not found");
+-				return [Buffer.from(file.data as string, "base64")];
+-			},
+-		};
++		const file = this.files.get(fileId);
++		return Readable.from(
++			file ? [Buffer.from(file.data as string, "base64")] : []
++		);
+ 	}
+ 
+ 	async delete(id: ObjectId | string) {
+@@ -1065,7 +1077,7 @@
+ 		scheduleSave();
+ 	}
+ 
+-	async find(filter: Record<string, unknown> = {}) {
++	find(filter: Record<string, unknown> = {}) {
+ 		const results: Record<string, unknown>[] = [];
+ 		for (const doc of this.files.values()) {
+ 			if (matchesFilter(doc, filter)) {
+@@ -1073,6 +1085,10 @@
+ 				results.push(meta);
+ 			}
+ 		}
+-		return { toArray: async () => results };
+-	}
+-}
++		let i = 0;
++		return {
++			next: async () => (i < results.length ? results[i++] : null),
++			toArray: async () => results,
++		};
++	}
++}

--- a/ruflo-server/test/rvf-gridfs-contract.test.mjs
+++ b/ruflo-server/test/rvf-gridfs-contract.test.mjs
@@ -1,0 +1,126 @@
+// Contract test for the patched RvfGridFSBucket GridFS shim.
+//
+// ruvocal's RVF backend ships an RvfGridFSBucket that mimics MongoDB's
+// GridFSBucket so the Mongo-era chat-ui callers compile. The upstream shim is
+// an incomplete mimic: openUploadStream returns a non-stream object,
+// openDownloadStream is not a Readable, and find() is async with no next() —
+// so uploadFile.ts (.once), downloadFile.ts (.on) and conversation.ts (.pipe)
+// all crash. This test pins the contract the callers actually require:
+//   - openUploadStream() -> Writable that accepts ArrayBuffer/Buffer/string,
+//     emits "finish"/"error", exposes .id
+//   - openDownloadStream() -> Readable emitting the stored bytes
+//   - find() -> SYNC cursor with next() and toArray()
+//   - base64 storage round-trips
+//
+// It mirrors the patched implementation (the patch lands in the vendored
+// ruflo source at build time, which is not present in this repo), so it doubles
+// as the executable spec for the upstream PR. Run: node --test ruflo-server/test/
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Readable, Writable } from "node:stream";
+
+function makeBucket() {
+	const files = new Map();
+	return {
+		openUploadStream(filename, options) {
+			const id = "id-" + files.size;
+			const chunks = [];
+			const s = new Writable({
+				objectMode: true,
+				write(chunk, _enc, cb) {
+					try {
+						chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : Buffer.from(chunk));
+						cb();
+					} catch (e) {
+						cb(e);
+					}
+				},
+				final(cb) {
+					try {
+						files.set(id, {
+							_id: id,
+							filename,
+							data: Buffer.concat(chunks).toString("base64"),
+							metadata: options?.metadata ?? {},
+						});
+						cb();
+					} catch (e) {
+						cb(e);
+					}
+				},
+			});
+			s.id = id;
+			return s;
+		},
+		openDownloadStream(id) {
+			const f = files.get(String(id));
+			return Readable.from(f ? [Buffer.from(f.data, "base64")] : []);
+		},
+		find(filter = {}) {
+			const r = [...files.values()]
+				.filter((d) => !filter.filename || d.filename === filter.filename)
+				.map(({ data, ...m }) => m);
+			let i = 0;
+			return { next: async () => (i < r.length ? r[i++] : null), toArray: async () => r };
+		},
+	};
+}
+
+function readBack(stream) {
+	return new Promise((resolve, reject) => {
+		const cs = [];
+		stream.on("data", (c) => cs.push(c));
+		stream.on("error", reject);
+		stream.on("end", () => resolve(Buffer.concat(cs)));
+	});
+}
+
+test("upload accepts an ArrayBuffer (uploadFile.ts pattern) and emits finish", async () => {
+	const b = makeBucket();
+	const bytes = Buffer.from("hello image");
+	const ab = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength); // ArrayBuffer
+	const up = b.openUploadStream("c-sha", { metadata: { conversation: "c" } });
+	up.write(ab); // upstream casts ArrayBuffer to Buffer; a default Writable would throw here
+	up.end();
+	await new Promise((res, rej) => {
+		up.once("finish", res);
+		up.once("error", rej);
+		setTimeout(() => rej(new Error("upload timed out")), 2000);
+	});
+
+	const meta = await b.find({ filename: "c-sha" }).next(); // sync cursor, no await on find
+	assert.equal(meta.filename, "c-sha");
+
+	const out = await readBack(b.openDownloadStream(meta._id)); // Readable, .on("data")
+	assert.equal(out.toString(), "hello image");
+});
+
+test("pipe copy round-trips (conversation.ts fork-from-shared pattern)", async () => {
+	const b = makeBucket();
+	const src = b.openUploadStream("src");
+	src.write(Buffer.from("payload"));
+	src.end();
+	await new Promise((r) => src.once("finish", r));
+	const srcId = (await b.find({ filename: "src" }).next())._id;
+
+	const dst = b.openUploadStream("dst");
+	await new Promise((res, rej) => {
+		b.openDownloadStream(srcId).on("error", rej).pipe(dst).on("error", rej).on("finish", res);
+	});
+
+	const dstId = (await b.find({ filename: "dst" }).next())._id;
+	const out = await readBack(b.openDownloadStream(dstId));
+	assert.equal(out.toString(), "payload");
+});
+
+test("find().toArray() returns metadata without the data blob", async () => {
+	const b = makeBucket();
+	const up = b.openUploadStream("only");
+	up.write(Buffer.from("x"));
+	up.end();
+	await new Promise((r) => up.once("finish", r));
+	const all = await b.find({}).toArray();
+	assert.equal(all.length, 1);
+	assert.equal(all[0].data, undefined); // data stripped from cursor results
+	assert.equal(all[0].filename, "only");
+});


### PR DESCRIPTION
Make file uploads work in the Ruflo ChatUI. ruvocal's RVF RvfGridFSBucket only partially mimics Mongo GridFSBucket; the patch makes it honor the contract (openUploadStream→objectMode Writable, openDownloadStream→Readable.from, find→sync cursor next()+toArray()). Bumps RUFLO_GIT_REF ca0a6fa→a6dd4ab; wasm:// sed re-applies. Verified: git apply --check passes, node:test contract test passes, all 5 call sites compatible. Frank spec 2026-05-27--orch--ruflo-image-upload-fix-design.