### PR TITLE
feat(kali): credential helper prefers mounted GitHub App token (least-privilege token delivery)

### DIFF
--- a/base/opt/agent-init.d/02-credential-migrate
+++ b/base/opt/agent-init.d/02-credential-migrate
@@ -2,25 +2,28 @@
 # 02-credential-migrate — Migrate stale gitconfig credential helpers on the PVC
 # to the current /opt/gitconfig.
 #
-# Two prior helper shapes have shipped:
-#   1. Legacy env-var reader: contained `password=$GITHUB_TOKEN`. Worked only
-#      when ~/.bashrc was sourced (interactive ssh), silently failed for
-#      VS Code git subprocesses and cron.
-#   2. /proc/1/environ reader: contained `/proc/1/environ`. Worked under tini,
-#      but stops being reliable under s6-overlay (PID 1 = s6-svscan does not
-#      forward K8s envFrom vars on every build).
+# Prior helper shapes that have shipped:
+#   1. Legacy env-var reader: contained `password=$GITHUB_TOKEN`.
+#   2. /proc/1/environ reader: contained `/proc/1/environ`.
+#   3. s6-envdir-only reader: read /run/s6/basedir/env/GITHUB_TOKEN directly.
 #
-# Current helper reads /run/s6/basedir/env/GITHUB_TOKEN (the s6 envdir, the
-# canonical s6 source). This script detects either prior shape on the PVC's
-# ~/.gitconfig and replaces it with the image's /opt/gitconfig.
+# Current helper PREFERS the mounted GitHub App token at /var/run/github/token
+# (rotated by ESO, key never on the pod) and falls back to the s6 envdir. This
+# script detects ANY older GitHub credential helper on the PVC's ~/.gitconfig —
+# i.e. one that references GITHUB_TOKEN / /proc/1/environ but NOT the new
+# /var/run/github/token path — and replaces it with the image's /opt/gitconfig.
+# A gitconfig already on the new path, or one with no GitHub helper at all, is
+# left untouched.
 set -e
 HOME="${AGENT_HOME:-$HOME}"
 [ -f /opt/gitconfig ] || exit 0
 [ -f "$HOME/.gitconfig" ] || exit 0
-if grep -qF 'password=$GITHUB_TOKEN' "$HOME/.gitconfig"; then
-    echo "[agent-init] migrating git credential helper: legacy env-var → s6 envdir reader"
-    cp /opt/gitconfig "$HOME/.gitconfig"
-elif grep -qF '/proc/1/environ' "$HOME/.gitconfig"; then
-    echo "[agent-init] migrating git credential helper: /proc/1/environ → s6 envdir reader"
+# Already current → nothing to do.
+if grep -qF '/var/run/github/token' "$HOME/.gitconfig"; then
+    exit 0
+fi
+# An older GitHub-token credential helper → upgrade in place.
+if grep -qE 'GITHUB_TOKEN|/proc/1/environ' "$HOME/.gitconfig"; then
+    echo "[agent-init] upgrading git credential helper → App-token file reader (fallback to s6 envdir)"
     cp /opt/gitconfig "$HOME/.gitconfig"
 fi

--- a/kali/config-templates/bashrc
+++ b/kali/config-templates/bashrc
@@ -15,7 +15,20 @@ _env_from_s6() {
     printf '%s' "$(< "$f")"
 }
 
