### PR TITLE
feat(kali): rotate remote-control sessions past max uptime + per-session debug logs

### DIFF
--- a/kali/scripts/session-manager.sh
+++ b/kali/scripts/session-manager.sh
@@ -42,6 +42,47 @@ if [[ -z "${WILLIKINS_REPOS:-}" ]]; then
   log "ERROR: WILLIKINS_REPOS not set"; exit 1
 fi
 
+# Overridable for tests; the image bakes the supervisor at /opt/scripts/.
+WRAP_CLAUDE="${WRAP_CLAUDE:-/opt/scripts/wrap-claude.py}"
+
+# Uptime rotation (#88): a remote-control session that has been up for days
+# accumulates state rot — the 2026-05-23 incident had a 5-day-old parent that
+# looked healthy while every App-attach child crashed within ~2s; a respawn
+# fixed it instantly. Refuse to treat a session as "already running" once its
+# process etime exceeds MAX_SESSION_UPTIME_S (default 3 days; 0 disables).
+# Rotation only fires during the ROTATE_UTC_HOUR window (default 03:xx UTC
+# ticks) so an App user mid-conversation isn't dropped at a random hour —
+# trading a deterministic ~minute of unavailability per 3 days for the silent
+# multi-day-unavailability mode it replaces.
+MAX_SESSION_UPTIME_S="${MAX_SESSION_UPTIME_S:-259200}"
+ROTATE_UTC_HOUR="${ROTATE_UTC_HOUR:-3}"
+
+session_due_rotation() {
+  local pid="$1" etime hour
+  [[ "$MAX_SESSION_UPTIME_S" -gt 0 ]] || return 1
+  hour=$((10#$(date -u +%H)))
+  [[ "$hour" -eq "$ROTATE_UTC_HOUR" ]] || return 1
+  etime="$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
+  [[ -n "$etime" && "$etime" -gt "$MAX_SESSION_UPTIME_S" ]]
+}
+
+rotate_session() {
+  local name="$1" pid="$2" waited=0
+  log "Session '$name' rotating: etime=$(ps -o etimes= -p "$pid" 2>/dev/null | tr -d ' ')s exceeds ${MAX_SESSION_UPTIME_S}s (PID $pid)"
+  # wrap-claude.py forwards SIGTERM to the claude process group and unlinks
+  # its env-id file on clean exit — same path as a graceful pod shutdown.
+  kill -TERM "$pid" 2>/dev/null || true
+  while kill -0 "$pid" 2>/dev/null && (( waited < 30 )); do
+    sleep 1; waited=$((waited + 1))
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    log "Session '$name' still alive ${waited}s after SIGTERM — SIGKILL"
+    kill -KILL "$pid" 2>/dev/null || true
+    sleep 1
+  fi
+  rm -f "$PIDDIR/${name}.pid"
+}
+
 IFS=':' read -ra ENTRIES <<< "$WILLIKINS_REPOS"
 for ((i=0; i<${#ENTRIES[@]}; i+=2)); do
   REPO_PATH="${ENTRIES[$i]}"
@@ -51,7 +92,12 @@ for ((i=0; i<${#ENTRIES[@]}; i+=2)); do
   if [[ -f "$PIDFILE" ]]; then
     PID=$(cat "$PIDFILE")
     if kill -0 "$PID" 2>/dev/null; then
-      log "Session '$SESSION_NAME' already running (PID $PID)"; continue
+      if session_due_rotation "$PID"; then
+        rotate_session "$SESSION_NAME" "$PID"
+        # fall through to the spawn block below
+      else
+        log "Session '$SESSION_NAME' already running (PID $PID)"; continue
+      fi
     else
       log "Session '$SESSION_NAME' stale PID $PID — restarting"; rm -f "$PIDFILE"
     fi
@@ -70,7 +116,10 @@ for ((i=0; i<${#ENTRIES[@]}; i+=2)); do
   # etc.). On graceful SIGTERM the wrapper forwards the signal and unlinks
   # the file after a clean exit. The `exec` replaces the bash wrapper in
   # place, so $! below is the python supervisor's PID.
-  nohup bash -c "exec python3 -u /opt/scripts/wrap-claude.py '$SESSION_NAME' < <(echo y)" \
+  # --debug-file: per-session claude debug log so a crashed/wedged session
+  # leaves evidence (#88) — the 2026-05-23 incident was undiagnosable because
+  # the old process wrote no debug stream.
+  nohup bash -c "exec python3 -u '$WRAP_CLAUDE' '$SESSION_NAME' --debug-file '${HOME}/.willikins-agent/debug-${SESSION_NAME}.log' < <(echo y)" \
     >> "${HOME}/.willikins-agent/session-${SESSION_NAME}.log" 2>&1 &
   echo $! > "$PIDFILE"
   log "Session '$SESSION_NAME' started (PID $!)"

--- a/kali/tests/test_session_manager.sh
+++ b/kali/tests/test_session_manager.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# test_session_manager.sh — harness for scripts/session-manager.sh
+# Focus: uptime-rotation guard (#88) + spawn/already-running paths.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$SCRIPT_DIR/scripts/session-manager.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+export HOME="$TMP/h"
+export AGENT_HOME="$HOME"
+mkdir -p "$HOME"
+
+# Fake repo + session config.
+REPO="$TMP/repo"
+mkdir -p "$REPO/.git"
+export WILLIKINS_REPOS="$REPO:testsess"
+
+# Stub supervisor: sleeps like a healthy long-running session. Must be python
+# (session-manager spawns `python3 -u $WRAP_CLAUDE`). Ignores stdin/args.
+export WRAP_CLAUDE="$TMP/wrap-stub.py"
+cat > "$WRAP_CLAUDE" <<'EOS'
+import time
+time.sleep(600)
+EOS
+
+# Keep the run hermetic: no orphan reaping, heartbeat fails fast + non-fatal.
+export REAP_ORPHAN_ENVS=0
+export PUSHGATEWAY_URL="http://127.0.0.1:1"
+
+LOG="$HOME/.willikins-agent/session-manager.log"
+PIDFILE="$HOME/.willikins-agent/pids/testsess.pid"
+NOW_HOUR=$((10#$(date -u +%H)))
+
+run_sm() { bash "$SCRIPT" >/dev/null 2>&1; }
+
+# --- Case 1: fresh spawn — pidfile written, process alive, debug-file flag passed ---
+export ROTATE_UTC_HOUR=$NOW_HOUR
+run_sm
+[[ -f "$PIDFILE" ]] || { echo "FAIL: no pidfile after fresh spawn" >&2; cat "$LOG" >&2; exit 1; }
+PID1=$(cat "$PIDFILE")
+sleep 0.5
+kill -0 "$PID1" || { echo "FAIL: spawned session not alive" >&2; cat "$LOG" >&2; exit 1; }
+grep -q "Starting session 'testsess'" "$LOG" || { echo "FAIL: spawn not logged" >&2; cat "$LOG" >&2; exit 1; }
+
+# --- Case 2: young session, window open — no rotation ---
+run_sm
+PID2=$(cat "$PIDFILE")
+[[ "$PID2" == "$PID1" ]] || { echo "FAIL: young session was respawned" >&2; cat "$LOG" >&2; exit 1; }
+grep -q "already running (PID $PID1)" "$LOG" || { echo "FAIL: already-running not logged" >&2; cat "$LOG" >&2; exit 1; }
+
+# --- Case 3: over-age session OUTSIDE the rotation window — no rotation ---
+# +12h so an hour rollover during the test run can't open the window.
+export MAX_SESSION_UPTIME_S=1
+export ROTATE_UTC_HOUR=$(( (NOW_HOUR + 12) % 24 ))
+sleep 2   # let etime exceed the 1s threshold
+run_sm
+PID3=$(cat "$PIDFILE")
+[[ "$PID3" == "$PID1" ]] || { echo "FAIL: rotated outside the window" >&2; cat "$LOG" >&2; exit 1; }
+
+# --- Case 4: over-age session, rotation DISABLED (0) — no rotation ---
+export MAX_SESSION_UPTIME_S=0
+export ROTATE_UTC_HOUR=$((10#$(date -u +%H)))   # re-read: window must be open NOW
+run_sm
+PID4=$(cat "$PIDFILE")
+[[ "$PID4" == "$PID1" ]] || { echo "FAIL: rotated despite MAX_SESSION_UPTIME_S=0" >&2; cat "$LOG" >&2; exit 1; }
+
+# --- Case 5: over-age session inside the window — SIGTERM + respawn ---
+export MAX_SESSION_UPTIME_S=1
+export ROTATE_UTC_HOUR=$((10#$(date -u +%H)))   # re-read: window must be open NOW
+run_sm
+PID5=$(cat "$PIDFILE")
+[[ "$PID5" != "$PID1" ]] || { echo "FAIL: over-age session not rotated" >&2; cat "$LOG" >&2; exit 1; }
+kill -0 "$PID1" 2>/dev/null && { echo "FAIL: old session still alive after rotation" >&2; cat "$LOG" >&2; exit 1; }
+sleep 0.5
+kill -0 "$PID5" || { echo "FAIL: replacement session not alive" >&2; cat "$LOG" >&2; exit 1; }
+grep -q "Session 'testsess' rotating: etime=" "$LOG" || { echo "FAIL: rotation not logged" >&2; cat "$LOG" >&2; exit 1; }
+
+# Cleanup the survivor.
+kill "$PID5" 2>/dev/null || true
+
+echo PASS


### PR DESCRIPTION
Closes #88.

## What

1. **Uptime rotation** — `session-manager.sh` refuses to treat a session as "already running" once `ps -o etimes=` exceeds `MAX_SESSION_UPTIME_S` (default **3 days**, `0` disables). Rotation = SIGTERM (wrap-claude's graceful path: forwards to the claude process group, unlinks the env-id file), 30 s bounded wait, SIGKILL fallback, respawn in the same supercronic tick.
2. **Low-traffic window** — rotation only fires when the tick lands in `ROTATE_UTC_HOUR` (default **03:xx UTC**), per the issue's mitigation: a deterministic ~minute of unavailability per 3 days instead of the silent multi-day App-attach outage it replaces.
3. **`--debug-file` piggyback** (issue's "Related") — each session now runs `claude remote-control --debug-file ~/.willikins-agent/debug-<session>.log` (flag verified against the current CLI), so the next wedged parent leaves evidence; the May incident was undiagnosable post-hoc.
4. `WRAP_CLAUDE` env override for the supervisor path (was hardcoded `/opt/scripts/`) — needed by the new test harness, harmless in the image.

## Tested

New `test_session_manager.sh` (5 cases): fresh spawn + pidfile + liveness, young-session no-op, over-age-but-outside-window no-op (+12 h so an hour rollover can't flip it), `MAX_SESSION_UPTIME_S=0` disable, and in-window rotation (old PID dead, new PID alive, rotation logged). PASS on `debian:bookworm-slim` alongside the existing suites.

## Knobs

| env | default | meaning |
|---|---|---|
| `MAX_SESSION_UPTIME_S` | 259200 (3 d) | rotation threshold; `0` disables |
| `ROTATE_UTC_HOUR` | 3 | UTC hour window in which rotation may fire |

3 days is the issue's starting guess — bump to 7 d via env on the pod if it feels aggressive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)