### PR TITLE
feat(hermes): PVC-resident venv + baked auto-continue patch (frank#496)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -711,8 +711,47 @@ jobs:
 
           # Single-harness manifest assertion (per
           # docs/standards/multi-harness-shells.md § "Smoke testing"):
-          # `hermes --version` runs cleanly as UID 1000.
+          # `hermes --version` runs cleanly as UID 1000. This now resolves
+          # through /usr/local/bin/hermes → the PVC venv that
+          # cont-init.d/35-hermes-venv-seed copied from the relocatable seed,
+          # so a green `--version` also proves the relocatable copy works.
           docker exec has-smoke hermes --version
+
+          # frank#496 — PVC-resident venv: the live venv must be on the PVC,
+          # uid-1000-owned and WRITABLE (the whole point: the in-pod operator
+          # can patch Hermes in place). The image seed at /opt is just a
+          # template.
+          # NB: $LIVE/bin/python is a symlink to the (root-owned) base
+          # interpreter, so `test -w` on it would follow the link and mislead.
+          # Assert writability on what the operator actually patches: the venv
+          # dir and a real site-packages file.
+          LIVE=/home/agent/.local/opt/hermes-agent
+          CL="$LIVE/lib/python3.11/site-packages/agent/conversation_loop.py"
+          docker exec has-smoke test -O "$LIVE/bin/hermes" \
+            || { echo "✗ live venv hermes not owned by uid 1000"; docker logs has-smoke; docker rm -f has-smoke; exit 1; }
+          docker exec has-smoke test -w "$CL" \
+            || { echo "✗ live conversation_loop.py not writable by uid 1000"; docker rm -f has-smoke; exit 1; }
+          docker exec has-smoke sh -c "touch $LIVE/.smoke-wtest && rm -f $LIVE/.smoke-wtest" \
+            || { echo "✗ cannot write into live venv dir"; docker rm -f has-smoke; exit 1; }
+          # The launcher must point at the PVC venv, not the /opt seed.
+          docker exec has-smoke sh -c 'readlink -f "$(command -v hermes)"' | grep -q "^$LIVE/" \
+            || { echo "✗ hermes launcher does not resolve into the PVC venv"; docker rm -f has-smoke; exit 1; }
+
+          # frank#496 — the auto-continue patch is BAKED into the live venv:
+          # the announce-only countermeasure gate is widened to chat_completions.
+          docker exec has-smoke grep -q 'api_mode in ("codex_responses", "chat_completions")' "$CL" \
+            || { echo "✗ auto-continue patch not present in live venv"; docker rm -f has-smoke; exit 1; }
+
+          # Version-aware re-seed: a changed seed marker replaces the live venv.
+          # Drop a sentinel + corrupt the live marker, re-run the hook, and
+          # assert the venv was re-seeded (sentinel gone, marker restored).
+          docker exec has-smoke sh -c "touch $LIVE/.smoke-sentinel && echo stale > $LIVE/.seed-version"
+          docker exec has-smoke /etc/cont-init.d/35-hermes-venv-seed
+          docker exec has-smoke sh -c "! test -e $LIVE/.smoke-sentinel" \
+            || { echo "✗ re-seed did not replace the live venv on version mismatch"; docker rm -f has-smoke; exit 1; }
+          docker exec has-smoke sh -c "grep -q autocontinue1 $LIVE/.seed-version" \
+            || { echo "✗ live seed marker not restored after re-seed"; docker rm -f has-smoke; exit 1; }
+          echo "✓ frank#496: PVC venv writable, patch baked, version-aware re-seed OK"
 
           # Inventory installer reconciles cleanly against the empty inventory
           # and writes a MOTD drop-in. failed=0 proves no section errored.

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -746,7 +746,11 @@ jobs:
           # Drop a sentinel + corrupt the live marker, re-run the hook, and
           # assert the venv was re-seeded (sentinel gone, marker restored).
           docker exec has-smoke sh -c "touch $LIVE/.smoke-sentinel && echo stale > $LIVE/.seed-version"
-          docker exec has-smoke /etc/cont-init.d/35-hermes-venv-seed
+          # Invoke via `bash`, not directly: the hook's `#!/command/with-contenv
+          # bash` shebang is an s6 execline wrapper that only resolves inside
+          # supervised cont-init, not a bare `docker exec`. The hook needs no
+          # container-env (it reads only SEED/LIVE, which default correctly).
+          docker exec has-smoke bash /etc/cont-init.d/35-hermes-venv-seed
           docker exec has-smoke sh -c "! test -e $LIVE/.smoke-sentinel" \
             || { echo "✗ re-seed did not replace the live venv on version mismatch"; docker rm -f has-smoke; exit 1; }
           docker exec has-smoke sh -c "grep -q autocontinue1 $LIVE/.seed-version" \

--- a/hermes-agent-shell/Dockerfile
+++ b/hermes-agent-shell/Dockerfile
@@ -34,18 +34,44 @@ USER root
 # overrides it on first reconcile.
 ARG HERMES_VERSION=0.15.2
 
-# Install into a dedicated venv at /opt/hermes-agent so the system-python
-# layout from agent-base stays untouched (PEP 668: /usr/bin/python3 is
-# externally-managed on Debian; pip would refuse to install into it
-# anyway). uv is provided by agent-base. `uv venv` deliberately omits
-# pip from the target interpreter (uv writes wheels directly), so no
-# ensurepip bootstrap is needed. The venv's `hermes` entry-point is
-# symlinked onto PATH so the operator just runs `hermes`.
-RUN uv venv --python 3.11 /opt/hermes-agent \
+# Build a RELOCATABLE SEED venv at /opt/hermes-agent (a read-only build
+# artifact, NOT the live runtime). `--relocatable` writes console scripts with
+# a `#!/bin/sh` polyglot shebang that re-execs the venv python by RELATIVE
+# path, so the seed can be copied to another directory and still run. On first
+# boot, cont-init.d/35-hermes-venv-seed `cp -a`'s this seed onto the
+# /home/agent PVC at /home/agent/.local/opt/hermes-agent — the LIVE venv,
+# uid-1000-owned and writable, so the in-pod operator can patch/maintain
+# Hermes in place (`hermes update`, site-packages edits) and have it persist
+# across pod restarts (frank#496). The venv cannot be baked at the PVC path
+# directly: the PVC mount at /home/agent shadows anything baked under it.
+#
+# The system-python layout from agent-base stays untouched (PEP 668:
+# /usr/bin/python3 is externally-managed). uv is provided by agent-base; `uv
+# venv` omits pip (uv writes wheels directly), so no ensurepip bootstrap.
+#
+# Auto-continue patch (frank#496): Hermes v0.15.2 gates its "announce-only
+# turn" countermeasure (inject `[System: Continue now…]`) on
+# api_mode == "codex_responses", so it never fires on the OpenAI-compatible
+# LiteLLM path Frank uses (api_mode "chat_completions"). The patch widens that
+# gate; the detection heuristic is provider-agnostic. We apply with `git apply`
+# (git is in agent-base; `patch` is not) — it tolerates ZERO context fuzz and
+# FAILS the build if the surrounding lines drift, a hard signal to refresh the
+# patch on the next HERMES_VERSION bump.
+#
+# .seed-version stamps the seed so the first-boot hook re-seeds on an
+# image/Hermes bump (and no-ops — preserving in-pod patches — when unchanged).
+# Bump the +autocontinueN suffix whenever the patch set changes.
+COPY patches/ /tmp/hermes-patches/
+RUN uv venv --relocatable --python 3.11 /opt/hermes-agent \
  && uv pip install --python /opt/hermes-agent/bin/python \
       "hermes-agent==${HERMES_VERSION}" \
- && ln -sf /opt/hermes-agent/bin/hermes /usr/local/bin/hermes \
- && /usr/local/bin/hermes --version
+ && site="$(/opt/hermes-agent/bin/python -c 'import sysconfig; print(sysconfig.get_path("purelib"))')" \
+ && ( cd "$site" && git apply -p1 /tmp/hermes-patches/hermes-autocontinue-chat-completions.patch ) \
+ && printf '%s+autocontinue1\n' "${HERMES_VERSION}" > /opt/hermes-agent/.seed-version \
+ && ln -sf /home/agent/.local/opt/hermes-agent/bin/hermes /usr/local/bin/hermes \
+ && chown -R ${AGENT_UID}:${AGENT_GID} /opt/hermes-agent \
+ && rm -rf /tmp/hermes-patches \
+ && /opt/hermes-agent/bin/hermes --version
 
 COPY --chown=root:root rootfs/ /
 
@@ -59,6 +85,7 @@ RUN install -d -o ${AGENT_UID} -g ${AGENT_GID} -m 0755 \
       /var/log/cont-init.d \
       /var/lib/hermes-agent-shell \
  && chmod +x \
+      /etc/cont-init.d/35-hermes-venv-seed \
       /etc/cont-init.d/40-shell-inventory \
       /etc/profile.d/40-hermes-agent-shell-paths.sh \
       /etc/profile.d/45-hermes-agent-shell-reconcile-motd.sh \

--- a/hermes-agent-shell/README.md
+++ b/hermes-agent-shell/README.md
@@ -22,13 +22,30 @@ version) and the other inventory keys stay sparse.
 
 | Harness | Bootstrap | Auth command | Credential file (on PV) | Update command |
 |---|---|---|---|---|
