### PR TITLE
fix(shells): resolve symlink in install-inventory.sh so reconcile works under cap-drop=ALL smoke

### DIFF
--- a/hermes-agent-shell/rootfs/usr/local/lib/hermes-agent-shell/install-inventory.sh
+++ b/hermes-agent-shell/rootfs/usr/local/lib/hermes-agent-shell/install-inventory.sh
@@ -15,8 +15,12 @@ set -uo pipefail
 
 # Source path resolves to the script's own directory so the same code runs
 # both in the baked image (under /usr/local/lib/hermes-agent-shell) and from
-# a checked-out tree during bats tests.
-_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# a checked-out tree during bats tests. `readlink -f` resolves the symlink
+# at /usr/local/bin/hermes-agent-shell-reconcile → this file; without it,
+# BASH_SOURCE[0] is the symlink path and `_self_dir` lands in /usr/local/bin/
+# where lib.sh doesn't exist — the source silently fails (no `set -e`),
+# functions go undefined, and `set -u` trips on the first sibling-var read.
+_self_dir="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 . "$_self_dir/lib.sh"
 hermes_agent_shell_init_dirs

--- a/infra-shell/rootfs/usr/local/lib/infra-shell/install-inventory.sh
+++ b/infra-shell/rootfs/usr/local/lib/infra-shell/install-inventory.sh
@@ -15,8 +15,12 @@ set -uo pipefail
 
 # Source path resolves to the script's own directory so the same code runs
 # both in the baked image (under /usr/local/lib/infra-shell) and from
-# a checked-out tree during bats tests.
-_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# a checked-out tree during bats tests. `readlink -f` resolves the symlink
+# at /usr/local/bin/infra-shell-reconcile → this file; without it,
+# BASH_SOURCE[0] is the symlink path and `_self_dir` lands in /usr/local/bin/
+# where lib.sh doesn't exist — the source silently fails (no `set -e`),
+# functions go undefined, and `set -u` trips on the first sibling-var read.
+_self_dir="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 . "$_self_dir/lib.sh"
 infra_shell_init_dirs

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/install-inventory.sh
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/install-inventory.sh
@@ -15,8 +15,12 @@ set -uo pipefail
 
 # Source path resolves to the script's own directory so the same code runs
 # both in the baked image (under /usr/local/lib/multi-agent-shell) and from
-# a checked-out tree during bats tests.
-_self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# a checked-out tree during bats tests. `readlink -f` resolves the symlink
+# at /usr/local/bin/multi-agent-shell-reconcile → this file; without it,
+# BASH_SOURCE[0] is the symlink path and `_self_dir` lands in /usr/local/bin/
+# where lib.sh doesn't exist — the source silently fails (no `set -e`),
+# functions go undefined, and `set -u` trips on the first sibling-var read.
+_self_dir="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 . "$_self_dir/lib.sh"
 multi_agent_shell_init_dirs


### PR DESCRIPTION
## Summary

Unblocks the CI smoke contract for all three `*-shell` images shipped by the 2026-06-01-agent-shells-batch (multi-agent-shell, hermes-agent-shell, infra-shell).

The `install-inventory.sh` script in each of those three trees uses
`_self_dir="$(cd "$(dirname "\${BASH_SOURCE[0]}")" && pwd)"` to find its sibling `lib.sh`. The Dockerfile installs the script as a symlink at `/usr/local/bin/<image>-shell-reconcile`, and the smoke test invokes the binary via that path — so `BASH_SOURCE[0]` is the symlink itself and `_self_dir` lands in `/usr/local/bin/` where `lib.sh` does not exist. With only `set -uo pipefail` (no `-e`), the failed `. "$_self_dir/lib.sh"` is silent; the next line calls `<image>_init_dirs` (`command not found`) and `${<IMAGE>_LOG_DIR}` trips `set -u`. The script exits 1 and the smoke job fails.

Fix: wrap the path in `readlink -f` so `_self_dir` resolves to the script's actual directory (`/usr/local/lib/<image>`) regardless of whether the symlink or the real path was used. Applied identically to all three shells.

## Affected runs (smoke jobs that have been failing on main since their respective phase merged)

| Image | Phase merge SHA | First failing run |
|---|---|---|
| `multi-agent-shell` | `eefacb3` (Phase 1, 2026-06-01) | run 26781140193 |
| `hermes-agent-shell` | `56bc131` (Phase 2, 2026-06-02) | run 26844706078 |
| `infra-shell` | `6af5c605` (Phase 3, 2026-06-03) | run 26867441909 |

Each fails with the same two-line error pair:

```
/usr/local/bin/<image>-shell-reconcile: line 22:
    <image>_init_dirs: command not found
/usr/local/bin/<image>-shell-reconcile: line 25:
    <IMAGE>_LOG_DIR: unbound variable
```

`dispatch-frank` has been skipped on every push since Phase 1's merge because of these failures.

## Local verification

Reproduced the failure path against an unfixed copy of the script + a symlink:

```
$ bash bin/reconcile-buggy
bin/reconcile-buggy: line 4: /tmp/fix-test/bin/lib.sh: No such file or directory
bin/reconcile-buggy: line 5: infra_shell_init_dirs: command not found
bin/reconcile-buggy: line 6: INFRA_SHELL_LOG_DIR: unbound variable
```

After the `readlink -f` fix, both direct and symlink invocations source `lib.sh`, expose the env vars, and reach `PASS`. (The `mkdir: Permission denied` on `/var/log/cont-init.d` is the no-root sandbox harmless side effect — relevant under cap-drop=ALL on the runner where the dir is pre-created by `install -d` in the Dockerfile.)

## Test plan

- [ ] CI build chain reaches `build-children` for all three shells (already green on main today).
- [ ] CI `smoke-test-multi-agent-shell` reports `failed=0` and a non-empty `last-reconcile.motd`; mcp.json merge step succeeds.
- [ ] CI `smoke-test-hermes-agent-shell` reports `failed=0`; BYOK MOTD prints `~ hermes`.
- [ ] CI `smoke-test-infra-shell` reports `failed=0`; auth MOTD prints `✗ claude`; the three admin-tool `--version` steps each exit 0.
- [ ] CI `dispatch-frank` fires `agent-images-bumped` for the first time since Phase 1's merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)