### PR TITLE
fix(kali): sweep stale npx atomic-swap remnants in npm-cache-prune

### DIFF
--- a/kali/scripts/npm-cache-prune.sh
+++ b/kali/scripts/npm-cache-prune.sh
@@ -9,7 +9,10 @@
 #      for npm cache content is when it was downloaded — slightly more
 #      conservative but correct).
 #   2. Removes cache files untouched for >7d.
-#   3. Runs `npm cache verify` so npm rebuilds its index after the deletion and
+#   3. Sweeps stale npx atomic-swap remnants (`.<pkg>-<random>` dirs) in
+#      ~/.npm/_npx/*/node_modules/ that block all future npx installs of the
+#      same package (agent-images#87).
+#   4. Runs `npm cache verify` so npm rebuilds its index after the deletion and
 #      emits a final size report into the log.
 #
 # A flock guard prevents overlap with a manual `kubectl exec` invocation or a
@@ -71,6 +74,26 @@ if [ -n "${PROBE:-}" ] && [ -f "$PROBE" ]; then
 fi
 
 find "$CACHE_DIR" -type f "$TIME_FLAG" +7 -delete 2>/dev/null || true
+
+# Sweep stale npx atomic-swap remnants (agent-images#87). During an npx
+# package swap, npm renames <pkg> -> .<pkg>-<random>; a crash/SIGKILL mid-swap
+# leaves that dot-dir behind, and every later swap of the same package then
+# fails the rename with ENOTEMPTY — permanently breaking npx install of that
+# package (seen as the gitnexus MCP failing on every child spawn). The regex
+# only matches dash-bearing dot-dirs that are direct children of node_modules
+# (or of an @scope dir), so `.bin` and package-internal dot-dirs never match.
+# The >24h mtime guard ensures an in-flight swap is never raced; mtime (not
+# atime) is deliberate — remnant dirs are never legitimately touched again.
+NPX_DIR="$HOME/.npm/_npx"
+if [ -d "$NPX_DIR" ]; then
+    find "$NPX_DIR" -mindepth 3 -maxdepth 4 -type d -mtime +0 \
+        -regextype posix-extended \
+        -regex '.*/node_modules/(@[^/]+/)?\.[^/]+-[^/]+' -prune -print 2>/dev/null \
+    | while IFS= read -r remnant; do
+        echo "removing stale npx swap remnant: $remnant"
+        rm -rf "$remnant"
+    done
+fi
 
 verify_rc=0
 if command -v npm >/dev/null 2>&1; then

--- a/kali/tests/test_npm_cache_prune.sh
+++ b/kali/tests/test_npm_cache_prune.sh
@@ -62,7 +62,27 @@ bash "$SCRIPT" >"$TMP/out3.log" 2>&1 || rc=$?
 [[ $rc -eq 7 ]] || { echo "FAIL: expected exit 7 from failing npm, got $rc" >&2; cat "$TMP/out3.log" >&2; exit 1; }
 grep -q "WARN: npm cache verify exited 7" "$TMP/out3.log" || { echo "FAIL: warn not logged" >&2; cat "$TMP/out3.log" >&2; exit 1; }
 
-# --- Case 4: lock guard — second concurrent run must noop ---
+# --- Case 4: stale npx swap remnants swept; fresh remnants, real packages,
+# .bin, and package-internal dot-dirs kept ---
+setup_fixture
+run_with_npm_stub 0
+NPX="$AGENT_HOME/.npm/_npx/e46929201c1128dd/node_modules"
+mkdir -p "$NPX/gitnexus" "$NPX/.gitnexus-P2oInPLH" "$NPX/.bin" \
+         "$NPX/@scope/.pkg-AbCdEf12" "$NPX/.fresh-XYZ" "$NPX/gitnexus/.inner-dot"
+echo x > "$NPX/.gitnexus-P2oInPLH/leftover"
+stale_ts="$(date -u -d '2 days ago' +%Y%m%d%H%M)"
+touch -m -t "$stale_ts" "$NPX/.gitnexus-P2oInPLH" "$NPX/@scope/.pkg-AbCdEf12" \
+                        "$NPX/gitnexus/.inner-dot"
+bash "$SCRIPT" >"$TMP/out5.log" 2>&1
+[[ ! -e "$NPX/.gitnexus-P2oInPLH" ]] || { echo "FAIL: stale remnant survived" >&2; cat "$TMP/out5.log" >&2; exit 1; }
+[[ ! -e "$NPX/@scope/.pkg-AbCdEf12" ]] || { echo "FAIL: stale scoped remnant survived" >&2; cat "$TMP/out5.log" >&2; exit 1; }
+[[ -d "$NPX/gitnexus" ]] || { echo "FAIL: real package deleted" >&2; cat "$TMP/out5.log" >&2; exit 1; }
+[[ -d "$NPX/.bin" ]] || { echo "FAIL: .bin deleted" >&2; cat "$TMP/out5.log" >&2; exit 1; }
+[[ -d "$NPX/.fresh-XYZ" ]] || { echo "FAIL: fresh (<24h) remnant deleted" >&2; cat "$TMP/out5.log" >&2; exit 1; }
+[[ -d "$NPX/gitnexus/.inner-dot" ]] || { echo "FAIL: package-internal dot-dir deleted" >&2; cat "$TMP/out5.log" >&2; exit 1; }
+grep -q "removing stale npx swap remnant" "$TMP/out5.log" || { echo "FAIL: remnant removal not logged" >&2; cat "$TMP/out5.log" >&2; exit 1; }
+
+# --- Case 5: lock guard — second concurrent run must noop ---
 setup_fixture
 run_with_npm_stub 0
 # Hold the lock from a background subshell; second invocation should bail.


### PR DESCRIPTION
Closes #87.

## What

`npm-cache-prune.sh` (weekly via supercronic) now also sweeps stale npx atomic-swap remnants: `.<pkg>-<random>` directories left in `~/.npm/_npx/*/node_modules/` when a swap is interrupted. These permanently block every subsequent `npx` install of the same package with `ENOTEMPTY` — the failure mode behind gitnexus MCP dying on every child spawn.

## Safety properties

- Regex `.*/node_modules/(@[^/]+/)?\.[^/]+-[^/]+` only matches **dash-bearing dot-dirs that are direct children of node_modules (or an @scope dir)** — `.bin` (no dash) and package-internal dot-dirs (wrong parent) can never match.
- **>24h mtime guard** so an in-flight swap is never raced; remnants are never legitimately touched again, so mtime is the right clock here (no atime-reliability dance needed, unlike the cacache prune above it).
- Each removal is logged (`removing stale npx swap remnant: …`) for the supercronic log.

## Tested

New harness case: stale plain + scoped remnants removed; fresh (<24h) remnant, real package dir, `.bin`, and a package-internal dot-dir all preserved; removal logged. Full `test_npm_cache_prune.sh` suite **PASS** on `debian:bookworm-slim` (CI userland — the harness needs GNU date, not runnable on macOS).

Note for the in-pod backlog: the currently-wedged remnant on secure-agent-pod still needs the one-time manual `rm -rf` from the issue (or wait for the first weekly tick after the fleet bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)