-export GITHUB_TOKEN="${GITHUB_TOKEN:-$(_env_from_s6 GITHUB_TOKEN)}"
+# GitHub token: PREFER the live App-installation-token file (mounted at
+# /var/run/github/token, rotated by ESO ~hourly), else fall back to the s6
+# envdir token (the clawdia PAT during cutover). The git credential helper in
+# ~/.gitconfig does the same for git; this covers gh/fr which read the token
+# from the environment. NOTE: a long-lived interactive shell captures the value
+# at startup, so it can go stale after a rotation — cron jobs re-source this
+# file (session-manager.sh), and new shells always pick up the current token.
+_token_from_file() {
+    local f=/var/run/github/token
+    [ -r "$f" ] || return 0
+    printf '%s' "$(< "$f")"
+}
+export GITHUB_TOKEN="$(_token_from_file)"
+[ -n "$GITHUB_TOKEN" ] || export GITHUB_TOKEN="$(_env_from_s6 GITHUB_TOKEN)"
 export TELEGRAM_BOT_TOKEN="${TELEGRAM_BOT_TOKEN:-$(_env_from_s6 TELEGRAM_BOT_TOKEN)}"
 export TELEGRAM_CHAT_ID="${TELEGRAM_CHAT_ID:-$(_env_from_s6 TELEGRAM_CHAT_ID)}"
 export GRAFANA_API_KEY="${GRAFANA_API_KEY:-$(_env_from_s6 GRAFANA_API_KEY)}"

--- a/kali/config-templates/gitconfig
+++ b/kali/config-templates/gitconfig
@@ -1,5 +1,12 @@
 [user]
 	email = clawdia-ai-assistant@gmail.com
 	name = Clawdia
+# Credential helper: prefer the GitHub App installation token mounted at
+# /var/run/github/token (short-lived, rotated by ESO, key never on the pod),
+# falling back to the s6 envdir token during cutover. `x-access-token` is the
+# App-token username convention and is also accepted with a classic PAT, so it
+# works for both sources. Reads the first readable path and stops; `$(< file)`
+# strips the single trailing newline s6 writes (an extra empty `password=` line
+# would break git's parser).
 [credential]
-	helper = "!f() { echo \"username=clawdia-ai-assistant\"; printf 'password=%s\\n' \"$(< /run/s6/basedir/env/GITHUB_TOKEN)\"; }; f"
+	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf 'password=%s\\n' \"$(< \"$t\")\"; return; done; }; f"

--- a/kali/tests/test_bashrc_env.sh
+++ b/kali/tests/test_bashrc_env.sh
@@ -1,12 +1,15 @@
 #!/usr/bin/env bash
 # test_bashrc_env.sh — harness for kali/config-templates/bashrc.
 #
-# Verifies that a fresh non-login shell sourcing the bashrc template reads
-# secrets from the s6-overlay envdir at /run/s6/basedir/env/ (not
-# /proc/1/environ). Runs against a temp envdir so it doesn't depend on a
-# live s6-overlay install or real pod secrets.
+# Verifies that a fresh non-login shell sourcing the bashrc template:
+#   - reads the bulk of its secrets from the s6-overlay envdir at
+#     /run/s6/basedir/env/ (not /proc/1/environ), and
+#   - resolves GITHUB_TOKEN by PREFERRING the mounted App-token file at
+#     /var/run/github/token, falling back to the s6 envdir when absent.
 #
-# Reports lengths and sha256 only — never plaintext values.
+# Runs against temp fixtures so it doesn't depend on a live s6-overlay install,
+# a real mounted token, or real pod secrets. Reports lengths and sha256 only —
+# never plaintext values.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -14,21 +17,23 @@ BASHRC="$SCRIPT_DIR/config-templates/bashrc"
 TMP="$(mktemp -d)"
 trap 'rm -rf "$TMP"' EXIT
 
-# Mirror the live envdir layout into a fixture and rewrite the bashrc to
-# point at it. The bashrc references /run/s6/basedir/env/ in exactly one
-# place (`_env_from_s6`).
-FIXTURE_ENVDIR="$TMP/envdir"
-mkdir -p "$FIXTURE_ENVDIR"
-sed "s|/run/s6/basedir/env|$FIXTURE_ENVDIR|g" "$BASHRC" > "$TMP/bashrc"
+sha() { printf '%s' "$1" | sha256sum | cut -d' ' -f1; }
 
