### PR TITLE
ci: fail-fast off for build-children matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -130,6 +130,10 @@ jobs:
     needs: [build-base, build-shell-base, build-multi-agent-shell]
     runs-on: ubuntu-latest
     strategy:
+      # One child's external flake (e.g. ruflo-server's build-time
+      # router.huggingface.co fetch returning 429, #115) must not cancel the
+      # unrelated sibling builds mid-push.
+      fail-fast: false
       matrix:
         image:
           - name: secure-agent-kali


### PR DESCRIPTION
Part of #115 (the one-liner half — the HF-fetch retry/offline fix in the ruflo-server build itself remains open).

Observed on run [27326936633](https://github.com/derio-net/agent-images/actions/runs/27326936633): `ruflo-server`'s build-time `router.huggingface.co` fetch returned 429, and matrix fail-fast then **cancelled the unrelated `secure-agent-kali` build mid-push**. The children are independent images — one child's external flake shouldn't kill the rest of the fleet build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)