### PR TITLE
[derio-net/agent-images] 2026-06-01-agent-shells-batch · Phase 1/3 · multi-agent-shell + standard impl + CI intermediate

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,6 +95,37 @@ jobs:
           cache-from: type=gha,scope=agent-shell-base
           cache-to: type=gha,scope=agent-shell-base,mode=max
 
+  # multi-agent-shell is a SECOND intermediate base — Phase 3 infra-shell
+  # builds FROM ghcr.io/derio-net/multi-agent-shell:<sha>. Mirrors the
+  # build-shell-base shape so downstream `needs.build-multi-agent-shell.outputs.sha`
+  # references work in the same idiomatic way.
+  build-multi-agent-shell:
+    needs: build-shell-base
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ github.sha }}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: multi-agent-shell
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/multi-agent-shell:${{ github.sha }}
+            ${{ env.REGISTRY }}/${{ env.OWNER }}/multi-agent-shell:latest
+          build-args: BASE_SHA=${{ needs.build-shell-base.outputs.sha }}
+          cache-from: type=gha,scope=multi-agent-shell
+          cache-to: type=gha,scope=multi-agent-shell,mode=max
+
   build-children:
     needs: [build-base, build-shell-base]
     runs-on: ubuntu-latest
@@ -509,6 +540,113 @@ jobs:
           docker logs ruflo-server-smoke | tail -50
           docker rm -f ruflo-server-smoke
 
+  smoke-test-multi-agent-shell:
+    needs: build-multi-agent-shell
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      MULTI_AGENT_SHELL_IMAGE: ghcr.io/derio-net/multi-agent-shell
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Smoke test — s6-overlay /init under K8s-equivalent securityContext
+        env:
+          IMAGE_SHA: ${{ github.sha }}
+        run: |
+          # Match the live K8s securityContext (runAsUser: 1000, cap-drop=ALL,
+          # no-new-privileges) so the s6-overlay preinit hits the same /run
+          # constraints it does on Frank.
+          mkdir -p /tmp/mas-home /tmp/mas-inventory
+          sudo chown 1000:1000 /tmp/mas-home /tmp/mas-inventory
+          # Empty inventory — first-deploy posture per the multi-harness
+          # standard's "Smoke testing" section. Installer must report 0
+          # installed and exit clean; sshd must come up regardless.
+          echo '{}' | sudo tee /tmp/mas-inventory/inventory.yaml >/dev/null
+          sudo chown 1000:1000 /tmp/mas-inventory/inventory.yaml
+
+          docker run -d --name mas-smoke \
+            --user 1000:1000 \
+            --cap-drop=ALL \
+            --security-opt=no-new-privileges \
+            -v /tmp/mas-home:/home/agent \
+            -v /tmp/mas-inventory:/etc/multi-agent-shell:ro \
+            "${MULTI_AGENT_SHELL_IMAGE}:${IMAGE_SHA}"
+
+          # /init must reach stage 2 (sshd up). 30s budget mirrors paperclip-shell.
+          for i in $(seq 1 30); do
+            if docker exec mas-smoke /command/s6-svstat /run/service/sshd 2>/dev/null | grep -q '^up'; then
+              echo "✓ s6-overlay started, sshd is up"
+              break
+            fi
+            sleep 1
+          done
+          if ! docker exec mas-smoke /command/s6-svstat /run/service/sshd 2>/dev/null | grep -q '^up'; then
+            echo "✗ sshd never came up within 30s"
+            docker logs mas-smoke
+            docker rm -f mas-smoke
+            exit 1
+          fi
+
+          # Layer-1 managers must be on PATH and runnable as the agent UID.
+          docker exec mas-smoke mise --version
+          docker exec mas-smoke rustup --version
+          docker exec mas-smoke pipx --version
+          docker exec mas-smoke python3 --version
+          docker exec mas-smoke yq --version
+          docker exec mas-smoke jq --version
+
+          # Multi-harness manifest assertion (per docs/standards/multi-harness-shells.md
+          # § "Smoke testing"): every harness in the image's manifest reports
+          # --version cleanly as UID 1000. claude inherited from agent-base;
+          # codex/gemini/opencode baked here.
+          for h in claude codex gemini opencode; do
+            echo "::group::$h --version"
+            docker exec mas-smoke "$h" --version
+            echo "::endgroup::"
+          done
+
+          # Inventory installer reconciles cleanly against the empty inventory
+          # and writes a MOTD drop-in. failed=0 proves no section errored.
+          docker exec mas-smoke /usr/local/bin/multi-agent-shell-reconcile
+          out=$(docker exec mas-smoke cat /var/log/cont-init.d/40-shell-inventory.log)
+          echo "$out"
+          echo "$out" | grep -q 'failed=0' || { echo "✗ empty-inventory reconcile reported failed>0"; docker rm -f mas-smoke; exit 1; }
+          docker exec mas-smoke test -s /var/lib/multi-agent-shell/last-reconcile.motd
+
+          # Auth-status MOTD drop-in must be present and executable. We don't
+          # assert content here — credentials are runtime, not CI — only that
+          # the script is in place and runs cleanly with empty $HOME.
+          docker exec mas-smoke test -x /etc/profile.d/50-multi-agent-shell-motd.sh
+          docker exec mas-smoke /etc/profile.d/50-multi-agent-shell-motd.sh | grep -q '✗ claude'
+
+          # Reconcile two new schema keys end-to-end against a populated
+          # inventory: mcp-servers merges into ~/.claude/mcp.json; harnesses:
+          # latest invokes the inherited `claude update` self-update path.
+          docker exec -i mas-smoke sh -c 'cat >/tmp/inv.yaml' <<'YAML'
+          harnesses:
+            claude: latest
+          mcp-servers:
+            claude:
+              - name: context7
+                command: npx
+                args: ["-y", "@upstash/context7-mcp"]
+          YAML
+          out=$(docker exec -e INVENTORY=/tmp/inv.yaml mas-smoke \
+                  /usr/local/bin/multi-agent-shell-reconcile 2>&1)
+          echo "$out"
+          guard_ok=1
+          echo "$out" | grep -q 'mcp-servers/claude reconciled' || { echo "✗ mcp-servers section did not run"; guard_ok=0; }
+          docker exec mas-smoke jq -e '.mcpServers.context7.command == "npx"' /home/agent/.claude/mcp.json >/dev/null || { echo "✗ mcp.json not merged correctly"; guard_ok=0; }
+
+          docker logs mas-smoke
+          docker rm -f mas-smoke
+          [ "$guard_ok" -eq 1 ] || exit 1
+
   dispatch-frank:
     needs:
       - test-kali
@@ -518,6 +656,7 @@ jobs:
       - smoke-test-paperclip-shell
       - smoke-test-ruflo-shell
       - smoke-test-ruflo-server
+      - smoke-test-multi-agent-shell
     runs-on: ubuntu-latest
     permissions: {}
     steps:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Shared base image and per-pod child images for secure agent pods on Frank.
 | `agent-base` | `debian:bookworm-slim` | Common toolchain (claude, gh, node, bun, python3, uv, supercronic) |
 | `secure-agent-kali` | `agent-base` | Kali pentest tools + sshd + kubectl/talosctl/omnictl |
 | `vk-local` | `agent-base` | VibeKanban local-mode server binary (from `derio-net/vibe-kanban` fork) |
+| [`multi-agent-shell`](multi-agent-shell/) | `agent-shell-base` | Multi-harness shell: claude + codex + gemini + opencode, implements the [multi-harness shell standard](docs/standards/multi-harness-shells.md). Second intermediate base for Phase 3 `infra-shell`. |
 
 ## Build
 

--- a/docs/superpowers/plans/2026-06-01-agent-shells-batch/01.yaml
+++ b/docs/superpowers/plans/2026-06-01-agent-shells-batch/01.yaml
@@ -536,88 +536,89 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:38+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:38+00:00'
       note: null
     P1.T1.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:39+00:00'
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:39+00:00'
       note: null
     P1.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:39+00:00'
       note: null
     P1.T2.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:39+00:00'
       note: null
     P1.T2.S4:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:39+00:00'
       note: null
     P1.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:39+00:00'
       note: null
     P1.T3.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:39+00:00'
       note: null
     P1.T3.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:40+00:00'
       note: null
     P1.T3.S4:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:40+00:00'
       note: null
     P1.T3.S5:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:40+00:00'
       note: null
     P1.T4.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:40+00:00'
       note: null
     P1.T4.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:40+00:00'
       note: null
     P1.T4.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-06-01T19:24:47+00:00'
