### PR TITLE
fix(ruflo-server): retry npm run build to survive HuggingFace 429s (#115)

### DIFF
--- a/ruflo-server/Dockerfile
+++ b/ruflo-server/Dockerfile
@@ -104,8 +104,23 @@ COPY --from=source --chown=1000:1000 /src/ruflo/ruflo/src/ruvocal/ ./
 # `git config safe.directory /app` is mirrored from upstream's Dockerfile (their
 # build context is `src/ruvocal/` so they have no `.git` either — the line is a
 # defensive no-op for any sveltekit plugin that probes for git metadata).
+# `npm run build` prerenders pages that fetch the HuggingFace router model
+# list (router.huggingface.co) at build time. A momentary HF 429 otherwise
+# fails the whole build — and matrix fail-fast then cancels the sibling images
+# (agent-images#115). Retry with linear backoff so a transient upstream
+# rate-limit doesn't break a build whose own sources are fine.
 RUN git config --global --add safe.directory /app \
- && npm run build
+ && for attempt in 1 2 3 4 5; do \
+      npm run build && break; \
+      status=$?; \
+      if [ "$attempt" -eq 5 ]; then \
+        echo "npm run build failed after 5 attempts (last exit $status)" >&2; \
+        exit "$status"; \
+      fi; \
+      delay=$((attempt * 15)); \
+      echo "npm run build failed (attempt $attempt/5, exit $status); retrying in ${delay}s…" >&2; \
+      sleep "$delay"; \
+    done
 
 # --- runtime: mirrors upstream `base` + `final` (INCLUDE_DB=false branch).
 #     The `local_db_true` Mongo install layer is intentionally omitted; ruvocal


### PR DESCRIPTION
## Summary

The `ruflo-server` image build runs `npm run build`, which prerenders pages that fetch the HuggingFace router model list (`router.huggingface.co/v1/models`) **at build time**. A momentary HF **429** failed the whole build — and matrix fail-fast then cancelled the sibling images (`secure-agent-kali` was a casualty while validating #114).

#116 already turned fail-fast **off** (one child's flake no longer cancels the others). This is the deeper half of #115: make the ruflo-server build itself resilient to the transient upstream rate-limit.

## Change

Wrap `npm run build` in a 5-attempt **linear-backoff retry** (15/30/45/60 s) in `ruflo-server/Dockerfile`. A build whose own sources are fine no longer dies on a momentary HF 429; genuine build failures still surface (exits with the last status after 5 attempts).

## Verification

- Retry loop logic checked in isolation: succeeds-first-try → rc 0; fails-twice-then-succeeds → rc 0 (attempt 3); always-fails → exits with the build's status after 5 attempts.
- `sh -n` syntax check of the full `RUN` block passes.
- Branch validation build triggered via `gh workflow run build.yaml --ref fix/ruflo-build-hf-retry` (agent-images CI only auto-runs on `push:main`) — confirms the happy-path build still completes with the wrapper.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)