### PR TITLE
fix(ruflo-server): GridFS shim errors on missing file (match upstream rvf.spec.ts)

### DIFF
--- a/ruflo-server/patches/rvf-gridfs-parity.patch
+++ b/ruflo-server/patches/rvf-gridfs-parity.patch
@@ -8,21 +8,20 @@
  
  // ---------------------------------------------------------------------------
  // ObjectId compatibility
-@@ -1022,41 +1023,52 @@
+@@ -1022,41 +1023,59 @@ export class RvfGridFSBucket {
  		options?: { metadata?: Record<string, unknown>; contentType?: string }
  	) {
  		const id = randomUUID();
 -		const chunks: string[] = [];
--
++		const chunks: Buffer[] = [];
++		const files = this.files;
+ 
 -		return {
 -			id: new ObjectId(id),
 -			write(chunk: Buffer | string) {
 -				chunks.push(
 -					typeof chunk === "string" ? chunk : chunk.toString("base64")
 -				);
-+		const chunks: Buffer[] = [];
-+		const files = this.files;
-+
 +		// objectMode so callers may pass ArrayBuffer/Uint8Array/Buffer/string
 +		// (uploadFile.ts hands us an ArrayBuffer cast to Buffer).
 +		const stream = new Writable({
@@ -84,13 +83,20 @@
 -			},
 -		};
 +		const file = this.files.get(fileId);
-+		return Readable.from(
-+			file ? [Buffer.from(file.data as string, "base64")] : []
-+		);
++		if (!file) {
++			// Match MongoDB GridFS (and the prior shim): a missing file is an
++			// error. Surface it on the stream so callers see it via either
++			// .on("error") or a rejected .toArray(), rather than silently
++			// yielding zero bytes.
++			const missing = new Readable({ read() {} });
++			missing.destroy(new Error("File not found"));
++			return missing;
++		}
++		return Readable.from([Buffer.from(file.data as string, "base64")]);
  	}
  
  	async delete(id: ObjectId | string) {
-@@ -1065,7 +1077,7 @@
+@@ -1065,7 +1084,7 @@ export class RvfGridFSBucket {
  		scheduleSave();
  	}
  
@@ -99,17 +105,15 @@
  		const results: Record<string, unknown>[] = [];
  		for (const doc of this.files.values()) {
  			if (matchesFilter(doc, filter)) {
-@@ -1073,6 +1085,10 @@
+@@ -1073,6 +1092,10 @@ export class RvfGridFSBucket {
  				results.push(meta);
  			}
  		}
 -		return { toArray: async () => results };
--	}
--}
 +		let i = 0;
 +		return {
 +			next: async () => (i < results.length ? results[i++] : null),
 +			toArray: async () => results,
 +		};
-+	}
-+}
+ 	}
+ }

--- a/ruflo-server/test/rvf-gridfs-contract.test.mjs
+++ b/ruflo-server/test/rvf-gridfs-contract.test.mjs
@@ -8,13 +8,14 @@
 // all crash. This test pins the contract the callers actually require:
 //   - openUploadStream() -> Writable that accepts ArrayBuffer/Buffer/string,
 //     emits "finish"/"error", exposes .id
-//   - openDownloadStream() -> Readable emitting the stored bytes
+//   - openDownloadStream() -> Readable emitting the stored bytes, or an
+//     error-stream ("File not found") for a missing file (GridFS semantics)
 //   - find() -> SYNC cursor with next() and toArray()
 //   - base64 storage round-trips
 //
 // It mirrors the patched implementation (the patch lands in the vendored
 // ruflo source at build time, which is not present in this repo), so it doubles
-// as the executable spec for the upstream PR. Run: node --test ruflo-server/test/
+// as the executable spec for the upstream PR. Run: node --test ruflo-server/test/*.mjs
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { Readable, Writable } from "node:stream";
@@ -54,7 +55,14 @@ function makeBucket() {
 		},
 		openDownloadStream(id) {
 			const f = files.get(String(id));
-			return Readable.from(f ? [Buffer.from(f.data, "base64")] : []);
+			if (!f) {
+				// Match MongoDB GridFS (and the prior shim): a missing file is
+				// an error, surfaced on the stream.
+				const missing = new Readable({ read() {} });
+				missing.destroy(new Error("File not found"));
+				return missing;
+			}
+			return Readable.from([Buffer.from(f.data, "base64")]);
 		},
 		find(filter = {}) {
 			const r = [...files.values()]
@@ -111,6 +119,14 @@ test("pipe copy round-trips (conversation.ts fork-from-shared pattern)", async (
 	const dstId = (await b.find({ filename: "dst" }).next())._id;
 	const out = await readBack(b.openDownloadStream(dstId));
 	assert.equal(out.toString(), "payload");
+});
+
+test("openDownloadStream errors on a missing file (GridFS semantics; matches upstream rvf.spec.ts)", async () => {
+	const b = makeBucket();
+	// The upstream rvf.spec.ts "delete file" case asserts that downloading a
+	// deleted/absent file rejects with "File not found". A naive empty-Readable
+	// would silently resolve to [] and break that test.
+	await assert.rejects(b.openDownloadStream("does-not-exist").toArray(), /File not found/);
 });
 
 test("find().toArray() returns metadata without the data blob", async () => {


### PR DESCRIPTION
## Summary

Follow-up to the `RvfGridFSBucket` GridFS-shim parity fix (PR #96). A code review of the upstream PR ([ruvnet/ruflo#2293](https://github.com/ruvnet/ruflo/pull/2293)) surfaced one defect: the patch made `openDownloadStream` return an **empty `Readable`** for a missing file, but upstream's own `rvf.spec.ts` "delete file" test asserts that downloading a deleted/absent file **rejects with `"File not found"`**. The empty-Readable would silently resolve `.toArray()` to `[]` → red CI on the upstream PR.

This makes `openDownloadStream` surface a missing file as an **error on the stream** — matching MongoDB GridFS semantics and what the prior (broken) shim did via `toArray()`. The fix has been mirrored into the upstream PR.

**No runtime impact on the deployed image.** The real callers never hit the missing-file path:
- `downloadFile.ts` guards with `find(...).next()` (returns `null` → handled) before `openDownloadStream`.
- `conversation.ts` (copy-on-fork) iterates `find(...).toArray()` first, downloading only files it just listed.
- Both also attach `.on("error", …)`.

So the currently-deployed `0ff7014` image (which returns the empty Readable on the unreachable path) is behaviorally equivalent; this change just keeps the local patch identical to the upstream PR and the contract honest. No redeploy required.

## Changes

- `ruflo-server/patches/rvf-gridfs-parity.patch` — `openDownloadStream` errors (`File not found`) on a missing file instead of returning an empty `Readable`. Verified the patch still applies cleanly at the pinned `RUFLO_GIT_REF=a6dd4ab` (rvf.ts is byte-identical at `a6dd4ab` and current upstream `main`).
- `ruflo-server/test/rvf-gridfs-contract.test.mjs` — sync the inline shim, add a missing-file rejection case, and fix the header's run command (`node --test` needs a file glob, not a bare directory, on current Node).

## Test plan

```
node --test ruflo-server/test/*.mjs    # 4 pass (round-trip, pipe copy, missing-file error, cursor metadata)
```