+      note: no docker available in execution env; verified by CI smoke-test-multi-agent-shell
     P1.T5.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:40+00:00'
       note: null
     P1.T5.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:41+00:00'
       note: null
     P1.T5.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-06-01T19:24:47+00:00'
+      note: took option (a) per the plan's default — only intermediate job, no children-matrix
+        entry; tag parity preserved by build-multi-agent-shell pushing :sha and :latest
     P1.T5.S4:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:41+00:00'
       note: null
     P1.T6.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:41+00:00'
       note: null
     P1.T6.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:24:41+00:00'
       note: null
     P1.T6.S3:
       state: ' '

--- a/docs/superpowers/plans/2026-06-01-agent-shells-batch/01.yaml
+++ b/docs/superpowers/plans/2026-06-01-agent-shells-batch/01.yaml
@@ -621,10 +621,10 @@ state:
       ticked_at: '2026-06-01T19:24:41+00:00'
       note: null
     P1.T6.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-01T19:26:00+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-01T19:26:00+00:00'
     note: null
     observed_prs: []

--- a/multi-agent-shell/Dockerfile
+++ b/multi-agent-shell/Dockerfile
@@ -1,0 +1,60 @@
+ARG BASE_SHA=latest
+FROM ghcr.io/derio-net/agent-shell-base:${BASE_SHA}
+
+# Inherit AGENT_USER=agent, AGENT_HOME=/home/agent, AGENT_UID=1000 from
+# agent-shell-base via its ENV line — do not override.
+#
+# AGENT_GID is set as ARG (not ENV) in agent-shell-base, so it does not
+# propagate to child images. Re-declare it here so Docker substitutes it at
+# build time in the RUN below; without this, ${AGENT_GID} expands to empty
+# in /bin/sh and `install -d -o 1000 -g  -m 0755` fails (-m read as group).
+ARG AGENT_GID=1000
+
+USER root
+
+# Per docs/standards/multi-harness-shells.md — bake the three additional
+# subscription/OAuth harness bootstrap shims. claude is inherited from
+# agent-base (npm i -g @anthropic-ai/claude-code) and the inherited shim's
+# self-update target is $HOME/.local/bin/. Each new shim follows the same
+# convention: the operator runs `<h> login` once on first SSH; the CLI
+# self-updates or is refreshed via inventory reconcile thereafter.
+#
+# Pins captured during plan execution (npm view <pkg> version on
+# 2026-06-01). These pins float forward via the inventory `harnesses:`
+# key; the Dockerfile shim is only a bootstrap.
+ARG CODEX_VERSION=0.136.0
+ARG GEMINI_CLI_VERSION=0.44.1
+ARG OPENCODE_VERSION=1.15.13
+RUN npm install -g --omit=dev \
+      @openai/codex@${CODEX_VERSION} \
+      @google/gemini-cli@${GEMINI_CLI_VERSION} \
+      opencode-ai@${OPENCODE_VERSION}
+
+COPY --chown=root:root rootfs/ /
+
+# Pre-create the dirs the inventory installer writes to. Under K8s
+# (runAsUser: 1000, cap-drop=ALL, allowPrivilegeEscalation: false) the agent
+# UID cannot create root-owned directories at runtime, and agent-shell-base
+# only chowns /run + /var/run. Without these, install-inventory.sh's tee +
+# motd write fail silently inside cont-init.d, the installer appears to
+# "succeed" (fail-open exit 0), and the operator gets no log and no MOTD.
+RUN install -d -o ${AGENT_UID} -g ${AGENT_GID} -m 0755 \
+      /var/log/cont-init.d \
+      /var/lib/multi-agent-shell \
+ && chmod +x \
+      /etc/cont-init.d/40-shell-inventory \
+      /etc/profile.d/40-multi-agent-shell-paths.sh \
+      /etc/profile.d/45-multi-agent-shell-reconcile-motd.sh \
+      /etc/profile.d/50-multi-agent-shell-motd.sh \
+      /usr/local/lib/multi-agent-shell/install-base-runtimes.sh \
+      /usr/local/lib/multi-agent-shell/install-inventory.sh \
+      /usr/local/lib/multi-agent-shell/notify-telegram.sh \
+      /usr/local/lib/multi-agent-shell/lib.sh \
+ && /usr/local/lib/multi-agent-shell/install-base-runtimes.sh \
+ && ln -sf /usr/local/lib/multi-agent-shell/install-inventory.sh \
+           /usr/local/bin/multi-agent-shell-reconcile
+
+USER ${AGENT_USER}
+WORKDIR ${AGENT_HOME}
+EXPOSE 2222
+# ENTRYPOINT inherited from agent-shell-base: /init (s6-overlay)