-# s6-overlay writes a trailing newline after the value. Mimic that so the
-# test exercises the same `$(< file)` newline-stripping the live shell does.
+FIXTURE_ENVDIR="$TMP/envdir"
+FIXTURE_NOFILE="$TMP/no-token-file"   # empty: no /var/run/github/token
+FIXTURE_FILE="$TMP/with-token-file"   # holds a token to prove file-preference
+mkdir -p "$FIXTURE_ENVDIR" "$FIXTURE_NOFILE" "$FIXTURE_FILE"
+
+# s6-overlay / the mounted secret write a trailing newline; mimic it so the test
+# exercises the same `$(< file)` newline-stripping the live shell does.
 printf 'fake-github-token-value\n' > "$FIXTURE_ENVDIR/GITHUB_TOKEN"
 printf 'fake-telegram-bot-token\n' > "$FIXTURE_ENVDIR/TELEGRAM_BOT_TOKEN"
 printf '12345\n'                    > "$FIXTURE_ENVDIR/TELEGRAM_CHAT_ID"
 printf 'fake-grafana-key\n'         > "$FIXTURE_ENVDIR/GRAFANA_API_KEY"
 printf 'fake-grafana-editor\n'      > "$FIXTURE_ENVDIR/GRAFANA_API_EDITOR_KEY"
+printf 'app-installation-token\n'   > "$FIXTURE_FILE/token"
 
+# runner sources a bashrc and emits len/sha for the requested vars.
 cat > "$TMP/runner.sh" <<'RUNNER'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -53,42 +58,52 @@ case ":$PATH:" in
 esac
 RUNNER
 
-# `env -i` strips every var, including the ones the bashrc tries to honor
-# via ${VAR:-…}. That's the strictest form of "fresh shell" — proves the
-# envdir is the actual source on a cold start.
-OUT="$(env -i HOME="$TMP" PATH=/usr/bin:/bin bash "$TMP/runner.sh" "$TMP/bashrc")"
-
+# Materialize a bashrc with both real paths rewritten to fixtures.
+#   $1 = dir to substitute for /var/run/github  (token file lives at <dir>/token)
+make_bashrc() {
+    sed -e "s|/var/run/github|$1|g" -e "s|/run/s6/basedir/env|$FIXTURE_ENVDIR|g" \
+        "$BASHRC" > "$TMP/bashrc"
+}
+run_bashrc() {
+    # `env -i` strips every var — strictest "fresh shell" / cold start.
+    env -i HOME="$TMP" PATH=/usr/bin:/bin bash "$TMP/runner.sh" "$TMP/bashrc"
+}
 expect() {
-    local label="$1" expected="$2"
-    if ! grep -qx "$label=$expected" <<< "$OUT"; then
-        printf 'FAIL: %s\n  expected: %s\n  got:\n%s\n' "$label" "$expected" "$OUT" >&2
+    local out="$1" label="$2" expected="$3"
+    if ! grep -qx "$label=$expected" <<< "$out"; then
+        printf 'FAIL: %s\n  expected: %s\n  got:\n%s\n' "$label" "$expected" "$out" >&2
         exit 1
     fi
 }
 
-sha() { printf '%s' "$1" | sha256sum | cut -d' ' -f1; }
+# --- Scenario A: no mounted token file → GITHUB_TOKEN falls back to s6 envdir ---
+make_bashrc "$FIXTURE_NOFILE"
+OUT_A="$(run_bashrc)"
+expect "$OUT_A" GITHUB_TOKEN_LEN 23
+expect "$OUT_A" GITHUB_TOKEN_SHA "$(sha 'fake-github-token-value')"
+# The other secrets always come from the s6 envdir.
+expect "$OUT_A" TELEGRAM_BOT_TOKEN_LEN 23
+expect "$OUT_A" TELEGRAM_BOT_TOKEN_SHA "$(sha 'fake-telegram-bot-token')"
+expect "$OUT_A" TELEGRAM_CHAT_ID_LEN 5
+expect "$OUT_A" TELEGRAM_CHAT_ID_SHA "$(sha '12345')"
+expect "$OUT_A" GRAFANA_API_KEY_LEN 16
+expect "$OUT_A" GRAFANA_API_KEY_SHA "$(sha 'fake-grafana-key')"
+expect "$OUT_A" GRAFANA_API_EDITOR_KEY_LEN 19
+expect "$OUT_A" GRAFANA_API_EDITOR_KEY_SHA "$(sha 'fake-grafana-editor')"
+expect "$OUT_A" WILLIKINS_REPOS "$TMP/repos/willikins:willikins"
+expect "$OUT_A" PUSHGATEWAY_URL 'http://pushgateway.monitoring.svc.cluster.local:9091'
+expect "$OUT_A" PATH_HAS_LOCAL_BIN yes
 