-| `hermes` | `uv pip install hermes-agent==${HERMES_VERSION}` into `/opt/hermes-agent` (venv), `hermes` entry point symlinked onto PATH | n/a — BYOK via env (`OPENAI_BASE_URL`, `OPENAI_API_KEY`) | n/a (no local credential — operator state lives at `~/.hermes/`) | inventory `harnesses: hermes: <ver>` (re-pins PyPI install via reconcile), or image rebuild |
+| `hermes` | `uv pip install hermes-agent==${HERMES_VERSION}` into a **relocatable seed** venv at `/opt/hermes-agent`, seeded onto the PVC at `/home/agent/.local/opt/hermes-agent` on first boot (see below); `hermes` entry point symlinked onto PATH | n/a — BYOK via env (`OPENAI_BASE_URL`, `OPENAI_API_KEY`) | n/a (no local credential — operator state lives at `~/.hermes/`) | inventory `harnesses: hermes: <ver>` (runs `hermes update` in the PVC venv), or image rebuild |
 
 Notes:
 
 - **No login flow.** The standard's MOTD detector ✓/✗ pattern does not
   apply; the `50-hermes-agent-shell-motd.sh` drop-in prints a constant
   BYOK row and a one-line hint when `OPENAI_BASE_URL` is unset.
+- **PVC-resident venv (frank#496).** The image bakes a *relocatable* seed
+  venv at `/opt/hermes-agent` (`uv venv --relocatable`). On first boot
+  `cont-init.d/35-hermes-venv-seed` `cp -a`'s it onto the `/home/agent` PVC
+  at `/home/agent/.local/opt/hermes-agent` — the **live** venv, uid-1000-owned
+  and writable. So the in-pod operator can patch/maintain Hermes in place
+  (`hermes update`, site-packages edits) and the changes **persist across pod
+  restarts**. The seed is version-stamped (`/opt/hermes-agent/.seed-version`);
+  the hook re-seeds when an image/Hermes bump changes the stamp, and is a
+  no-op (preserving in-pod patches) when it matches. The launcher
+  `/usr/local/bin/hermes` points at the PVC venv. The venv cannot be baked at
+  the PVC path directly — the PVC mount shadows anything under `/home/agent`.
+- **Baked auto-continue patch (frank#496).** `patches/hermes-autocontinue-chat-completions.patch`
+  widens Hermes' "announce-only turn" countermeasure gate from
+  `codex_responses` to also fire on `chat_completions` (the LiteLLM path
+  Frank uses), permanently fixing the qwen36-a3b "announce then idle" stall.
+  Applied at build with `git apply` (zero fuzz → the build fails if the hunk
+  drifts on a `HERMES_VERSION` bump; refresh the patch then).
 - **`~/.hermes/` on the PV** is hermes' own data dir (per its installer):
   config, sessions, skills, memories. It is per-operator state, never
   baked into the image.
@@ -97,7 +114,8 @@ Same three-layer model as `multi-agent-shell` and `paperclip-shell`:
 
 | Layer | Source | Where it lands | When |
 |---|---|---|---|
-| 1 — Image baseline | this Dockerfile | image rootfs (`/opt/hermes-agent`, `/usr/local/bin/hermes`) | image build |
+| 1 — Image baseline | this Dockerfile | image rootfs: relocatable **seed** venv `/opt/hermes-agent` + launcher `/usr/local/bin/hermes` | image build |
+| 1.5 — Venv seed | relocatable seed at `/opt/hermes-agent` | **live** venv on PV `/home/agent/.local/opt/hermes-agent` (uid-1000 writable) | first boot / image bump via `cont-init.d/35-hermes-venv-seed` |
 | 2 — Inventory | mounted ConfigMap `inventory.yaml` | per-user PV under `$HOME` | every container boot via `cont-init.d/40-shell-inventory` |
 | 3 — Interactive | operator typing `hermes …`, `mise install …`, etc. | per-user PV under `$HOME` | on demand inside the SSH session |
 

--- a/hermes-agent-shell/patches/hermes-autocontinue-chat-completions.patch
+++ b/hermes-agent-shell/patches/hermes-autocontinue-chat-completions.patch
@@ -1,0 +1,11 @@
+--- a/agent/conversation_loop.py
++++ b/agent/conversation_loop.py
+@@ -4180,7 +4180,7 @@
+                 agent._clear_status_buffer()
+
+                 if (
+-                    agent.api_mode == "codex_responses"
++                    agent.api_mode in ("codex_responses", "chat_completions")
+                     and agent.valid_tool_names
+                     and codex_ack_continuations < 2
+                     and agent._looks_like_codex_intermediate_ack(

--- a/hermes-agent-shell/rootfs/etc/cont-init.d/35-hermes-venv-seed
+++ b/hermes-agent-shell/rootfs/etc/cont-init.d/35-hermes-venv-seed
@@ -1,0 +1,52 @@
+#!/command/with-contenv bash
+# 35-hermes-venv-seed — Seed the Hermes venv onto the writable PVC on first
+# boot, and re-seed when the image's seed version changes.
+#
+# The image bakes a RELOCATABLE seed venv at $SEED (read-only build artifact).
+# The LIVE venv lives at $LIVE on the /home/agent PVC — uid-1000-owned and
+# writable — so the in-pod operator can patch/maintain Hermes in place
+# (`hermes update`, site-packages edits) and have it PERSIST across pod
+# restarts. The launcher /usr/local/bin/hermes points at $LIVE/bin/hermes.
+#
+# Version-aware: when $SEED/.seed-version differs from the live marker
+# (first boot, or an image/Hermes bump) we replace the live venv. When they
+# match it's a no-op, which deliberately PRESERVES any in-pod hot-patches.
+#
+# Runs in s6 cont-init as uid 1000, numbered 35 so it precedes
+# 40-shell-inventory and the MOTD profile.d scripts that reference `hermes`.
+#
+# Fail-OPEN (always exit 0) so a seeding failure never blocks sshd — the
+# operator can still log in to debug; a dangling launcher / failed
+# `hermes --version` is the visible signal (and the CI smoke test catches it).
+#
+# SEED/LIVE are env-overridable (defaulting to the real image paths) so the
+# bats unit test can drive the logic against tmpdirs.
+set -u
+
+SEED="${SEED:-/opt/hermes-agent}"
+LIVE="${LIVE:-/home/agent/.local/opt/hermes-agent}"
+
+want="$(cat "$SEED/.seed-version" 2>/dev/null || true)"
+if [ -z "$want" ]; then
+    echo "35-hermes-venv-seed: no seed marker at $SEED/.seed-version — nothing to seed" >&2
+    exit 0
+fi
+
+have="$(cat "$LIVE/.seed-version" 2>/dev/null || true)"
+if [ "$want" = "$have" ]; then
+    echo "35-hermes-venv-seed: live venv up to date ($have) — preserving in-place changes"
+    exit 0
+fi
+
+echo "35-hermes-venv-seed: seeding ${have:-<none>} -> ${want} (SEED=$SEED LIVE=$LIVE)"
+mkdir -p "$(dirname "$LIVE")"
+rm -rf "$LIVE.new"
+if cp -a "$SEED" "$LIVE.new"; then
+    rm -rf "$LIVE"
+    mv "$LIVE.new" "$LIVE"
+    echo "35-hermes-venv-seed: live venv now ${want}"
+else
+    echo "35-hermes-venv-seed: ERROR cp -a failed; live venv left unchanged (hermes may be unavailable)" >&2
+    rm -rf "$LIVE.new"
+fi
+exit 0

--- a/hermes-agent-shell/tests/test_venv_seed.bats
+++ b/hermes-agent-shell/tests/test_venv_seed.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# Tests the first-boot venv seed hook (cont-init.d/35-hermes-venv-seed).
+#
+# The image ships a RELOCATABLE seed venv at $SEED; on first boot the hook
+# copies it onto the writable /home/agent PVC at $LIVE so uid 1000 can patch
+# Hermes in place and the changes persist across restarts. The hook is
+# version-aware: an image/Hermes bump (new $SEED/.seed-version) re-seeds,
+# while an unchanged version is a no-op that PRESERVES in-pod hot-patches.
+#
+# The hook reads SEED/LIVE from the environment (defaulting to the real image
+# paths) precisely so this test can point them at tmpdirs and run with plain
+# `bash` — no container, no s6, no network.
+
+setup() {
+  HOOK="$(realpath rootfs/etc/cont-init.d/35-hermes-venv-seed)"
+  SEED="$BATS_TEST_TMPDIR/seed"
+  LIVE="$BATS_TEST_TMPDIR/live"
+  export SEED LIVE
+  # Fake "venv": a marker + a representative file.
+  mkdir -p "$SEED/bin"
+  printf 'hermes\n' > "$SEED/bin/hermes"
+  printf '0.15.2+autocontinue1\n' > "$SEED/.seed-version"
+}
+
+run_hook() { run bash "$HOOK"; }
+
+@test "first boot seeds the venv onto the PVC path" {
+  [ ! -e "$LIVE" ]
+  run_hook
+  [ "$status" -eq 0 ]
+  [ -f "$LIVE/bin/hermes" ]
+  [ "$(cat "$LIVE/.seed-version")" = "0.15.2+autocontinue1" ]
+}
+
+@test "same-version re-run is a no-op and preserves an in-pod patch" {
+  run_hook
+  [ "$status" -eq 0 ]
+  # Operator hot-patches the live venv.
+  printf 'patched\n' > "$LIVE/bin/hermes"
+  printf 'sentinel\n' > "$LIVE/MY_PATCH"
+  run_hook
+  [ "$status" -eq 0 ]
+  [ -f "$LIVE/MY_PATCH" ]                       # patch survived
+  [ "$(cat "$LIVE/bin/hermes")" = "patched" ]   # edit survived
+}
+
+@test "a seed-version bump re-seeds and supersedes in-pod patches" {
+  run_hook
+  printf 'sentinel\n' > "$LIVE/MY_PATCH"
+  printf 'patched\n' > "$LIVE/bin/hermes"
+  # Image bump: new seed version + new content.
+  printf '0.16.0+autocontinue1\n' > "$SEED/.seed-version"
+  printf 'hermes-new\n' > "$SEED/bin/hermes"
+  run_hook
+  [ "$status" -eq 0 ]
+  [ ! -e "$LIVE/MY_PATCH" ]                          # stale patch removed
+  [ "$(cat "$LIVE/.seed-version")" = "0.16.0+autocontinue1" ]
+  [ "$(cat "$LIVE/bin/hermes")" = "hermes-new" ]     # fresh seed content
+}
+
+@test "missing seed marker is a clean no-op (does not create LIVE)" {
+  rm -f "$SEED/.seed-version"
+  run_hook
+  [ "$status" -eq 0 ]
+  [ ! -e "$LIVE" ]
+}


### PR DESCRIPTION
## Summary

Fixes [derio-net/frank#496](https://github.com/derio-net/frank/issues/496) at the image layer. The `agent` user (uid 1000) in `hermes-agent-shell` had **no way to patch the root-owned `/opt/hermes-agent` venv** (no privesc; `fsGroup` never touches image-baked files). Two operator-chosen changes (frank Q&A):

### 1. PVC-resident Hermes venv (persists patches)
- Build a **relocatable** seed venv at `/opt/hermes-agent` (`uv venv --relocatable`) — a read-only build artifact.
- New `cont-init.d/35-hermes-venv-seed` `cp -a`'s the seed onto the `/home/agent` PVC at `/home/agent/.local/opt/hermes-agent` on first boot — the **live** venv, uid-1000-owned and writable. In-pod patches / `hermes update` now persist across pod restarts.
- **Version-aware:** re-seeds when an image/Hermes bump changes `/opt/hermes-agent/.seed-version`; no-ops (preserving in-pod hot-patches) when unchanged.
- The launcher `/usr/local/bin/hermes` points at the PVC venv. (The venv can't be baked at the PVC path directly — the mount shadows it.)

### 2. Baked auto-continue patch (fixes the qwen36-a3b stall)
- `patches/hermes-autocontinue-chat-completions.patch` widens Hermes' "announce-only turn" countermeasure gate from `codex_responses` to also fire on `chat_completions` (the LiteLLM path Frank uses). The detection heuristic is provider-agnostic; verified the LiteLLM BYOK path resolves to `api_mode == "chat_completions"` via `determine_api_mode`.
- Applied at build with `git apply` (zero fuzz → build fails if the hunk drifts on a `HERMES_VERSION` bump).

## Verification
- **Local, real package:** built a relocatable hermes-0.15.2 seed, applied the patch, `cp -a`'d it to a new path, and ran `hermes --version` from the copy with the patch intact — the whole seed mechanism proven end-to-end.
- **bats unit test** (`tests/test_venv_seed.bats`): first-boot seeds; same-version re-run is a no-op preserving an in-pod patch; version bump re-seeds; missing marker is a clean no-op.
- **Extended `smoke-test-hermes-agent-shell`** (the CI integration gate): live venv is uid-1000-owned + writable, `hermes` launcher resolves into the PVC venv, the patch is baked into the live venv, and a version-mismatch re-seed replaces it.

## Downstream (frank)
After this merges and CI publishes `ghcr.io/derio-net/hermes-agent-shell:<new-sha>`, the operator bumps frank's image pin via `/bump-image hermes-agent-shell <new-sha>` (frank plan `2026-06-07--orch--hermes-agent-shell-pvc-venv`, Phase 2). The frank PR for the spec/plan tracks that back-loaded step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)