--- a/multi-agent-shell/README.md
+++ b/multi-agent-shell/README.md
@@ -99,8 +99,20 @@ skills:
 ```
 
 Source of truth: `/etc/multi-agent-shell/inventory.yaml` (mounted ConfigMap
-on Frank). Removed semantics mirror the existing block:
-`removed.harnesses`, `removed.mcp-servers.<harness>`, `removed.skills.<harness>`.
+on Frank). Removed semantics mirror the existing block and are implemented
+for all three new keys:
+
+```yaml
+removed:
+  harnesses:        # deletes $HOME/.local/bin/<h> if a PV shim is present
+    - opencode
+  mcp-servers:      # deletes the named server from $HOME/.<harness>/mcp.json
+    claude:
+      - context7
+  skills:           # deletes $HOME/.<harness>/skills/<name>
+    claude:
+      - superpowers
+```
 
 ## First-boot operator runbook
 

--- a/multi-agent-shell/README.md
+++ b/multi-agent-shell/README.md
@@ -1,0 +1,183 @@
+# multi-agent-shell
+
+SSH-able shell image carrying four agent-CLI harnesses
+(`claude`, `codex`, `gemini`, `opencode`). The load-bearing reference
+implementation of the
+[multi-harness shell standard](../docs/standards/multi-harness-shells.md):
+per-harness state under `$HOME` on the per-pod PV, no API tokens in the
+image, an inventory installer that knows the three new schema keys
+(`harnesses`, `mcp-servers`, `skills`), and an auth-status MOTD printed on
+SSH login.
+
+Intended consumers:
+
+- The n8n sidecar use case — workflow nodes `exec` into this shell to invoke
+  `claude -p`, `codex`, `gemini`, or `opencode` against a shared pod
+  filesystem with PV-resident OAuth credentials.
+- `infra-shell` (Phase 3 of the agent-shells-batch plan) builds **FROM**
+  this image and adds cluster-admin tooling.
+
+## Harness manifest
+
+Per the standard's "Harness manifest" section, every harness baked into this
+image is declared below. The bootstrap install only puts the CLI on PATH;
+the operator runs `<h> login` once on first SSH and the OAuth credential
+lands on the PV. Updates flow via `<h> update` (CLI self-update) or via the
+inventory `harnesses:` key on each reconcile.
+
+| Harness | Bootstrap | Auth command | Credential file (on PV) | Update command |
+|---|---|---|---|---|
+| `claude` | `npm i -g @anthropic-ai/claude-code` (inherited from `agent-base`) | `claude login` | `~/.claude/credentials.json` | `claude update` |
+| `codex` | `npm i -g @openai/codex@${CODEX_VERSION}` | `codex login` | `~/.config/codex/auth.json` | `codex update` (or inventory `harnesses: codex: <ver>`) |
+| `gemini` | `npm i -g @google/gemini-cli@${GEMINI_CLI_VERSION}` | `gemini` (first run prompts the OAuth flow) | `~/.config/gemini/auth.json` | inventory `harnesses: gemini: <ver>` |
+| `opencode` | `npm i -g opencode-ai@${OPENCODE_VERSION}` | `opencode auth login` | `~/.local/share/opencode/auth.json` | inventory `harnesses: opencode: <ver>` |
+
+Notes:
+
+- **Credential paths are the MOTD detector's contract** (see
+  `rootfs/etc/profile.d/50-multi-agent-shell-motd.sh`). When upstream changes
+  one, update the MOTD checks and this table together.
+- **`opencode` credential path is a best-effort default** until first
+  operator login confirms upstream's chosen location; if it differs, fix
+  here and in the MOTD detector — both must agree.
+- **No `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / etc. in the image or in
+  Frank's `env:` block for this image.** The subscription-OAuth flows replace
+  API-key auth per the standard.
+
+## Inventory schema
+
+The inventory installer is the same shape as `paperclip-shell`/`ruflo-shell`
+(`mise`, `npm-global`, `pipx`, `cargo`, `removed`) **plus** the three new
+keys mandated by the multi-harness standard. All three are optional;
+fail-open semantics match the existing keys (a broken install logs + fires a
+Telegram alert and lets sshd come up anyway).
+
+```yaml
+# Existing keys (unchanged) ---------------------------------------------------
+mise:
+  - python@3.12
+  - node@22
+npm-global:
+  - "@anthropic-ai/claude-code"
+pipx:
+  - ruff
+cargo:
+  - ripgrep
+
+# New keys (multi-harness standard) ------------------------------------------
+
+# Per-harness CLI pins. "latest" floats; a specific version pins.
+# Reconcile invokes each harness's update command from the manifest above.
+harnesses:
+  claude: latest
+  codex: latest
+  gemini: latest
+  opencode: 1.15.13
+
+# Per-harness MCP servers. Each entry is merged into the harness's
+# mcp.json by .name (idempotent — re-running reconcile produces no
+# duplicates).
+mcp-servers:
+  claude:
+    - name: context7
+      command: npx
+      args: ["-y", "@upstash/context7-mcp"]
+  codex: []
+  gemini: []
+  opencode: []
+
+# Per-harness skills/plugins. Reconcile clones (or fast-forwards to ref)
+# each git source into the harness's skills/ directory under $HOME.
+skills:
+  claude:
+    - name: superpowers
+      source: git+https://github.com/obra/superpowers
+      ref: main
+  codex: []
+  gemini: []
+  opencode: []
+```
+
+Source of truth: `/etc/multi-agent-shell/inventory.yaml` (mounted ConfigMap
+on Frank). Removed semantics mirror the existing block:
+`removed.harnesses`, `removed.mcp-servers.<harness>`, `removed.skills.<harness>`.
+
+## First-boot operator runbook
+
+1. SSH to the pod (`ssh -p 2222 agent@<pod-ip>`).
+2. The MOTD prints the auth-status table — all four harnesses show
+   `✗ not logged in`.
+3. Run each `<h> login` once. OAuth opens in your local browser; the
+   credential lands on the PV at the path in the manifest table above.
+4. Re-login (`exit && ssh ...`). MOTD now shows `✓ <h>` for the harnesses
+   you logged in to.
+5. (Optional.) Edit `inventory.yaml` on Frank with the desired `harnesses:`,
+   `mcp-servers:`, and `skills:` content; the next pod restart (or running
+   `multi-agent-shell-reconcile` interactively) applies them.
+
+From this point, restarts and image updates are zero-touch — the PV
+preserves auth, skills, MCP configs, and self-updated CLI binaries.
+
+## Layered install model
+
+Same three-layer model as `paperclip-shell`:
+
+| Layer | Source | Where it lands | When |
+|---|---|---|---|
+| 1 — Image baseline | this Dockerfile | image rootfs (immutable) | image build |
+| 2 — Inventory | mounted ConfigMap `inventory.yaml` | per-user PV under `$HOME` | every container boot via `cont-init.d/40-shell-inventory` |
+| 3 — Interactive | operator typing `mise install …`, `<h> install …`, etc. | per-user PV under `$HOME` | on demand inside the SSH session |
+
+## Operator commands
+
+```bash
+# Re-run the inventory installer without restarting the pod
+multi-agent-shell-reconcile
+
+# Read the last reconcile log
+cat /var/log/cont-init.d/40-shell-inventory.log
+
+# Read the MOTD that prints on every login
+cat /var/lib/multi-agent-shell/last-reconcile.motd
+```
+
+## Build args
+
+| Arg | Default | Notes |
+|---|---|---|
+| `BASE_SHA` | `latest` | The `agent-shell-base` tag/SHA to inherit from. CI passes the SHA of the same workflow run. |
+| `CODEX_VERSION` | `0.136.0` | `@openai/codex` npm pin. |
+| `GEMINI_CLI_VERSION` | `0.44.1` | `@google/gemini-cli` npm pin. |
+| `OPENCODE_VERSION` | `1.15.13` | `opencode-ai` npm pin. |
+
+`AGENT_USER`, `AGENT_HOME`, `AGENT_UID`, `AGENT_GID` are inherited from
+`agent-shell-base` (defaults: `agent`, `/home/agent`, `1000`, `1000`).
+
+## Smoke test
+
+CI job: `smoke-test-multi-agent-shell` in
+[`.github/workflows/build.yaml`](../.github/workflows/build.yaml). Asserts
+the standard's smoke contract: sshd up under K8s-equivalent
+securityContext, every harness reports `--version` cleanly as UID 1000, and
+`multi-agent-shell-reconcile` produces a clean exit and a non-empty MOTD
+against an empty inventory.
+
+Local bats coverage:
+
+```bash
+cd multi-agent-shell
+bats tests/test_motd.bats              # auth-status MOTD detector
+bats tests/test_install_inventory.bats # harnesses/mcp-servers/skills handlers
+```
+
+## Telegram alerting
+
+Failures fire to `@agent_zero_cc_bot` via `FRANK_C2_TELEGRAM_BOT_TOKEN` +
+`FRANK_C2_TELEGRAM_CHAT_ID` env vars (same Infisical-backed Secret used by
+the other shells). Fail-silent if either env is empty.
+
+## Plan / spec
+
+- Standard: [`docs/standards/multi-harness-shells.md`](../docs/standards/multi-harness-shells.md)
+- Spec: [`docs/superpowers/specs/2026-05-12-agent-shells-batch-design.md`](../docs/superpowers/specs/2026-05-12-agent-shells-batch-design.md)
+- Plan: [`docs/superpowers/plans/2026-06-01-agent-shells-batch/`](../docs/superpowers/plans/2026-06-01-agent-shells-batch/)

--- a/multi-agent-shell/rootfs/etc/cont-init.d/40-shell-inventory
+++ b/multi-agent-shell/rootfs/etc/cont-init.d/40-shell-inventory
@@ -1,0 +1,4 @@
+#!/command/with-contenv bash
+# 40-shell-inventory — Reconcile the declarative software inventory on every
+# container boot. Idempotent and fail-open — never blocks sshd startup.
+exec /usr/local/lib/multi-agent-shell/install-inventory.sh

--- a/multi-agent-shell/rootfs/etc/profile.d/40-multi-agent-shell-paths.sh
+++ b/multi-agent-shell/rootfs/etc/profile.d/40-multi-agent-shell-paths.sh
@@ -1,0 +1,24 @@
+# 40-multi-agent-shell-paths.sh — Wire mise shims and cargo's bin dir into the
+# operator's interactive PATH. Both directories live under $HOME on the PVC,
+# so they survive image bumps but only exist after the inventory installer (or
+# the operator) has installed something via the corresponding manager.
+#
+# Activated for every login shell (and re-sourced by ~/.bashrc).
+
+case ":$PATH:" in
+    *":$HOME/.local/share/mise/shims:"*) ;;
+    *) PATH="$HOME/.local/share/mise/shims:$PATH" ;;
+esac
+
+case ":$PATH:" in
+    *":$HOME/.cargo/bin:"*) ;;
+    *) PATH="$HOME/.cargo/bin:$PATH" ;;
+esac
+
+# pipx puts user-installed entry points here.
+case ":$PATH:" in
+    *":$HOME/.local/bin:"*) ;;
+    *) PATH="$HOME/.local/bin:$PATH" ;;
+esac
+
+export PATH

--- a/multi-agent-shell/rootfs/etc/profile.d/45-multi-agent-shell-reconcile-motd.sh
+++ b/multi-agent-shell/rootfs/etc/profile.d/45-multi-agent-shell-reconcile-motd.sh
@@ -1,0 +1,20 @@
+# 45-multi-agent-shell-reconcile-motd.sh — Print the last reconcile summary
+# on interactive shell login. The s6-overlay sshd is built with UsePAM=no
+# (see agent-shell-base sshd_config), so pam_motd does not fire; profile.d is
+# the simplest mechanism that still works for both ssh and
+# `kubectl exec -it ... bash -l`.
+#
+# Numbered 45- so it prints BEFORE the 50- auth-status table — per the
+# multi-harness-shells spec, the reconcile summary leads and the auth table
+# is appended.
+#
+# Sourced by /etc/profile (interactive login shells) and by ~/.bashrc via
+# the default Debian skeleton. Quiet for non-interactive shells.
+
+[ -n "$PS1" ] || return 0
+
+_multi_agent_shell_motd_file=/var/lib/multi-agent-shell/last-reconcile.motd
+if [ -r "$_multi_agent_shell_motd_file" ]; then
+    cat "$_multi_agent_shell_motd_file"
+fi
+unset _multi_agent_shell_motd_file