-# Each fixture file ends with \n; `$(< file)` strips exactly one newline.
-expect GITHUB_TOKEN_LEN 23
-expect GITHUB_TOKEN_SHA "$(sha 'fake-github-token-value')"
-expect TELEGRAM_BOT_TOKEN_LEN 23
-expect TELEGRAM_BOT_TOKEN_SHA "$(sha 'fake-telegram-bot-token')"
-expect TELEGRAM_CHAT_ID_LEN 5
-expect TELEGRAM_CHAT_ID_SHA "$(sha '12345')"
-expect GRAFANA_API_KEY_LEN 16
-expect GRAFANA_API_KEY_SHA "$(sha 'fake-grafana-key')"
-expect GRAFANA_API_EDITOR_KEY_LEN 19
-expect GRAFANA_API_EDITOR_KEY_SHA "$(sha 'fake-grafana-editor')"
+# --- Scenario B: mounted token file present → GITHUB_TOKEN PREFERS it ---
+make_bashrc "$FIXTURE_FILE"
+OUT_B="$(run_bashrc)"
+expect "$OUT_B" GITHUB_TOKEN_LEN 22
+expect "$OUT_B" GITHUB_TOKEN_SHA "$(sha 'app-installation-token')"
 
-expect WILLIKINS_REPOS "$TMP/repos/willikins:willikins"
-expect PUSHGATEWAY_URL 'http://pushgateway.monitoring.svc.cluster.local:9091'
-expect PATH_HAS_LOCAL_BIN yes
-
-# Negative test: no executable line in bashrc still reads /proc/1/environ.
-# Comments are allowed (the historical context is useful).
+# Negative test: no executable line in bashrc reads /proc/1/environ.
 if grep -nE '^[^#]*\b/proc/1/environ' "$BASHRC"; then
     printf 'FAIL: bashrc has an executable reference to /proc/1/environ\n' >&2
     exit 1
 fi
 
-echo "PASS: bashrc loads all secrets from the s6-overlay envdir (lengths + SHA verified)."
+echo "PASS: bashrc prefers the mounted App-token file for GITHUB_TOKEN, falls back to the s6 envdir, and loads the other secrets from the envdir."

--- a/kali/tests/test_credential_migrate.sh
+++ b/kali/tests/test_credential_migrate.sh
@@ -2,13 +2,17 @@
 # test_credential_migrate.sh — harness for base/opt/agent-init.d/02-credential-migrate.
 #
 # The script lives in base/ and is shared across all agent-images children.
-# It runs on every boot from agent-init.d, detects stale gitconfig credential
-# helpers on the persistent volume, and re-copies the image's /opt/gitconfig.
+# It runs on every boot from agent-init.d, detects an OLD gitconfig GitHub
+# credential helper on the persistent volume, and re-copies the image's
+# /opt/gitconfig (which now prefers the mounted App token at
+# /var/run/github/token).
 #
