### PR TITLE
vk apply: persist tracking_issue for 2026-06-01-agent-shells-batch

### DIFF
--- a/docs/superpowers/plans/2026-06-01-agent-shells-batch/01.yaml
+++ b/docs/superpowers/plans/2026-06-01-agent-shells-batch/01.yaml
@@ -4,7 +4,7 @@ phase:
   title: multi-agent-shell + standard impl + CI intermediate
   tag: agentic
   depends_on: []
-  tracking_issue: null
+  tracking_issue: https://github.com/derio-net/agent-images/issues/98
 tasks:
 - number: 1
   title: Scaffold image dir mirroring paperclip-shell

--- a/docs/superpowers/plans/2026-06-01-agent-shells-batch/02.yaml
+++ b/docs/superpowers/plans/2026-06-01-agent-shells-batch/02.yaml
@@ -5,7 +5,7 @@ phase:
   tag: agentic
   depends_on:
   - 1
-  tracking_issue: null
+  tracking_issue: https://github.com/derio-net/agent-images/issues/99
 tasks:
 - number: 1
   title: Resolve hermes upstream + scaffold image dir

--- a/docs/superpowers/plans/2026-06-01-agent-shells-batch/03.yaml
+++ b/docs/superpowers/plans/2026-06-01-agent-shells-batch/03.yaml
@@ -5,7 +5,7 @@ phase:
   tag: agentic
   depends_on:
   - 1
-  tracking_issue: null
+  tracking_issue: https://github.com/derio-net/agent-images/issues/100
 tasks:
 - number: 1
   title: Scaffold FROM multi-agent-shell


### PR DESCRIPTION
## Summary

`vk apply --yes` created the three phase tracking Issues (#98/#99/#100) for `2026-06-01-agent-shells-batch` and staged their URLs into the per-phase YAMLs. This PR commits that writeback so the pod-side bridge's checkout sees the Issue URLs on its next tick.

## Dispatched

| Phase | Issue | Projected label | Why |
|---|---|---|---|
| 1 | #98 | `vk-ready` | `depends_on: []` |
| 2 | #99 | `vk-blocked` | `depends_on: [1]` |
| 3 | #100 | `vk-blocked` | `depends_on: [1]` |

After merge, the bridge ticks Phase 1 onto the VK board. Phases 2 and 3 flip from `vk-blocked` → `vk-ready` automatically once Phase 1's tracking Issue closes (merged PR + `state.completion.at` set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)