--- a/multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh
+++ b/multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# multi-agent-shell auth-status MOTD — printed on SSH login.
+# Presence-only check on each harness's credential file
+# (declared in the image's harness manifest, multi-agent-shell/README.md).
+#
+# Per the multi-harness standard: the detector does NOT validate the
+# credential; rotation/expiry is the operator's concern. A printed ✓ means
+# only that the file exists.
+
+echo "Harness auth status:"
+
+check() {
+  # $1=name $2=path (relative to $HOME)
+  if [ -e "$HOME/$2" ]; then
+    age_days=$(( ( $(date +%s) - $(stat -c %Y "$HOME/$2") ) / 86400 ))
+    echo "  ✓ $1     (~/$2, age ${age_days}d)"
+  else
+    echo "  ✗ $1     not logged in — run: $1 login"
+  fi
+}
+
+check claude   .claude/credentials.json
+check codex    .config/codex/auth.json
+check gemini   .config/gemini/auth.json
+check opencode .local/share/opencode/auth.json

--- a/multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh
+++ b/multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh
@@ -12,10 +12,17 @@ echo "Harness auth status:"
 check() {
   # $1=name $2=path (relative to $HOME)
   if [ -e "$HOME/$2" ]; then
-    age_days=$(( ( $(date +%s) - $(stat -c %Y "$HOME/$2") ) / 86400 ))
-    echo "  ✓ $1     (~/$2, age ${age_days}d)"
+    # stat may fail on an unreadable/dangling target; degrade to "?" rather
+    # than emit a shell arithmetic error on login.
+    mtime=$(stat -c %Y "$HOME/$2" 2>/dev/null)
+    if [ -n "$mtime" ]; then
+      age_days=$(( ( $(date +%s) - mtime ) / 86400 ))
+      printf '  ✓ %-9s (~/%s, age %sd)\n' "$1" "$2" "$age_days"
+    else
+      printf '  ✓ %-9s (~/%s, age ?)\n' "$1" "$2"
+    fi
   else
-    echo "  ✗ $1     not logged in — run: $1 login"
+    printf '  ✗ %-9s not logged in — run: %s login\n' "$1" "$1"
   fi
 }
 

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/install-base-runtimes.sh
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/install-base-runtimes.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# install-base-runtimes.sh — Image-time install of the Layer-1 runtime managers.
+# These are slow-changing, baked into the image. Per-user state lives on the PVC.
+set -euo pipefail
+
+# Build dependencies the managers themselves need at install time, plus
+# python3-yaml for install-inventory.sh's YAML parsing. The inventory script
+# deliberately uses the system python (/usr/bin/python3 + apt-installed
+# PyYAML) for parsing rather than a mise-managed runtime — at cont-init.d
+# boot time mise shims are not yet on PATH for the script's own environment,
+# and we want YAML parsing to keep working even before any mise tools land
+# on the PV.
+apt-get update
+apt-get install -y --no-install-recommends \
+    ca-certificates curl build-essential pkg-config libssl-dev \
+    python3 python3-pip python3-yaml pipx jq
+rm -rf /var/lib/apt/lists/*
+
+# yq is already installed by agent-base (base/Dockerfile § "yq") — confirm
+# it's on PATH at build time so install-inventory.sh's harnesses/mcp-servers/
+# skills sections (which use yq for YAML parsing) can rely on it.
+command -v yq >/dev/null
+yq --version
+
+# mise — asdf-style multi-runtime version manager. System-wide binary;
+# per-user toolchains and shims under $HOME/.local/share/mise on the PV.
+curl -fsSL https://mise.run | MISE_INSTALL_PATH=/usr/local/bin/mise sh
+chmod +x /usr/local/bin/mise
+
+# rustup — system-wide binary only; toolchains live under $HOME/.rustup on
+# the PV (each operator gets a fresh rustup root on first run). Steering the
+# bootstrap RUSTUP_HOME/CARGO_HOME under /tmp keeps the image slim and avoids
+# leaving orphaned root-owned state under /root or /usr/local that the
+# runtime user could not read or extend anyway. --default-toolchain none
+# keeps the image slim; the operator pulls toolchains via mise
+# (rust@stable) or `rustup toolchain install` on demand.
+export RUSTUP_HOME=/tmp/rustup-bootstrap CARGO_HOME=/tmp/cargo-bootstrap
+mkdir -p "$RUSTUP_HOME" "$CARGO_HOME"
+curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs \
+  | sh -s -- -y --default-toolchain none --no-modify-path
+mv "$CARGO_HOME"/bin/rustup /usr/local/bin/rustup
+chmod +x /usr/local/bin/rustup
+rm -rf "$RUSTUP_HOME" "$CARGO_HOME" /root/.cargo /root/.rustup
+
+# pipx came from apt above. Confirm.
+command -v pipx >/dev/null
+command -v mise >/dev/null
+command -v rustup >/dev/null
+command -v python3 >/dev/null

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/install-inventory.sh
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/install-inventory.sh
@@ -209,19 +209,6 @@ if command -v yq >/dev/null 2>&1; then
             fi
             run "harness $harness update (pin=$pin)" "$harness" update && installed+=1
         done < <(yq -r '.harnesses | to_entries[] | "\(.key)\t\(.value)"' "$INVENTORY")
-
-        # removed.harnesses — declarative uninstall. Most harness CLIs do not
-        # expose an `uninstall` subcommand, so we delegate to a generic shim
-        # path under $HOME/.local/bin/<h> if present, then warn-only otherwise.
-        while IFS= read -r harness; do
-            [[ -z "$harness" ]] && continue
-            if [[ -e "$HOME/.local/bin/$harness" ]]; then
-                rm -f "$HOME/.local/bin/$harness" && removed+=1
-                echo "✓ removed $HOME/.local/bin/$harness"
-            else
-                echo "= warn: removed.harnesses.$harness has no PV-installed binary at \$HOME/.local/bin; nothing to remove"
-            fi
-        done < <(yq -r '.removed.harnesses // [] | .[]' "$INVENTORY")
     fi
 
     # --- mcp-servers ---
@@ -257,36 +244,88 @@ if command -v yq >/dev/null 2>&1; then
 
     # --- skills ---
     # Clone (or fast-forward to ref) into $HOME/.<harness>/skills/<name>.
+    # Entries are streamed as "harness<TAB>name<TAB>source<TAB>ref" so the
+    # whole section runs in ONE while-loop with no pipe — counter mutations
+    # (installed/already/failed) persist in the current shell rather than
+    # being lost to a subshell. yq emits "null" for a missing .ref; bash
+    # normalises that to HEAD below (avoids a nested-quote yq interpolation).
     if yq -e 'has("skills")' "$INVENTORY" >/dev/null 2>&1; then
-        while IFS= read -r harness; do
-            [[ -z "$harness" ]] && continue
+        while IFS=$'\t' read -r harness name source ref; do
+            [[ -z "$harness" || -z "$name" ]] && continue
             skills_dir="$HOME/.${harness}/skills"
             mkdir -p "$skills_dir"
-            yq -o=json ".skills.\"$harness\"" "$INVENTORY" \
-                | jq -c '.[]' \
-                | while IFS= read -r entry; do
-                      name=$(echo "$entry" | jq -r '.name')
-                      source=$(echo "$entry" | jq -r '.source')
-                      ref=$(echo "$entry" | jq -r '.ref // "HEAD"')
-                      target="$skills_dir/$name"
-                      url="${source#git+}"
-                      if [[ -d "$target/.git" ]]; then
-                          if (cd "$target" && git fetch -q origin 2>/dev/null && git checkout -q "$ref" 2>/dev/null); then
-                              echo "= skill $harness/$name checked out at $ref"
-                          else
-                              echo "= warn: skill $harness/$name update to $ref failed"
-                          fi
-                      else
-                          if git clone -q "$url" "$target" 2>/dev/null; then
-                              (cd "$target" && git checkout -q "$ref" 2>/dev/null) || true
-                              echo "✓ skill $harness/$name cloned from $url"
-                              installed+=1
-                          else
-                              echo "= warn: skill $harness/$name clone from $url failed"
-                          fi
-                      fi
-                  done
-        done < <(yq -r '.skills | keys | .[]' "$INVENTORY")
+            target="$skills_dir/$name"
+            url="${source#git+}"
+            [[ "$ref" == "null" || -z "$ref" ]] && ref=HEAD
+            if [[ -d "$target/.git" ]]; then
+                if (cd "$target" && git fetch -q origin 2>/dev/null && git checkout -q "$ref" 2>/dev/null); then
+                    already+=1
+                    echo "= skill $harness/$name checked out at $ref"
+                else
+                    echo "✗ skill $harness/$name update to $ref failed"
+                    failures+=("skills/$harness/$name")
+                    failed+=1
+                fi
+            else
+                if git clone -q "$url" "$target" 2>/dev/null; then
+                    (cd "$target" && git checkout -q "$ref" 2>/dev/null) || true
+                    installed+=1
+                    echo "✓ skill $harness/$name cloned from $url"
+                else
+                    echo "✗ skill $harness/$name clone from $url failed"
+                    failures+=("skills/$harness/$name")
+                    failed+=1
+                fi
+            fi
+        done < <(yq -r '.skills | to_entries[] | .key as $h | .value[] | [$h, .name, .source, (.ref // "HEAD")] | @tsv' "$INVENTORY")
+    fi
+
+    # --- removed.* for the three new keys ---
+    # Guarded independently of the additive blocks above: a removal-only
+    # inventory carries `removed:` without the matching top-level key.
+    if yq -e 'has("removed")' "$INVENTORY" >/dev/null 2>&1; then
+
+        # removed.harnesses — declarative uninstall. Most harness CLIs do not
+        # expose an `uninstall` subcommand, so we delete a PV-installed shim at
+        # $HOME/.local/bin/<h> if present, then warn-only otherwise.
+        while IFS= read -r harness; do
+            [[ -z "$harness" ]] && continue
+            if [[ -e "$HOME/.local/bin/$harness" ]]; then
+                rm -f "$HOME/.local/bin/$harness" && removed+=1
+                echo "✓ removed $HOME/.local/bin/$harness"
+            else
+                echo "= warn: removed.harnesses.$harness has no PV-installed binary at \$HOME/.local/bin; nothing to remove"
+            fi
+        done < <(yq -r '.removed.harnesses // [] | .[]' "$INVENTORY")
+
+        # removed.mcp-servers.<harness> — delete named servers from mcp.json.
+        while IFS=$'\t' read -r harness name; do
+            [[ -z "$harness" || -z "$name" ]] && continue
+            mcp_path="$HOME/.${harness}/mcp.json"
+            [[ -f "$mcp_path" ]] || continue
+            tmp=$(mktemp)
+            if jq --arg n "$name" 'del(.mcpServers[$n])' "$mcp_path" > "$tmp" 2>/dev/null; then
+                mv "$tmp" "$mcp_path" && removed+=1
+                echo "✓ removed mcp-servers/$harness/$name"
+            else
+                echo "✗ removed.mcp-servers/$harness/$name: jq delete failed"
+                failures+=("removed.mcp-servers/$harness/$name")
+                failed+=1
+                rm -f "$tmp"
+            fi
+        done < <(yq -r '(.removed."mcp-servers" // {}) | to_entries[] | .key as $h | .value[] | [$h, .] | @tsv' "$INVENTORY")
+
+        # removed.skills.<harness> — delete the cloned skill dir.
+        while IFS=$'\t' read -r harness name; do
+            [[ -z "$harness" || -z "$name" ]] && continue
+            target="$HOME/.${harness}/skills/$name"
+            if [[ -d "$target" ]]; then
+                rm -rf "$target" && removed+=1
+                echo "✓ removed skills/$harness/$name"
+            else
+                echo "= warn: removed.skills.$harness.$name not present; nothing to remove"
+            fi
+        done < <(yq -r '(.removed.skills // {}) | to_entries[] | .key as $h | .value[] | [$h, .] | @tsv' "$INVENTORY")
     fi
 
 else

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/install-inventory.sh
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/install-inventory.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# install-inventory.sh — Layer-2 inventory installer.
+#   * Idempotent: re-running with no changes is a quick no-op.
+#   * Fail-open: a single broken install logs and continues; never blocks sshd.
+#   * Source of truth: /etc/multi-agent-shell/inventory.yaml (mounted ConfigMap).
+#   * On any failure, fires a Telegram alert via notify-telegram.sh.
+#
+# YAML parsing deliberately uses /usr/bin/python3 + apt-installed PyYAML
+# (python3-yaml). At cont-init.d boot time mise shims are not yet on PATH for
+# the script's own environment, and we want YAML parsing to keep working
+# even before any mise-managed runtimes land on the PV.
+#
+# NOT `set -e` — failures are accumulated, not propagated.
+set -uo pipefail
+
+# Source path resolves to the script's own directory so the same code runs
+# both in the baked image (under /usr/local/lib/multi-agent-shell) and from
+# a checked-out tree during bats tests.
+_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+. "$_self_dir/lib.sh"
+multi_agent_shell_init_dirs
+
+INVENTORY="${INVENTORY:-/etc/multi-agent-shell/inventory.yaml}"
+LOG="${MULTI_AGENT_SHELL_LOG_DIR}/40-shell-inventory.log"
+NOTIFY="$_self_dir/notify-telegram.sh"
+
+exec > >(tee -a "$LOG") 2>&1
+
+echo "=== multi-agent-shell-reconcile @ $(date -Iseconds) ==="
+
+# Make mise shims and the rustup-managed cargo bin visible for the npm-global
+# and cargo sections below. Prepended unconditionally; missing dirs are a
+# no-op until the relevant runtime is installed.
+export PATH="${HOME}/.local/share/mise/shims:${HOME}/.cargo/bin:${PATH}"
+
+if [[ ! -f "$INVENTORY" ]]; then
+    echo "WARN: $INVENTORY missing; nothing to do"
+    multi_agent_shell_motd_write "⚠ multi-agent-shell: inventory file missing"
+    exit 0
+fi
+
+declare -i installed=0 already=0 removed=0 failed=0
+declare -a failures=()
+
+run() {
+    local label="$1"
+    shift
+    local rc
+    if "$@"; then
+        echo "✓ $label"
+        return 0
+    fi
+    # Capture rc immediately on the first line of the failure path so any
+    # future refactor that adds a command above this line does not silently
+    # corrupt rc (e.g. an `echo`'s `$?` shadowing the real failure).
+    rc=$?
+    echo "✗ $label (rc=$rc)"
+    failures+=("$label")
+    failed+=1
+    return "$rc"
+}
+
+# Read a top-level list from inventory.yaml. Returns one item per line.
+yaml_list() {
+    /usr/bin/python3 -c "
+import sys, yaml
+d = yaml.safe_load(open('$INVENTORY')) or {}
+for x in (d.get('$1') or []):
+    print(x)
+"
+}
+
+# Read a list under 'removed.<key>'. Returns one item per line.
+yaml_removed_list() {
+    /usr/bin/python3 -c "
+import sys, yaml
+d = yaml.safe_load(open('$INVENTORY')) or {}
+for x in ((d.get('removed') or {}).get('$1') or []):
+    print(x)
+"
+}
+
+assert_manager() {
+    local cmd="$1"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "✗ manager '$cmd' missing from image; cannot reconcile its section"
+        failures+=("manager-missing:$cmd")
+        failed+=1
+        return 1
+    fi
+}
+
+# --- mise ---
+if assert_manager mise; then
+    while IFS= read -r tool; do
+        [[ -z "$tool" ]] && continue
+        if mise where "$tool" >/dev/null 2>&1; then
+            already+=1
+            echo "= mise $tool"
+        else
+            run "mise install $tool" mise install "$tool" && installed+=1
+        fi
+        # Activate globally so the shim dispatches to this runtime; without it
+        # npm/cargo fall through to the root-owned system prefix → EACCES.
+        # Unconditional + idempotent: also heals PVs left unactivated by older
+        # versions of this script. (#56)
+        run "mise use -g $tool" mise use -g "$tool"
+    done < <(yaml_list mise)
+
+    while IFS= read -r tool; do
+        [[ -z "$tool" ]] && continue
+        run "mise uninstall $tool" mise uninstall "$tool" && removed+=1
+    done < <(yaml_removed_list mise)
+fi
+
+# --- npm-global --- (npm comes from a runtime managed by mise; skip section if missing)
+if command -v npm >/dev/null 2>&1; then
+    while IFS= read -r pkg; do
+        [[ -z "$pkg" ]] && continue
+        if npm ls -g "$pkg" --depth=0 >/dev/null 2>&1; then
+            already+=1
+            echo "= npm $pkg"
+            continue
+        fi
+        run "npm i -g $pkg" npm install -g "$pkg" && installed+=1
+    done < <(yaml_list npm-global)
+
+    while IFS= read -r pkg; do
+        [[ -z "$pkg" ]] && continue
+        run "npm rm -g $pkg" npm uninstall -g "$pkg" && removed+=1
+    done < <(yaml_removed_list npm-global)
+else
+    if [[ -n "$(yaml_list npm-global)" || -n "$(yaml_removed_list npm-global)" ]]; then
+        echo "= npm-global section declared but no npm on PATH (install node via mise first); skipping"
+    fi
+fi
+
+# --- pipx ---
+if assert_manager pipx; then
+    while IFS= read -r pkg; do
+        [[ -z "$pkg" ]] && continue
+        if pipx list --short 2>/dev/null | awk '{print $1}' | grep -qx "$pkg"; then
+            already+=1
+            echo "= pipx $pkg"
+            continue
+        fi
+        run "pipx install $pkg" pipx install "$pkg" && installed+=1
+    done < <(yaml_list pipx)
+
+    while IFS= read -r pkg; do
+        [[ -z "$pkg" ]] && continue
+        run "pipx uninstall $pkg" pipx uninstall "$pkg" && removed+=1
+    done < <(yaml_removed_list pipx)
+fi
+
+# --- cargo --- (cargo comes from rustup-installed toolchain on PV; skip if missing)
+if command -v cargo >/dev/null 2>&1; then
+    while IFS= read -r crate; do
+        [[ -z "$crate" ]] && continue
+        # `cargo install --list` output:
+        #     ripgrep v14.1.0:
+        #         rg
+        #     cargo-binstall v1.6.0:
+        #         cargo-binstall
+        # Package lines start at column 0; binary-name lines are indented.
+        # Strip the version+colon to get just the package name.
+        if cargo install --list 2>/dev/null \
+            | awk '/^[^[:space:]]/{sub(/ .*$/, ""); print}' \
+            | grep -qx "$crate"; then
+            already+=1
+            echo "= cargo $crate"
+            continue
+        fi
+        run "cargo install $crate" cargo install "$crate" && installed+=1
+    done < <(yaml_list cargo)
+
+    while IFS= read -r crate; do
+        [[ -z "$crate" ]] && continue
+        run "cargo uninstall $crate" cargo uninstall "$crate" && removed+=1
+    done < <(yaml_removed_list cargo)
+else
+    if [[ -n "$(yaml_list cargo)" || -n "$(yaml_removed_list cargo)" ]]; then
+        echo "= cargo section declared but no cargo on PATH (run \`rustup toolchain install stable\` or \`mise install rust@stable\` first); skipping"
+    fi
+fi
+
+# === multi-harness standard extension =======================================
+# Three new keys per docs/standards/multi-harness-shells.md:
+#   harnesses:    pinned/floating CLI versions, refreshed via `<h> update`
+#   mcp-servers:  per-harness mcp.json merge (idempotent by name)
+#   skills:       per-harness git-cloned skills/plugins under $HOME
+#
+# YAML parsing for these sections uses yq (binary-distributed, no Python
+# import) so the same code paths run cleanly in bats tests that may not have
+# PyYAML available. The existing keys above keep their python+PyYAML path
+# to minimise diff against paperclip-shell's baseline.
+
+if command -v yq >/dev/null 2>&1; then
+
+    # --- harnesses ---
+    if yq -e 'has("harnesses")' "$INVENTORY" >/dev/null 2>&1; then
+        # Stream "name<TAB>pin" pairs so values with spaces/quotes stay intact.
+        while IFS=$'\t' read -r harness pin; do
+            [[ -z "$harness" ]] && continue
+            if ! command -v "$harness" >/dev/null 2>&1; then
+                echo "= warn: harness $harness pinned to '$pin' but CLI not on PATH; skipping update"
+                continue
+            fi
+            run "harness $harness update (pin=$pin)" "$harness" update && installed+=1
+        done < <(yq -r '.harnesses | to_entries[] | "\(.key)\t\(.value)"' "$INVENTORY")
+
+        # removed.harnesses — declarative uninstall. Most harness CLIs do not
+        # expose an `uninstall` subcommand, so we delegate to a generic shim
+        # path under $HOME/.local/bin/<h> if present, then warn-only otherwise.
+        while IFS= read -r harness; do
+            [[ -z "$harness" ]] && continue
+            if [[ -e "$HOME/.local/bin/$harness" ]]; then
+                rm -f "$HOME/.local/bin/$harness" && removed+=1
+                echo "✓ removed $HOME/.local/bin/$harness"
+            else
+                echo "= warn: removed.harnesses.$harness has no PV-installed binary at \$HOME/.local/bin; nothing to remove"
+            fi
+        done < <(yq -r '.removed.harnesses // [] | .[]' "$INVENTORY")
+    fi
+
+    # --- mcp-servers ---
+    # Merge each entry into $HOME/.<harness>/mcp.json by .name (idempotent).
+    if yq -e 'has("mcp-servers")' "$INVENTORY" >/dev/null 2>&1; then
+        while IFS= read -r harness; do
+            [[ -z "$harness" ]] && continue
+            mcp_path="$HOME/.${harness}/mcp.json"
+            mkdir -p "$(dirname "$mcp_path")"
+            [[ -f "$mcp_path" ]] || echo '{"mcpServers":{}}' > "$mcp_path"
+            entries=$(mktemp)
+            yq -o=json ".\"mcp-servers\".\"$harness\"" "$INVENTORY" > "$entries"
+            tmp=$(mktemp)
+            if jq --slurpfile new "$entries" '
+                  .mcpServers = (
+                      (.mcpServers // {}) as $existing
+                      | reduce $new[0][] as $e ($existing;
+                          .[$e.name] = ($e | del(.name)))
+                  )' "$mcp_path" > "$tmp" 2>/dev/null; then
+                mv "$tmp" "$mcp_path"
+                count=$(jq '.mcpServers | length' "$mcp_path")
+                echo "= mcp-servers/$harness reconciled ($count total)"
+                installed+=1
+            else
+                echo "✗ mcp-servers/$harness: jq merge failed"
+                failures+=("mcp-servers/$harness")
+                failed+=1
+                rm -f "$tmp"
+            fi
+            rm -f "$entries"
+        done < <(yq -r '."mcp-servers" | keys | .[]' "$INVENTORY")
+    fi
+
+    # --- skills ---
+    # Clone (or fast-forward to ref) into $HOME/.<harness>/skills/<name>.
+    if yq -e 'has("skills")' "$INVENTORY" >/dev/null 2>&1; then
+        while IFS= read -r harness; do
+            [[ -z "$harness" ]] && continue
+            skills_dir="$HOME/.${harness}/skills"
+            mkdir -p "$skills_dir"
+            yq -o=json ".skills.\"$harness\"" "$INVENTORY" \
+                | jq -c '.[]' \
+                | while IFS= read -r entry; do
+                      name=$(echo "$entry" | jq -r '.name')
+                      source=$(echo "$entry" | jq -r '.source')
+                      ref=$(echo "$entry" | jq -r '.ref // "HEAD"')
+                      target="$skills_dir/$name"
+                      url="${source#git+}"
+                      if [[ -d "$target/.git" ]]; then
+                          if (cd "$target" && git fetch -q origin 2>/dev/null && git checkout -q "$ref" 2>/dev/null); then
+                              echo "= skill $harness/$name checked out at $ref"
+                          else
+                              echo "= warn: skill $harness/$name update to $ref failed"
+                          fi
+                      else
+                          if git clone -q "$url" "$target" 2>/dev/null; then
+                              (cd "$target" && git checkout -q "$ref" 2>/dev/null) || true
+                              echo "✓ skill $harness/$name cloned from $url"
+                              installed+=1
+                          else
+                              echo "= warn: skill $harness/$name clone from $url failed"
+                          fi
+                      fi
+                  done
+        done < <(yq -r '.skills | keys | .[]' "$INVENTORY")
+    fi
+
+else
+    # yq missing — log once and proceed; the three new sections are skipped.
+    if /usr/bin/python3 -c "
+import sys, yaml
+d = yaml.safe_load(open('$INVENTORY')) or {}
+sys.exit(0 if any(k in d for k in ('harnesses','mcp-servers','skills')) else 1)
+" 2>/dev/null; then
+        echo "= warn: yq not on PATH; harnesses/mcp-servers/skills sections skipped"
+    fi
+fi
+# === end multi-harness standard extension ===================================
+
+echo "=== summary: installed=$installed already=$already removed=$removed failed=$failed ==="
+
+if (( failed > 0 )); then
+    multi_agent_shell_motd_write "$(printf '⚠ multi-agent-shell: %d install(s) failed on last reconcile (%s)\n  See: %s' \
+        "$failed" "$(IFS=,; echo "${failures[*]}")" "$LOG")"
+    "$NOTIFY" \
+        "multi-agent-shell: $failed install(s) failed on boot" \
+        "$(printf '%s\n' "${failures[@]}")" || true
+else
+    multi_agent_shell_motd_write "$(printf '✓ multi-agent-shell: %d installed, %d already present, %d removed @ %s' \
+        "$installed" "$already" "$removed" "$(date -Iseconds)")"
+fi
+
+exit 0  # always succeed — fail-open

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/lib.sh
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/lib.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# lib.sh — shared helpers for multi-agent-shell installer scripts.
+# Source from other scripts:
+#     # shellcheck source=/dev/null
+#     . /usr/local/lib/multi-agent-shell/lib.sh
+
+MULTI_AGENT_SHELL_LOG_DIR="${MULTI_AGENT_SHELL_LOG_DIR:-/var/log/cont-init.d}"
+MULTI_AGENT_SHELL_STATE_DIR="${MULTI_AGENT_SHELL_STATE_DIR:-/var/lib/multi-agent-shell}"
+MULTI_AGENT_SHELL_MOTD_FILE="${MULTI_AGENT_SHELL_STATE_DIR}/last-reconcile.motd"
+
+multi_agent_shell_init_dirs() {
+    mkdir -p "$MULTI_AGENT_SHELL_LOG_DIR" "$MULTI_AGENT_SHELL_STATE_DIR"
+}
+
+multi_agent_shell_motd_write() {
+    multi_agent_shell_init_dirs
+    printf '%s\n' "$*" > "$MULTI_AGENT_SHELL_MOTD_FILE"
+}

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/notify-telegram.sh
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/notify-telegram.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# notify-telegram.sh — Send a Telegram alert. Fail-silent if env is missing.
+# Usage: notify-telegram.sh "title" "detail body"
+#
+# Reads FRANK_C2_TELEGRAM_BOT_TOKEN + FRANK_C2_TELEGRAM_CHAT_ID from env
+# (mounted from the same Infisical-backed Secret used by Grafana/ArgoCD).
+set -uo pipefail
+
+TITLE="${1:-multi-agent-shell alert}"
+DETAIL="${2:-}"
+
+: "${FRANK_C2_TELEGRAM_BOT_TOKEN:=}"
+: "${FRANK_C2_TELEGRAM_CHAT_ID:=}"
+if [[ -z "$FRANK_C2_TELEGRAM_BOT_TOKEN" || -z "$FRANK_C2_TELEGRAM_CHAT_ID" ]]; then
+    # Fail-silent: missing creds is not an installer-blocking condition.
+    exit 0
+fi
+
+POD="${HOSTNAME:-multi-agent-shell}"
+# `printf` (no trailing %s\n) avoids the trailing-blank-line that a HEREDOC
+# leaves in the urlencoded body — Telegram renders the extra blank line in chat.
+TEXT=$(printf '%s\n\n%s\n\nPod: %s\nLogs: kubectl logs %s -c multi-agent-shell' \
+    "$TITLE" "$DETAIL" "$POD" "$POD")
+
+curl -fsS --max-time 10 \
+    -X POST "https://api.telegram.org/bot${FRANK_C2_TELEGRAM_BOT_TOKEN}/sendMessage" \
+    --data-urlencode "chat_id=${FRANK_C2_TELEGRAM_CHAT_ID}" \
+    --data-urlencode "text=${TEXT}" >/dev/null || true

--- a/multi-agent-shell/tests/test_install_inventory.bats
+++ b/multi-agent-shell/tests/test_install_inventory.bats
@@ -16,6 +16,24 @@ setup() {
 
 teardown() { rm -rf "$TMP_HOME"; }
 
+# Seed a local bare git repo with one commit on `main` and echo its path.
+# Used as a network-free skill source.
+seed_bare_repo() {
+  local remote seed
+  remote=$(mktemp -d)
+  git init -q --bare "$remote/superpowers.git"
+  seed=$(mktemp -d)
+  git -C "$seed" init -q
+  git -C "$seed" config user.email t@t
+  git -C "$seed" config user.name t
+  : > "$seed/README"
+  git -C "$seed" add README
+  git -C "$seed" -c commit.gpgsign=false commit -qm seed
+  git -C "$seed" branch -M main
+  git -C "$seed" push -q "$remote/superpowers.git" main
+  echo "$remote/superpowers.git"
+}
+
 @test "harnesses: latest invokes update command" {
   cat > "$HOME/inventory.yaml" <<'YAML'
 harnesses:
@@ -90,4 +108,95 @@ YAML
   echo '{}' > "$HOME/inventory.yaml"
   run env INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
   [ "$status" -eq 0 ]
+}
+
+@test "skills: successful clone is counted in the summary (no subshell loss)" {
+  bare="$(seed_bare_repo)"
+  cat > "$HOME/inventory.yaml" <<YAML
+skills:
+  claude:
+    - name: superpowers
+      source: git+file://$bare
+      ref: main
+YAML
+  run env INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
+  [ "$status" -eq 0 ]
+  # The clone must register in installed=N (regression guard: the counter
+  # used to be lost to a pipe-induced subshell and reported installed=0).
+  [[ "$output" == *"✓ skill claude/superpowers cloned"* ]]
+  echo "$output" | grep -qE 'installed=[1-9]'
+}
+
+@test "skills: second run is idempotent (fast-forwards, not re-clone)" {
+  bare="$(seed_bare_repo)"
+  cat > "$HOME/inventory.yaml" <<YAML
+skills:
+  claude:
+    - name: superpowers
+      source: git+file://$bare
+      ref: main
+YAML
+  INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
+  run env INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"= skill claude/superpowers checked out"* ]]
+  [ -d "$HOME/.claude/skills/superpowers/.git" ]
+}
+
+@test "skills: broken source is accounted as failed (not silent)" {
+  cat > "$HOME/inventory.yaml" <<'YAML'
+skills:
+  claude:
+    - name: bogus
+      source: git+file:///nonexistent/no/such/repo.git
+      ref: main
+YAML
+  run env INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
+  # Fail-open: still exits 0, but the failure must show in the summary so the
+  # Telegram notifier fires (unlike the previous warn-only behaviour).
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -qE 'failed=[1-9]'
+}
+
+@test "removed.skills: deletes the cloned skill dir" {
+  bare="$(seed_bare_repo)"
+  cat > "$HOME/inventory.yaml" <<YAML
+skills:
+  claude:
+    - name: superpowers
+      source: git+file://$bare
+      ref: main
+YAML
+  INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
+  [ -d "$HOME/.claude/skills/superpowers" ]
+  cat > "$HOME/inventory.yaml" <<'YAML'
+removed:
+  skills:
+    claude:
+      - superpowers
+YAML
+  run env INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
+  [ "$status" -eq 0 ]
+  [ ! -d "$HOME/.claude/skills/superpowers" ]
+}
+
+@test "removed.mcp-servers: deletes the named server from mcp.json" {
+  cat > "$HOME/inventory.yaml" <<'YAML'
+mcp-servers:
+  claude:
+    - name: context7
+      command: npx
+      args: ["-y", "@upstash/context7-mcp"]
+YAML
+  INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
+  [ "$(jq '.mcpServers | length' "$HOME/.claude/mcp.json")" = "1" ]
+  cat > "$HOME/inventory.yaml" <<'YAML'
+removed:
+  mcp-servers:
+    claude:
+      - context7
+YAML
+  run env INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
+  [ "$status" -eq 0 ]
+  [ "$(jq '.mcpServers | length' "$HOME/.claude/mcp.json")" = "0" ]
 }

--- a/multi-agent-shell/tests/test_install_inventory.bats
+++ b/multi-agent-shell/tests/test_install_inventory.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+# Tests the three new inventory keys added by the multi-harness standard:
+# harnesses, mcp-servers, skills. The existing keys (mise/npm-global/pipx/cargo)
+# are exercised by the CI smoke job, not here.
+
+setup() {
+  export TMP_HOME=$(mktemp -d)
+  export HOME=$TMP_HOME
+  mkdir -p "$HOME/.claude"
+  # Redirect lib.sh state/log dirs into the tmp HOME so the installer can run
+  # as a normal user without /var/* permissions.
+  export MULTI_AGENT_SHELL_LOG_DIR="$HOME/log"
+  export MULTI_AGENT_SHELL_STATE_DIR="$HOME/state"
+  INSTALLER="$(realpath rootfs/usr/local/lib/multi-agent-shell/install-inventory.sh)"
+}
+
+teardown() { rm -rf "$TMP_HOME"; }
+
+@test "harnesses: latest invokes update command" {
+  cat > "$HOME/inventory.yaml" <<'YAML'
+harnesses:
+  claude: latest
+YAML
+  # Stub `claude` to record invocation. The installer is expected to call
+  # `claude update` (or whatever the harness manifest declares); presence in
+  # the log file is sufficient to prove the key was handled.
+  mkdir -p "$HOME/.local/bin"
+  cat > "$HOME/.local/bin/claude" <<STUB
+#!/bin/sh
+echo "claude \$*" >> "$HOME/claude.log"
+STUB
+  chmod +x "$HOME/.local/bin/claude"
+  PATH="$HOME/.local/bin:$PATH" INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
+  grep -q 'claude update' "$HOME/claude.log"
+}
+
+@test "mcp-servers: appends to per-harness mcp.json idempotently" {
+  cat > "$HOME/inventory.yaml" <<'YAML'
+mcp-servers:
+  claude:
+    - name: context7
+      command: npx
+      args: ["-y", "@upstash/context7-mcp"]
+YAML
+  INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
+  INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"   # idempotency
+  # Two runs must produce exactly one entry under .mcpServers.
+  [ "$(jq '.mcpServers | length' "$HOME/.claude/mcp.json")" = "1" ]
+  [ "$(jq -r '.mcpServers.context7.command' "$HOME/.claude/mcp.json")" = "npx" ]
+}
+
+@test "skills: clones git source into per-harness skills dir" {
+  # Use a local bare repo as the source so we don't touch network.
+  tmp_remote=$(mktemp -d)
+  git init -q --bare "$tmp_remote/superpowers.git"
+  # Seed the bare repo with a single commit so `git clone` does not yield
+  # an empty working tree (which still creates the dir, but we also want
+  # to prove the clone succeeded end-to-end).
+  tmp_seed=$(mktemp -d)
+  git -C "$tmp_seed" init -q
+  git -C "$tmp_seed" config user.email t@t
+  git -C "$tmp_seed" config user.name t
+  : > "$tmp_seed/README"
+  git -C "$tmp_seed" add README
+  git -C "$tmp_seed" -c commit.gpgsign=false commit -qm seed
+  git -C "$tmp_seed" branch -M main
+  git -C "$tmp_seed" push -q "$tmp_remote/superpowers.git" main
+  cat > "$HOME/inventory.yaml" <<YAML
+skills:
+  claude:
+    - name: superpowers
+      source: git+file://$tmp_remote/superpowers.git
+      ref: main
+YAML
+  INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
+  [ -d "$HOME/.claude/skills/superpowers/.git" ]
+}
+
+@test "fail-open: broken harness pin logs but exits 0" {
+  cat > "$HOME/inventory.yaml" <<'YAML'
+harnesses:
+  nonexistent_xyz_no_such_harness: latest
+YAML
+  run env INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"nonexistent_xyz_no_such_harness"* ]]
+}
+
+@test "empty inventory: clean exit, no errors" {
+  echo '{}' > "$HOME/inventory.yaml"
+  run env INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
+  [ "$status" -eq 0 ]
+}

--- a/multi-agent-shell/tests/test_motd.bats
+++ b/multi-agent-shell/tests/test_motd.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+# Tests the auth-status MOTD drop-in for multi-agent-shell.
+# The detector reads only the credential file paths declared
+# in the harness manifest; presence-only, no validity check.
+
+setup() {
+  export TMP_HOME="$(mktemp -d)"
+  export HOME="$TMP_HOME"
+  MOTD="$(realpath rootfs/etc/profile.d/50-multi-agent-shell-motd.sh)"
+}
+
+teardown() { rm -rf "$TMP_HOME"; }
+
+@test "no creds: all harnesses show ✗ not logged in" {
+  run bash "$MOTD"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✗ claude"* ]]
+  [[ "$output" == *"✗ codex"* ]]
+  [[ "$output" == *"✗ gemini"* ]]
+  [[ "$output" == *"✗ opencode"* ]]
+}
+
+@test "claude creds present: shows ✓ for claude only" {
+  mkdir -p "$TMP_HOME/.claude"
+  echo '{}' > "$TMP_HOME/.claude/credentials.json"
+  run bash "$MOTD"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✓ claude"* ]]
+  [[ "$output" == *"✗ codex"* ]]
+}


### PR DESCRIPTION
📦 Repo:   derio-net/agent-images
📋 Plan:   docs/superpowers/plans/2026-06-01-agent-shells-batch
📐 Spec:   docs/superpowers/specs/2026-05-12-agent-shells-batch-design.md
🎯 Phase:  1/3 — multi-agent-shell + standard impl + CI intermediate [agentic]
🔗 Issue:  https://github.com/derio-net/agent-images/issues/98

**Goal (from plan):** Add the load-bearing `multi-agent-shell` image — bakes `claude`/`codex`/`gemini`/`opencode`, implements `docs/standards/multi-harness-shells.md`, and establishes the reusable scaffolding (inventory-installer extension, auth-MOTD drop-in, CI intermediate-base + smoke job) that Phases 2 (hermes-agent-shell) and 3 (infra-shell, `FROM multi-agent-shell`) mirror or inherit.

## Summary

- **Image** — `multi-agent-shell/Dockerfile` is `FROM agent-shell-base` and bakes three new harness bootstrap shims (`codex` `0.136.0`, `gemini-cli` `0.44.1`, `opencode-ai` `1.15.13`) alongside the inherited `claude`. Pins captured during execution (`npm view <pkg> version` on 2026-06-01) and exposed as build args so CI can override.
- **Auth-status MOTD** — `rootfs/etc/profile.d/50-multi-agent-shell-motd.sh` is the standard's presence-only detector. `45-multi-agent-shell-reconcile-motd.sh` retains the paperclip-style "last reconcile" summary; the 45/50 numbering preserves the spec order (reconcile first, auth table appended).
- **Inventory installer** — extended with the three new schema keys (`harnesses`, `mcp-servers`, `skills`). New code uses `yq`+`jq` (yq inherited from `agent-base`). `mcp-servers` merges idempotently by `.name`; `skills` clones-or-fast-forwards git sources into `~/.<harness>/skills/<name>`. All three are fail-open per the standard.
- **CI** — `build-multi-agent-shell` is a SECOND intermediate base (parallel to `build-shell-base`) so Phase 3 `infra-shell` can `FROM multi-agent-shell:<sha>`. New `smoke-test-multi-agent-shell` asserts the standard's smoke contract end-to-end against an empty inventory AND a populated one (mcp.json merge round-trip). Wired into `dispatch-frank.needs`.
- **Docs** — image `README.md` written per the standard's "Adopting the standard" checklist (harness manifest table, inventory schema, first-boot operator runbook, smoke pointer). Top-level `README.md` Images table gains the row.

## Decisions taken during execution

- **YAML parsing for the new sections uses `yq`** (already in `agent-base`) rather than the existing python+PyYAML path. Keeps the new code self-contained, makes bats tests work without PyYAML on the host, and the existing keys keep their python parsing to minimise diff against paperclip-shell's baseline.
- **T5.S3 default (a)**: only the `build-multi-agent-shell` intermediate job, no `build-children` matrix entry. The intermediate already pushes `:sha` and `:latest`, so tag parity is preserved; a matrix entry would double-build.
- **T4.S3 local build skipped**: no docker available in the execution environment. CI `smoke-test-multi-agent-shell` performs the equivalent `<h> --version` walk as UID 1000 — that's the load-bearing assertion, not the local run.

## Smoke checklist

- [ ] CI `build-multi-agent-shell` green (new intermediate base layer pushes).
- [ ] CI `smoke-test-multi-agent-shell` green — all four `<h> --version` clean on UID 1000, empty-inventory reconcile reports `failed=0`, mcp.json merge round-trip lands `context7` under `.mcpServers`.
- [ ] `dispatch-frank` includes `smoke-test-multi-agent-shell` and stays green.

Refs #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)