-# Two prior helper shapes need migrating:
-#   - Legacy:   contains `password=$GITHUB_TOKEN`
-#   - tini-era: contains `/proc/1/environ`
-# Current helper reads /run/s6/basedir/env/GITHUB_TOKEN.
+# Migrates ANY older GitHub-token helper:
+#   - Legacy:    contains `password=$GITHUB_TOKEN`
+#   - tini-era:  contains `/proc/1/environ`
+#   - s6-envdir: reads /run/s6/basedir/env/GITHUB_TOKEN but NOT the new path
+# Leaves untouched: a config already on /var/run/github/token, or one with no
+# GitHub credential helper at all.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -26,7 +30,7 @@ run_case() {
     local sha_before
     sha_before="$(sha256sum "$agent_home/.gitconfig" | cut -d' ' -f1)"
 
-    # Stage a "current" /opt/gitconfig the script can copy from.
+    # Stage the CURRENT /opt/gitconfig (file-aware helper) the script copies from.
     local fake_opt="$TMP/$label-opt"
     mkdir -p "$fake_opt"
     cat > "$fake_opt/gitconfig" <<'GIT'
@@ -34,28 +38,23 @@ run_case() {
 	email = clawdia-ai-assistant@gmail.com
 	name = Clawdia
 [credential]
-	helper = "!f() { echo username=clawdia-ai-assistant; printf 'password=%s\\n' \"$(< /run/s6/basedir/env/GITHUB_TOKEN)\"; }; f"
+	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf 'password=%s\\n' \"$(< \"$t\")\"; return; done; }; f"
 GIT
 
-    # Sandbox /opt by running with a script-local PATH prefix that swaps the
-    # path. Easiest cross-platform approach: copy the script and rewrite the
-    # /opt/gitconfig path before exec.
     sed "s|/opt/gitconfig|$fake_opt/gitconfig|g" "$SCRIPT" > "$TMP/$label.sh"
     chmod +x "$TMP/$label.sh"
 
     AGENT_HOME="$agent_home" HOME="$agent_home" bash "$TMP/$label.sh" >"$TMP/$label.log" 2>&1
 
-    local sha_after
+    local sha_after sha_target
     sha_after="$(sha256sum "$agent_home/.gitconfig" | cut -d' ' -f1)"
-    local sha_target
     sha_target="$(sha256sum "$fake_opt/gitconfig" | cut -d' ' -f1)"
 
     case "$expect_migrated" in
         yes)
             if [ "$sha_after" = "$sha_before" ]; then
                 printf 'FAIL [%s]: gitconfig was NOT migrated but should have been\n' "$label" >&2
-                cat "$TMP/$label.log" >&2
-                exit 1
+                cat "$TMP/$label.log" >&2; exit 1
             fi
             if [ "$sha_after" != "$sha_target" ]; then
                 printf 'FAIL [%s]: post-migration gitconfig does not match /opt/gitconfig\n' "$label" >&2
@@ -65,8 +64,7 @@ GIT
         no)
             if [ "$sha_after" != "$sha_before" ]; then
                 printf 'FAIL [%s]: gitconfig was migrated but should NOT have been\n' "$label" >&2
-                cat "$TMP/$label.log" >&2
-                exit 1
+                cat "$TMP/$label.log" >&2; exit 1
             fi
             ;;
     esac
@@ -81,12 +79,16 @@ run_case legacy_envvar '[credential]
 run_case proc_environ '[credential]
 	helper = "!f() { echo username=clawdia-ai-assistant; echo \"password=$(tr \"\\0\" \"\\n\" < /proc/1/environ | sed -n \"s/^GITHUB_TOKEN=//p\")\"; }; f"' yes
 
-# Case 3: already on the s6 envdir — must NOT migrate.
+# Case 3: s6-envdir-only helper (no App-token file path) — must now MIGRATE.
 run_case s6_envdir '[credential]
-	helper = "!f() { echo username=clawdia-ai-assistant; printf '"'"'password=%s\\n'"'"' \"$(< /run/s6/basedir/env/GITHUB_TOKEN)\"; }; f"' no
+	helper = "!f() { echo username=clawdia-ai-assistant; printf '"'"'password=%s\\n'"'"' \"$(< /run/s6/basedir/env/GITHUB_TOKEN)\"; }; f"' yes
 
