### PR TITLE
chore: vk repair — normalize plan/spec refs (vk 2.6.0 sweep)

### DIFF
--- a/docs/superpowers/implemented/plans/2026-04-18-persistent-agent-reliability/_meta.yaml
+++ b/docs/superpowers/implemented/plans/2026-04-18-persistent-agent-reliability/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-18-persistent-agent-reliability
-spec: docs/superpowers/specs/2026-04-18-persistent-agent-reliability-design.md
+spec: 2026-04-18-persistent-agent-reliability-design.md
 target_repo: derio-net/agent-images
 vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-18'

--- a/docs/superpowers/implemented/plans/2026-04-22-silent-reconnect-phantoms/_meta.yaml
+++ b/docs/superpowers/implemented/plans/2026-04-22-silent-reconnect-phantoms/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-22-silent-reconnect-phantoms
-spec: docs/superpowers/specs/2026-04-22-silent-reconnect-phantoms-design.md
+spec: 2026-04-22-silent-reconnect-phantoms-design.md
 target_repo: derio-net/agent-images
 vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-22'

--- a/docs/superpowers/implemented/plans/2026-04-22-vk-bridge-warn-patterns/_meta.yaml
+++ b/docs/superpowers/implemented/plans/2026-04-22-vk-bridge-warn-patterns/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-22-vk-bridge-warn-patterns
-spec: docs/superpowers/specs/2026-04-18-persistent-agent-reliability-design.md
+spec: 2026-04-18-persistent-agent-reliability-design.md
 target_repo: derio-net/agent-images
 vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-22'

--- a/docs/superpowers/implemented/plans/2026-04-22-vk-local-memory-profile/_meta.yaml
+++ b/docs/superpowers/implemented/plans/2026-04-22-vk-local-memory-profile/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-04-22-vk-local-memory-profile
-spec: docs/superpowers/specs/2026-04-18-persistent-agent-reliability-design.md
+spec: 2026-04-18-persistent-agent-reliability-design.md
 target_repo: derio-net/agent-images
 vk_version: '>=2.0.0,<3.0.0'
 created: '2026-04-22'

--- a/docs/superpowers/implemented/plans/2026-05-25-shell-inventory-mise-activation/_meta.yaml
+++ b/docs/superpowers/implemented/plans/2026-05-25-shell-inventory-mise-activation/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-05-25-shell-inventory-mise-activation
-spec: docs/superpowers/specs/2026-05-25-shell-inventory-mise-activation-design.md
+spec: 2026-05-25-shell-inventory-mise-activation-design.md
 target_repo: derio-net/agent-images
 vk_version: '>=2.0.0,<3.0.0'
 created: '2026-05-25'

--- a/docs/superpowers/implemented/specs/2026-04-18-persistent-agent-reliability-design.md
+++ b/docs/superpowers/implemented/specs/2026-04-18-persistent-agent-reliability-design.md
@@ -54,7 +54,7 @@ None. No new capabilities, no loosened guardrails. The audit-hook fix restores a
 
 | Plan | Repo | File | Depends on |
 |------|------|------|------------|
-| Persistent Agent Reliability Implementation Plan | `derio-net/agent-images` | `docs/superpowers/archived-plans/2026-04-18-persistent-agent-reliability/` | — |
-| vk-bridge Warn-Pattern Broadening Implementation Plan | `derio-net/agent-images` | `docs/superpowers/archived-plans/2026-04-22-vk-bridge-warn-patterns/` | — |
-| vk-local Memory Profiling Implementation Plan | `derio-net/agent-images` | `docs/superpowers/archived-plans/2026-04-22-vk-local-memory-profile/` | — |
-| Silent-Reconnect Phantom Reaper Implementation Plan | `derio-net/agent-images` | `docs/superpowers/archived-plans/2026-04-22-silent-reconnect-phantoms/` | — |
+| Persistent Agent Reliability Implementation Plan | `derio-net/agent-images` | `2026-04-18-persistent-agent-reliability` | — |
+| vk-bridge Warn-Pattern Broadening Implementation Plan | `derio-net/agent-images` | `2026-04-22-vk-bridge-warn-patterns` | — |
+| vk-local Memory Profiling Implementation Plan | `derio-net/agent-images` | `2026-04-22-vk-local-memory-profile` | — |
+| Silent-Reconnect Phantom Reaper Implementation Plan | `derio-net/agent-images` | `2026-04-22-silent-reconnect-phantoms` | — |

