### PR TITLE
fix(kali): git uses the App-token helper for github.com (drop gh override + dash-safe read)

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -55,6 +55,12 @@ RUN ARCH=$([ "${TARGETARCH}" = "arm64" ] && echo "arm64" || echo "amd64") \
 COPY opt/agent-init.d/ /opt/agent-init.d/
 RUN chmod +x /opt/agent-init.d/*
 
+# ── gh wrapper: authenticate gh with the current mounted App token (PATH puts
+#    /usr/local/bin ahead of the apt gh at /usr/bin/gh; falls back transparently
+#    where no token is mounted). ──
+COPY usr/local/bin/gh /usr/local/bin/gh
+RUN chmod +x /usr/local/bin/gh
+
 # ── Non-root user (UID/GID 1000 — matches PVC ownership) ──
 RUN /usr/sbin/addgroup --gid 1000 claude \
     && /usr/sbin/adduser --uid 1000 --gid 1000 --disabled-password --gecos "" --shell /bin/bash claude

--- a/base/opt/agent-init.d/02-credential-migrate
+++ b/base/opt/agent-init.d/02-credential-migrate
@@ -9,23 +9,30 @@
 #   4. App-token reader with the bash-only `$(< file)` read — BROKEN under git's
 #      /bin/sh=dash (empty password → private-repo auth fails). Has the new path
 #      but must still be upgraded to the `$(cat …)` form.
+#   5. A github.com-SPECIFIC helper `!/usr/bin/gh auth git-credential` (left by a
+#      past `gh auth setup-git`). It OVERRIDES the generic helper for github.com
+#      and serves gh's STORED token (e.g. a revoked clawdia PAT) → 401. Must be
+#      dropped so the generic App-token helper wins.
 #
 # Current helper reads the mounted GitHub App token at /var/run/github/token with
-# `$(cat …)` (dash-safe), falling back to the s6 envdir. This script upgrades any
-# older OR dash-broken GitHub credential helper on the PVC's ~/.gitconfig to the
-# image's /opt/gitconfig. A gitconfig already on the dash-safe reader, or one
-# with no GitHub helper at all, is left untouched.
+# `$(cat …)` (dash-safe), falling back to the s6 envdir, with NO host-specific
+# override. This script re-seeds the PVC's ~/.gitconfig from the image's
+# /opt/gitconfig whenever it finds any older / dash-broken / gh-overridden GitHub
+# credential config. A gitconfig already on the dash-safe reader (and free of the
+# gh override), or one with no GitHub helper at all, is left untouched.
 set -e
 HOME="${AGENT_HOME:-$HOME}"
 [ -f /opt/gitconfig ] || exit 0
 [ -f "$HOME/.gitconfig" ] || exit 0
-# Already on the dash-safe App-token reader (has the new path AND no $(< … ) read)
-# → nothing to do.
-if grep -qF '/var/run/github/token' "$HOME/.gitconfig" && ! grep -qF '$(<' "$HOME/.gitconfig"; then
+# Already current: dash-safe App-token reader, no $(< …) read, no gh override.
+if grep -qF '/var/run/github/token' "$HOME/.gitconfig" \
+   && ! grep -qF '$(<' "$HOME/.gitconfig" \
+   && ! grep -qF 'gh auth git-credential' "$HOME/.gitconfig"; then
     exit 0
 fi
-# Any older OR dash-broken GitHub-token credential helper → upgrade in place.
-if grep -qE 'GITHUB_TOKEN|/proc/1/environ' "$HOME/.gitconfig"; then
-    echo "[agent-init] upgrading git credential helper → dash-safe App-token reader"
+# Older / dash-broken / gh-overridden GitHub credential config → re-seed the image
+# gitconfig (generic App-token helper only; drops any gh host-specific helper).
+if grep -qE 'GITHUB_TOKEN|/proc/1/environ|gh auth git-credential' "$HOME/.gitconfig"; then
+    echo "[agent-init] re-seeding git credential config → dash-safe App-token helper (no gh override)"
     cp /opt/gitconfig "$HOME/.gitconfig"
 fi

--- a/base/opt/agent-init.d/02-credential-migrate
+++ b/base/opt/agent-init.d/02-credential-migrate
@@ -6,24 +6,26 @@
 #   1. Legacy env-var reader: contained `password=$GITHUB_TOKEN`.
 #   2. /proc/1/environ reader: contained `/proc/1/environ`.
 #   3. s6-envdir-only reader: read /run/s6/basedir/env/GITHUB_TOKEN directly.
+#   4. App-token reader with the bash-only `$(< file)` read — BROKEN under git's
+#      /bin/sh=dash (empty password → private-repo auth fails). Has the new path
+#      but must still be upgraded to the `$(cat …)` form.
 #
-# Current helper PREFERS the mounted GitHub App token at /var/run/github/token
-# (rotated by ESO, key never on the pod) and falls back to the s6 envdir. This
-# script detects ANY older GitHub credential helper on the PVC's ~/.gitconfig —
-# i.e. one that references GITHUB_TOKEN / /proc/1/environ but NOT the new
-# /var/run/github/token path — and replaces it with the image's /opt/gitconfig.
-# A gitconfig already on the new path, or one with no GitHub helper at all, is
-# left untouched.
+# Current helper reads the mounted GitHub App token at /var/run/github/token with
+# `$(cat …)` (dash-safe), falling back to the s6 envdir. This script upgrades any
+# older OR dash-broken GitHub credential helper on the PVC's ~/.gitconfig to the
+# image's /opt/gitconfig. A gitconfig already on the dash-safe reader, or one
+# with no GitHub helper at all, is left untouched.
 set -e
 HOME="${AGENT_HOME:-$HOME}"
 [ -f /opt/gitconfig ] || exit 0
 [ -f "$HOME/.gitconfig" ] || exit 0
-# Already current → nothing to do.
-if grep -qF '/var/run/github/token' "$HOME/.gitconfig"; then
+# Already on the dash-safe App-token reader (has the new path AND no $(< … ) read)
+# → nothing to do.
+if grep -qF '/var/run/github/token' "$HOME/.gitconfig" && ! grep -qF '$(<' "$HOME/.gitconfig"; then
     exit 0
 fi
-# An older GitHub-token credential helper → upgrade in place.
+# Any older OR dash-broken GitHub-token credential helper → upgrade in place.
 if grep -qE 'GITHUB_TOKEN|/proc/1/environ' "$HOME/.gitconfig"; then
-    echo "[agent-init] upgrading git credential helper → App-token file reader (fallback to s6 envdir)"
+    echo "[agent-init] upgrading git credential helper → dash-safe App-token reader"
     cp /opt/gitconfig "$HOME/.gitconfig"
 fi

--- a/base/usr/local/bin/gh
+++ b/base/usr/local/bin/gh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# gh wrapper — authenticate `gh` with the current GitHub App installation token.
+#
+# The agent's git credential is a short-lived App token mounted (and rotated by
+# ESO) at /var/run/github/token. `gh` needs that SAME current token per call:
+# App installation tokens rotate hourly, and gh otherwise falls back to a stale
+# env value or ~/.config/gh/hosts.yml (which may hold a revoked PAT) → "Bad
+# credentials". This shim reads the token file fresh on every invocation and
+# exports it as GH_TOKEN (gh's highest-priority source).
+#
+# On images/pods where no token file is mounted, it transparently falls through
+# to the real gh (env / hosts.yml unchanged). It exec's the absolute real-gh
+# path to avoid re-invoking itself via PATH.
+#
+# The two override vars exist only so the unit test can point at fixtures.
+_tok="${GH_APP_TOKEN_FILE:-/var/run/github/token}"
+_real="${GH_REAL_BIN:-/usr/bin/gh}"
+
+if [ -r "$_tok" ]; then
+    exec env GH_TOKEN="$(cat "$_tok")" "$_real" "$@"
+fi
+exec "$_real" "$@"

--- a/kali/config-templates/gitconfig
+++ b/kali/config-templates/gitconfig
@@ -5,8 +5,12 @@
 # /var/run/github/token (short-lived, rotated by ESO, key never on the pod),
 # falling back to the s6 envdir token during cutover. `x-access-token` is the
 # App-token username convention and is also accepted with a classic PAT, so it
-# works for both sources. Reads the first readable path and stops; `$(< file)`
-# strips the single trailing newline s6 writes (an extra empty `password=` line
-# would break git's parser).
+# works for both sources. Reads the first readable path and stops.
+#
+# MUST use $(cat …), NOT $(< …): git runs credential helpers via /bin/sh (dash),
+# where the $(< file) read shortcut is a bash-only feature that yields an EMPTY
+# string — producing `password=` and rejected auth on PRIVATE repos (public
+# repos mask it: git reads them with no auth). $(cat …) also strips the single
+# trailing newline s6 writes, so no extra empty `password=` line.
 [credential]
-	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf 'password=%s\\n' \"$(< \"$t\")\"; return; done; }; f"
+	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf 'password=%s\\n' \"$(cat \"$t\")\"; return; done; }; f"

--- a/kali/tests/test_credential_migrate.sh
+++ b/kali/tests/test_credential_migrate.sh
@@ -38,7 +38,7 @@ run_case() {
 	email = clawdia-ai-assistant@gmail.com
 	name = Clawdia
 [credential]
-	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf 'password=%s\\n' \"$(< \"$t\")\"; return; done; }; f"
+	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf 'password=%s\\n' \"$(cat \"$t\")\"; return; done; }; f"
 GIT
 
     sed "s|/opt/gitconfig|$fake_opt/gitconfig|g" "$SCRIPT" > "$TMP/$label.sh"
@@ -83,11 +83,16 @@ run_case proc_environ '[credential]
 run_case s6_envdir '[credential]
 	helper = "!f() { echo username=clawdia-ai-assistant; printf '"'"'password=%s\\n'"'"' \"$(< /run/s6/basedir/env/GITHUB_TOKEN)\"; }; f"' yes
 
-# Case 4: already on the App-token file reader — must NOT migrate.
-run_case current_filereader '[credential]
-	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf '"'"'password=%s\\n'"'"' \"$(< \"$t\")\"; return; done; }; f"' no
+# Case 4: dash-broken App-token reader ($(< …), has the new path but empty under
+# dash) — must MIGRATE to the $(cat …) form.
+run_case dash_broken '[credential]
+	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf '"'"'password=%s\\n'"'"' \"$(< \"$t\")\"; return; done; }; f"' yes
 
-# Case 5: unrelated user gitconfig (no GitHub credential helper) — must NOT migrate.
+# Case 5: already on the dash-safe App-token reader ($(cat …)) — must NOT migrate.
+run_case current_filereader '[credential]
+	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf '"'"'password=%s\\n'"'"' \"$(cat \"$t\")\"; return; done; }; f"' no
+
+# Case 6: unrelated user gitconfig (no GitHub credential helper) — must NOT migrate.
 run_case unrelated '[user]
 	name = Some Other Identity' no
 

--- a/kali/tests/test_credential_migrate.sh
+++ b/kali/tests/test_credential_migrate.sh
@@ -92,7 +92,15 @@ run_case dash_broken '[credential]
 run_case current_filereader '[credential]
 	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf '"'"'password=%s\\n'"'"' \"$(cat \"$t\")\"; return; done; }; f"' no
 
-# Case 6: unrelated user gitconfig (no GitHub credential helper) — must NOT migrate.
+# Case 6: dash-safe generic helper BUT a gh host-specific override present
+# (`gh auth git-credential` serves gh's stored token for github.com) — must
+# MIGRATE so `cp /opt/gitconfig` drops the override.
+run_case gh_override '[credential]
+	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf '"'"'password=%s\\n'"'"' \"$(cat \"$t\")\"; return; done; }; f"
+[credential "https://github.com"]
+	helper = !/usr/bin/gh auth git-credential' yes
+
+# Case 7: unrelated user gitconfig (no GitHub credential helper) — must NOT migrate.
 run_case unrelated '[user]
 	name = Some Other Identity' no
 

--- a/kali/tests/test_gh_wrapper.sh
+++ b/kali/tests/test_gh_wrapper.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# test_gh_wrapper.sh — harness for base/usr/local/bin/gh.
+#
+# The wrapper must authenticate `gh` with the CURRENT mounted GitHub App token
+# (read fresh per call, since App tokens rotate), and fall through transparently
+# to the real gh where no token file is mounted. Uses the wrapper's override
+# vars (GH_APP_TOKEN_FILE / GH_REAL_BIN) to point at fixtures.
+set -euo pipefail
+
+WRAPPER="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/base/usr/local/bin/gh"
+[ -f "$WRAPPER" ] || { echo "FAIL: wrapper not found at $WRAPPER" >&2; exit 1; }
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+# Stub "real gh": echoes the GH_TOKEN it received + its args.
+cat > "$TMP/realgh" <<'STUB'
+#!/bin/sh
+printf 'GH_TOKEN=%s ARGS=%s\n' "${GH_TOKEN:-NONE}" "$*"
+STUB
+chmod +x "$TMP/realgh"
+
+# Case 1: token file present → wrapper injects its contents as GH_TOKEN.
+printf 'ghs_apptoken123' > "$TMP/token"
+out="$(GH_APP_TOKEN_FILE="$TMP/token" GH_REAL_BIN="$TMP/realgh" sh "$WRAPPER" api graphql)"
+if [ "$out" != "GH_TOKEN=ghs_apptoken123 ARGS=api graphql" ]; then
+    printf 'FAIL [token present]: got %q\n' "$out" >&2; exit 1
+fi
+echo "OK [token present → GH_TOKEN injected from file]"
+
+# Case 2: no token file → fall through to real gh, GH_TOKEN untouched.
+out="$(env -u GH_TOKEN GH_APP_TOKEN_FILE="$TMP/absent" GH_REAL_BIN="$TMP/realgh" sh "$WRAPPER" auth status)"
+if [ "$out" != "GH_TOKEN=NONE ARGS=auth status" ]; then
+    printf 'FAIL [no token file]: got %q\n' "$out" >&2; exit 1
+fi
+echo "OK [no token file → fall through, GH_TOKEN untouched]"
+
+echo "PASS: gh wrapper injects the current App token when mounted, falls back otherwise."

--- a/kali/tests/test_gitconfig_credential_helper.sh
+++ b/kali/tests/test_gitconfig_credential_helper.sh
@@ -49,7 +49,10 @@ run_scenario() {
     esac
 
     local out_file="$tmp/out"
-    env -i HOME="$tmp" PATH=/usr/bin:/bin bash -c "$helper" > "$out_file"
+    # Run under /bin/sh (dash), NOT bash — git invokes credential helpers via
+    # `sh -c`, so the helper must be POSIX-sh-safe (e.g. $(cat …), not the
+    # bash-only $(< …) read which yields an empty password under dash).
+    env -i HOME="$tmp" PATH=/usr/bin:/bin sh -c "$helper" > "$out_file"
     local username_line password_line
     username_line="$(grep '^username=' "$out_file" || true)"
     password_line="$(grep '^password=' "$out_file" || true)"


### PR DESCRIPTION
## Dash-safe git credential helper

**Bug:** the credential helper reads the token with `$(< "$t")` — a **bash-only** shortcut. Git invokes credential helpers via **`/bin/sh` = dash**, where `$(< file)` returns an **empty string**, so the helper emits `password=` → GitHub rejects auth (`Invalid username or token. Password authentication is not supported`) on **private** repos.

**Why it slipped through:** public repos need no auth for read, so the cutover verification (`runs-fr`, public) passed. It surfaced when the **fr-bridge failed to `git fetch` the private `willikins`** repo — `credential-scrub` had stripped the embedded clawdia PAT from the remote at the cutover roll, so git fell through to the (dash-broken) helper, and the clawdia PAT was already revoked.

**Proof:** under dash, `$(< file)` → empty; the deployed helper emitted a 10-char `password=` line. An inline helper with the same App token (`echo password=$TOK`) authenticated private willikins fine.

### Changes
- `config-templates/gitconfig` — read with `$(cat "$t")` (POSIX-sh-safe; also strips the trailing newline).
- `base/opt/agent-init.d/02-credential-migrate` — also upgrade existing PVCs whose helper still uses the broken `$(< …)` form.
- `tests/test_gitconfig_credential_helper.sh` — run the helper via **`sh -c`** (dash), the guard that would have caught this.
- `tests/test_credential_migrate.sh` — `dash_broken` case must migrate; the no-migrate case now uses `$(cat …)`.

### Rollout
Existing pods: run the stopgap (`scripts/tmp/fix-bridge-git-helper.sh`) for an immediate fix, **or** let this merge → fleet bump → pod roll, after which `02-credential-migrate` re-seeds the dash-safe helper automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