-# Case 4: unrelated user gitconfig (no GitHub credential helper) — must NOT migrate.
+# Case 4: already on the App-token file reader — must NOT migrate.
+run_case current_filereader '[credential]
+	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf '"'"'password=%s\\n'"'"' \"$(< \"$t\")\"; return; done; }; f"' no
+
+# Case 5: unrelated user gitconfig (no GitHub credential helper) — must NOT migrate.
 run_case unrelated '[user]
 	name = Some Other Identity' no
 
-echo "PASS: 02-credential-migrate detects both legacy + /proc/1/environ helpers and skips current/unrelated configs."
+echo "PASS: 02-credential-migrate upgrades all older GitHub helpers (legacy/proc/s6) and skips current/unrelated configs."

--- a/kali/tests/test_gitconfig_credential_helper.sh
+++ b/kali/tests/test_gitconfig_credential_helper.sh
@@ -3,88 +3,86 @@
 #
 # The credential helper is the only path that runs in non-interactive
 # subprocesses (VS Code git, supercronic cron jobs) where ~/.bashrc is not
-# sourced. It must read GITHUB_TOKEN from the s6-overlay envdir directly
-# and emit the git credential protocol shape:
-#     username=<value>
+# sourced. It emits the git credential protocol shape:
+#     username=x-access-token
 #     password=<value>
 #
-# Critically, the helper must NOT include the trailing newline that s6
-# writes to envdir files. A `password=<token>\n` line followed by the
-# extra envdir newline produces `password=<token>` and `password=` (empty)
-# — git takes the last-seen value, breaks auth.
+# It PREFERS the mounted GitHub App token at /var/run/github/token (rotated by
+# ESO, key never on the pod) and falls back to the s6 envdir token during
+# cutover. `x-access-token` is the App-token username convention and is also
+# accepted with a classic PAT, so it works for both sources.
+#
+# Critically, the helper must NOT include the trailing newline that s6 / the
+# mounted file write. A `password=<token>\n` line followed by an extra envdir
+# newline produces `password=<token>` and `password=` (empty) — git takes the
+# last-seen value, breaks auth.
 #
 # Reports lengths and sha256 only — never plaintext values.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 GITCONFIG="$SCRIPT_DIR/config-templates/gitconfig"
-TMP="$(mktemp -d)"
-trap 'rm -rf "$TMP"' EXIT
 
-FIXTURE_ENVDIR="$TMP/envdir"
-mkdir -p "$FIXTURE_ENVDIR"
+sha() { printf '%s' "$1" | sha256sum | cut -d' ' -f1; }
 
-# Token with shell-metachar bytes (=, ", $) plus a trailing newline matching
-# what s6 actually writes. NOT a newline embedded in the value — git's
-# credential protocol uses newline as a key/value terminator and rejects
-# embedded newlines, so we don't simulate that case.
-printf 'tok=value "with" $meta\n' > "$FIXTURE_ENVDIR/GITHUB_TOKEN"
+# Run the helper for one scenario and assert the emitted wire output.
+#   $1 label   $2 file-token (empty = no /var/run/github/token)   $3 env-token
+#   $4 expected password value the helper should choose
+run_scenario() {
+    local label="$1" file_token="$2" env_token="$3" expected="$4"
+    local tmp; tmp="$(mktemp -d)"
+    local file_dir="$tmp/var-run-github" env_dir="$tmp/envdir"
+    mkdir -p "$file_dir" "$env_dir"
+    [ -n "$file_token" ] && printf '%s\n' "$file_token" > "$file_dir/token"
+    printf '%s\n' "$env_token" > "$env_dir/GITHUB_TOKEN"
 
-# Materialize the gitconfig with the envdir path rewritten.
-sed "s|/run/s6/basedir/env|$FIXTURE_ENVDIR|g" "$GITCONFIG" > "$TMP/gitconfig"
+    # Rewrite BOTH real paths to the fixtures so the test never touches a real
+    # /var/run/github/token on the build host.
+    local cfg="$tmp/gitconfig"
+    sed -e "s|/var/run/github|$file_dir|g" -e "s|/run/s6/basedir/env|$env_dir|g" \
+        "$GITCONFIG" > "$cfg"
 
-# Extract and execute the helper directly. We don't shell out to git here
-# because CI may not have git's credential subsystem reachable; we exercise
-# the shell function git would invoke.
-HELPER="$(git config --file "$TMP/gitconfig" credential.helper)"
-case "$HELPER" in
-    !*) HELPER="${HELPER#!}" ;;
-    *) printf 'FAIL: helper does not start with "!" (got %q)\n' "$HELPER" >&2; exit 1 ;;
-esac
+    local helper; helper="$(git config --file "$cfg" credential.helper)"
+    case "$helper" in
+        !*) helper="${helper#!}" ;;
+        *) printf 'FAIL [%s]: helper does not start with "!" (got %q)\n' "$label" "$helper" >&2; exit 1 ;;
+    esac
 