--- a/docs/superpowers/implemented/specs/2026-04-22-silent-reconnect-phantoms-design.md
+++ b/docs/superpowers/implemented/specs/2026-04-22-silent-reconnect-phantoms-design.md
@@ -216,4 +216,4 @@ Triggered only if Phase 0 records Decision **B**.
 
 | Plan | Repo | File | Depends on |
 |------|------|------|------------|
-| Silent-Reconnect Phantom Reaper Implementation Plan | `derio-net/agent-images` | `docs/superpowers/archived-plans/2026-04-22-silent-reconnect-phantoms/` | — |
+| Silent-Reconnect Phantom Reaper Implementation Plan | `derio-net/agent-images` | `2026-04-22-silent-reconnect-phantoms` | — |

--- a/docs/superpowers/implemented/specs/2026-05-25-shell-inventory-mise-activation-design.md
+++ b/docs/superpowers/implemented/specs/2026-05-25-shell-inventory-mise-activation-design.md
@@ -187,7 +187,7 @@ not built here.
 
 | Plan | Repo | File | Depends on |
 |------|------|------|------------|
-| 2026-05-25-shell-inventory-mise-activation | `derio-net/agent-images` | `docs/superpowers/archived-plans/2026-05-25-shell-inventory-mise-activation/` | — |
+| 2026-05-25-shell-inventory-mise-activation | `derio-net/agent-images` | `2026-05-25-shell-inventory-mise-activation` | — |
 
 ## Out of scope
 

--- a/docs/superpowers/plans/2026-06-01-agent-shells-batch/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-01-agent-shells-batch/_meta.yaml
@@ -1,6 +1,6 @@
 schema_version: 2
 plan: 2026-06-01-agent-shells-batch
-spec: docs/superpowers/specs/2026-05-12-agent-shells-batch-design.md
+spec: 2026-05-12-agent-shells-batch-design.md
 target_repo: derio-net/agent-images
 vk_version: '>=2.0.0,<3.0.0'
 created: '2026-06-01'

--- a/docs/superpowers/specs/2026-05-12-agent-shells-batch-design.md
+++ b/docs/superpowers/specs/2026-05-12-agent-shells-batch-design.md
@@ -277,4 +277,4 @@ Tracked here so the plan author has the complete list:
 
 | Plan | Repo | File | Depends on |
 |------|------|------|------------|
-| 2026-06-01-agent-shells-batch | `derio-net/agent-images` | `docs/superpowers/plans/2026-06-01-agent-shells-batch/` | — |
+| 2026-06-01-agent-shells-batch | `derio-net/agent-images` | `2026-06-01-agent-shells-batch` | — |


### PR DESCRIPTION
Stale path-form plan/spec references were normalized to bare slugs by `vk repair --yes`.

`_meta.yaml` `spec:` fields and Implementation-Plans table File cells previously held lifecycle-coupled paths (e.g. `docs/superpowers/archived-plans/<slug>/`, `docs/superpowers/specs/<slug>-design.md`). `vk repair` rewrites these to lifecycle-independent bare slugs (`<slug>`, `<slug>-design.md`) so refs survive plan/spec promotion and archival.

13 rewrites across 10 files. Docs-only — no code or installer changes.

Part of the post-superpowers-for-vk#266 fleet sweep (vk 2.6.0 lifecycle-independent refs).

Two unresolved cross-repo spec warnings (`2026-05-06-vk-rebuild-state-machine-design.md`, `2026-05-13-spec-dispatch-design.md`) were left untouched by `vk repair` as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)