### PR TITLE
feat(kali): rewrite SSH GitHub remotes to HTTPS (App-token auth, no SSH key)

### DIFF
--- a/base/opt/agent-init.d/02-credential-migrate
+++ b/base/opt/agent-init.d/02-credential-migrate
@@ -24,15 +24,20 @@ set -e
 HOME="${AGENT_HOME:-$HOME}"
 [ -f /opt/gitconfig ] || exit 0
 [ -f "$HOME/.gitconfig" ] || exit 0
-# Already current: dash-safe App-token reader, no $(< …) read, no gh override.
+# Already current: dash-safe App-token reader, no $(< …) read, no gh override, and
+# the SSH→HTTPS rewrite (url.insteadOf) present.
 if grep -qF '/var/run/github/token' "$HOME/.gitconfig" \
    && ! grep -qF '$(<' "$HOME/.gitconfig" \
-   && ! grep -qF 'gh auth git-credential' "$HOME/.gitconfig"; then
+   && ! grep -qF 'gh auth git-credential' "$HOME/.gitconfig" \
+   && grep -qF 'insteadOf = git@github.com:' "$HOME/.gitconfig"; then
     exit 0
 fi
-# Older / dash-broken / gh-overridden GitHub credential config → re-seed the image
-# gitconfig (generic App-token helper only; drops any gh host-specific helper).
+# Older / dash-broken / gh-overridden config, OR a current helper missing the
+# SSH→HTTPS rewrite → re-seed the image gitconfig (generic App-token helper +
+# url.insteadOf; drops any gh host-specific helper). A current helper still
+# references GITHUB_TOKEN (the s6 fallback path), so this grep also catches the
+# "good helper but no insteadOf" case.
 if grep -qE 'GITHUB_TOKEN|/proc/1/environ|gh auth git-credential' "$HOME/.gitconfig"; then
-    echo "[agent-init] re-seeding git credential config → dash-safe App-token helper (no gh override)"
+    echo "[agent-init] re-seeding git credential config → dash-safe App-token helper + SSH→HTTPS rewrite"
     cp /opt/gitconfig "$HOME/.gitconfig"
 fi

--- a/kali/config-templates/gitconfig
+++ b/kali/config-templates/gitconfig
@@ -14,3 +14,11 @@
 # trailing newline s6 writes, so no extra empty `password=` line.
 [credential]
 	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf 'password=%s\\n' \"$(cat \"$t\")\"; return; done; }; f"
+# Rewrite SSH GitHub remotes to HTTPS so they authenticate via the App-token
+# credential helper above. The agent has NO SSH key registered on GitHub — its
+# only credential is the App installation token, which works over HTTPS. Without
+# this, `git remote add origin git@github.com:…` (or an SSH clone URL) fails with
+# "Permission denied (publickey)".
+[url "https://github.com/"]
+	insteadOf = git@github.com:
+	insteadOf = ssh://git@github.com/

--- a/kali/tests/test_credential_migrate.sh
+++ b/kali/tests/test_credential_migrate.sh
@@ -39,6 +39,9 @@ run_case() {
 	name = Clawdia
 [credential]
 	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf 'password=%s\\n' \"$(cat \"$t\")\"; return; done; }; f"
+[url "https://github.com/"]
+	insteadOf = git@github.com:
+	insteadOf = ssh://git@github.com/
 GIT
 
     sed "s|/opt/gitconfig|$fake_opt/gitconfig|g" "$SCRIPT" > "$TMP/$label.sh"
@@ -88,9 +91,15 @@ run_case s6_envdir '[credential]
 run_case dash_broken '[credential]
 	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf '"'"'password=%s\\n'"'"' \"$(< \"$t\")\"; return; done; }; f"' yes
 
-# Case 5: already on the dash-safe App-token reader ($(cat …)) — must NOT migrate.
+# Case 5a: dash-safe helper but MISSING the SSH→HTTPS rewrite — must MIGRATE to add it.
+run_case missing_insteadof '[credential]
+	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf '"'"'password=%s\\n'"'"' \"$(cat \"$t\")\"; return; done; }; f"' yes
+
+# Case 5: already on the dash-safe App-token reader + SSH→HTTPS rewrite — must NOT migrate.
 run_case current_filereader '[credential]
-	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf '"'"'password=%s\\n'"'"' \"$(cat \"$t\")\"; return; done; }; f"' no
+	helper = "!f() { for t in /var/run/github/token /run/s6/basedir/env/GITHUB_TOKEN; do [ -r \"$t\" ] || continue; echo username=x-access-token; printf '"'"'password=%s\\n'"'"' \"$(cat \"$t\")\"; return; done; }; f"
+[url "https://github.com/"]
+	insteadOf = git@github.com:' no
 
 # Case 6: dash-safe generic helper BUT a gh host-specific override present
 # (`gh auth git-credential` serves gh's stored token for github.com) — must


### PR DESCRIPTION
Agents auth to GitHub via the App installation token over **HTTPS**; they have no SSH key registered. An SSH remote (`git@github.com:…`) fails with "Permission denied (publickey)" (hit when pushing a new repo). Adds `url."https://github.com/".insteadOf` so SSH GitHub URLs transparently use HTTPS + the App-token credential helper — `git remote add origin git@github.com:…` just works.

- `config-templates/gitconfig`: the rewrite (git@ + ssh://)
- `02-credential-migrate`: re-seeds existing PVCs missing the rewrite
- `test_credential_migrate`: `missing_insteadof` case added; all 8 cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)