-OUT="$(env -i HOME="$TMP" PATH=/usr/bin:/bin bash -c "$HELPER")"
+    local out_file="$tmp/out"
+    env -i HOME="$tmp" PATH=/usr/bin:/bin bash -c "$helper" > "$out_file"
+    local username_line password_line
+    username_line="$(grep '^username=' "$out_file" || true)"
+    password_line="$(grep '^password=' "$out_file" || true)"
 
-# Expected wire format:
-#   username=clawdia-ai-assistant
-#   password=tok=value "with" $meta
-expected_username="username=clawdia-ai-assistant"
-expected_password='password=tok=value "with" $meta'
+    if [ "$username_line" != "username=x-access-token" ]; then
+        printf 'FAIL [%s]: username line mismatch\n  expected: username=x-access-token\n  got:      %s\n' \
+            "$label" "$username_line" >&2; exit 1
+    fi
+    if [ "$(sha "$password_line")" != "$(sha "password=$expected")" ]; then
+        printf 'FAIL [%s]: password line sha mismatch (got len=%d)\n' "$label" "${#password_line}" >&2; exit 1
+    fi
+    # Exactly two newline-terminated non-empty lines — no trailing-newline leak.
+    local total nonempty
+    total="$(wc -l < "$out_file")"; nonempty="$(grep -c . "$out_file" || true)"
+    if [ "$total" -ne 2 ] || [ "$nonempty" -ne 2 ]; then
+        printf 'FAIL [%s]: expected 2 non-empty lines, got total=%d nonempty=%d\n' \
+            "$label" "$total" "$nonempty" >&2; exit 1
+    fi
+    rm -rf "$tmp"
+    printf 'OK   [%s]\n' "$label"
+}
 
-USERNAME_LINE="$(grep '^username=' <<< "$OUT" || true)"
-PASSWORD_LINE="$(grep '^password=' <<< "$OUT" || true)"
+# Prefer the mounted App-token file when present (value differs from the env one
+# to prove precedence). Token carries shell-metachar bytes (=, ", $).
+run_scenario prefer_file 'file=tok "with" $meta' 'env-token-should-be-ignored' 'file=tok "with" $meta'
 
-if [ "$USERNAME_LINE" != "$expected_username" ]; then
-    printf 'FAIL: username line mismatch\n  expected: %s\n  got:      %s\n' "$expected_username" "$USERNAME_LINE" >&2
-    exit 1
-fi
+# Fall back to the s6 envdir token when the file is absent (cutover / pre-mount).
+run_scenario fallback_envdir '' 'env=tok "with" $meta' 'env=tok "with" $meta'
 
-# Compare via SHA so a regression doesn't echo the (potentially secret) value.
-got_pw_sha="$(printf '%s' "$PASSWORD_LINE" | sha256sum | cut -d' ' -f1)"
-exp_pw_sha="$(printf '%s' "$expected_password" | sha256sum | cut -d' ' -f1)"
-if [ "$got_pw_sha" != "$exp_pw_sha" ]; then
-    printf 'FAIL: password line sha mismatch\n  expected_sha: %s (len=%d)\n  got_sha:      %s (len=%d)\n' \
-        "$exp_pw_sha" "${#expected_password}" "$got_pw_sha" "${#PASSWORD_LINE}" >&2
-    exit 1
-fi
-
-# The helper must emit exactly two non-empty lines (username + password).
-# A naive `cat /run/s6/...` would smuggle the envdir's trailing newline into
-# the password value, producing a third empty line that breaks git's parser.
-# Capture into a file so we see real terminator structure (command
-# substitution would otherwise strip trailing newlines).
-env -i HOME="$TMP" PATH=/usr/bin:/bin bash -c "$HELPER" > "$TMP/helper-out"
-TOTAL_LINES="$(wc -l < "$TMP/helper-out")"
-NONEMPTY_LINES="$(grep -c . "$TMP/helper-out" || true)"
-if [ "$TOTAL_LINES" -ne 2 ] || [ "$NONEMPTY_LINES" -ne 2 ]; then
-    printf 'FAIL: expected 2 newline-terminated non-empty lines, got total=%d nonempty=%d\n' \
-        "$TOTAL_LINES" "$NONEMPTY_LINES" >&2
-    exit 1
-fi
-
-# Negative test: gitconfig must not still mention /proc/1/environ.
+# Negative test: gitconfig must not reference /proc/1/environ.
 if grep -q '/proc/1/environ' "$GITCONFIG"; then
     printf 'FAIL: gitconfig still references /proc/1/environ\n' >&2
     exit 1
 fi
 
-echo "PASS: gitconfig credential helper emits well-formed wire output, no trailing-newline leak."
+echo "PASS: gitconfig credential helper prefers the App-token file, falls back to the s6 envdir, emits well-formed wire output."


### PR DESCRIPTION
## What

Deliver the agent pod's GitHub token as a **short-lived GitHub App installation token** via a live-updated mounted file (`/var/run/github/token`), keeping the **App private key off the pod entirely** (it is minted centrally by ESO). Replaces the clawdia org-owner PAT as the in-pod credential.

## Why

`clawdia-ai-assistant` is an **org owner** on both `derio-net` and `agentic-stoa` — a standing PAT for it can do anything. This moves agent git/gh auth to a least-privilege GitHub App (`derio-fr-automation`, scoped repos + `contents/issues/PRs/workflows`), with tokens that expire in ~1h and a key that never reaches the pod.

## Changes

- `kali/config-templates/gitconfig` — credential helper reads `/var/run/github/token` first, falls back to `/run/s6/basedir/env/GITHUB_TOKEN`; username `x-access-token` (works for the App token **and** a classic PAT).
- `kali/config-templates/bashrc` — `GITHUB_TOKEN` prefers the mounted file, falls back to the s6 envdir (covers `gh`/`fr`).
- `base/opt/agent-init.d/02-credential-migrate` — upgrades any older GitHub helper (legacy / `/proc/1/environ` / s6-envdir-only) lacking the new path.
- tests updated + extended with prefer-file + fallback coverage (`test-kali` runs them in CI).

**Backward-compatible:** with no file mounted, the helper falls back to the existing env token — so this image is safe to ship before the frank cutover.

## Credential-delivery contract (for the Component-A run-pod image redesign to preserve)

The token arrives as a **rotating file at `/var/run/github/token`**; the **App private key is never delivered to the pod**. Component A should keep this shape.

## Pairs with

`derio-net/frank` branch `agents/github-app-least-privilege` (ESO `ClusterGenerator` `GithubAccessToken` → `agent-github-token` ExternalSecret → mounted volume).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
