### PR TITLE
Replace gemini CLI with antigravity CLI (agy) in multi-agent-shell (#119)

### DIFF
--- a/.devcontainer/dev/devcontainer.json
+++ b/.devcontainer/dev/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "agent-images — dev",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {}
+  },
+  "postCreateCommand": "pipx install uv 2>/dev/null || true; uv tool install 'git+https://github.com/derio-net/super-fr#subdirectory=packages/fr' || true",
+  "workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
+  "workspaceFolder": "${localWorkspaceFolder}",
+  "runArgs": [
+    "--env-file",
+    "${localEnv:HOME}/.config/fr/secrets/agent-images/dev.env"
+  ],
+  "customizations": {
+    "fr": {
+      "profile": "dev",
+      "purpose": "Day-to-day dev on agent-images: edit Dockerfiles/docs/shell, run bats MOTD tests + pytest locally; GitHub ops on host"
+    }
+  }
+}

--- a/.devcontainer/fr-profiles.yaml
+++ b/.devcontainer/fr-profiles.yaml
@@ -1,0 +1,6 @@
+profiles:
+  dev:
+    purpose: 'Day-to-day dev on agent-images: edit Dockerfiles/docs/shell, run bats
+      MOTD tests + pytest locally; GitHub ops on host'
+    secrets: []
+default: dev

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -615,8 +615,8 @@ jobs:
           # Multi-harness manifest assertion (per docs/standards/multi-harness-shells.md
           # § "Smoke testing"): every harness in the image's manifest reports
           # --version cleanly as UID 1000. claude inherited from agent-base;
-          # codex/gemini/opencode baked here.
-          for h in claude codex gemini opencode; do
+          # codex/agy/opencode baked here.
+          for h in claude codex agy opencode; do
             echo "::group::$h --version"
             docker exec mas-smoke "$h" --version
             echo "::endgroup::"
@@ -841,7 +841,7 @@ jobs:
           docker exec infra-smoke jq --version
 
           # Multi-harness manifest assertion (inherited from multi-agent-shell).
-          for h in claude codex gemini opencode; do
+          for h in claude codex agy opencode; do
             echo "::group::$h --version"
             docker exec infra-smoke "$h" --version
             echo "::endgroup::"

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Shared base image and per-pod child images for secure agent pods on Frank.
 | `agent-base` | `debian:bookworm-slim` | Common toolchain (claude, gh, node, bun, python3, uv, supercronic) |
 | `secure-agent-kali` | `agent-base` | Kali pentest tools + sshd + kubectl/talosctl/omnictl |
 | `vk-local` | `agent-base` | VibeKanban local-mode server binary (from `derio-net/vibe-kanban` fork) |
-| [`multi-agent-shell`](multi-agent-shell/) | `agent-shell-base` | Multi-harness shell: claude + codex + gemini + opencode, implements the [multi-harness shell standard](docs/standards/multi-harness-shells.md). Second intermediate base for Phase 3 `infra-shell`. |
+| [`multi-agent-shell`](multi-agent-shell/) | `agent-shell-base` | Multi-harness shell: claude + codex + agy + opencode, implements the [multi-harness shell standard](docs/standards/multi-harness-shells.md). Second intermediate base for Phase 3 `infra-shell`. |
 | [`hermes-agent-shell`](hermes-agent-shell/) | `agent-shell-base` | Single-harness shell for the `hermes` agent (BYOK against an OpenAI-compatible endpoint — the documented exception to the [standard](docs/standards/multi-harness-shells.md)'s no-API-tokens auth contract). |
 | [`infra-shell`](infra-shell/) | `multi-agent-shell` | Cluster-ops shell: inherits the four multi-agent-shell harnesses and adds `kubectl`/`talosctl`/`omnictl`. No pentest packages — operators can layer via inventory `apt:` if ever needed. |
 

--- a/docs/standards/multi-harness-shells.md
+++ b/docs/standards/multi-harness-shells.md
@@ -2,7 +2,7 @@
 
 **Status:** Draft (living document)
 **Applies to:** any `*-shell` image in this repo that hosts one or more agent-CLI
-harnesses (`claude`, `codex`, `gemini`, `opencode`, `hermes`, future harnesses).
+harnesses (`claude`, `codex`, `agy`, `opencode`, `hermes`, future harnesses).
 **Does not apply to:** server images (`ruflo-server`, `vk-local`).
 
 ## Purpose
@@ -58,8 +58,9 @@ $HOME/
 │   └── state/<image>-shell/  # inventory reconcile state, last-run logs
 ├── .config/                  # XDG-Base-Dir per-harness configs that follow XDG
 │   ├── codex/                # auth.json, settings.json (TBD per upstream)
-│   ├── gemini/               # auth.json, settings.json (TBD per upstream)
 │   └── opencode/             # (TBD per upstream)
+├── .gemini/antigravity-cli/  # agy (antigravity) settings.json + credentials.enc
+│                             #   (agy reuses the ~/.gemini dir; not XDG)
 ├── .claude/                  # claude-code; canonical layout — see below
 │   ├── credentials.json
 │   ├── settings.json
@@ -84,6 +85,9 @@ Each `*-shell` image declares which harnesses it carries. For every
 harness, the image's README lists:
 
 1. **Bootstrap install** — the Dockerfile line that puts the CLI on PATH.
+   Usually `npm i -g <pkg>`, but it may instead be a vendor binary installer
+   (e.g. `agy`/antigravity installs via `curl …/install.sh | bash -s -- --dir
+   /usr/local/bin`).
 2. **Self-update path** — where the CLI writes updates (`$HOME/.local/bin/`
    preferred). If the upstream CLI has no self-update mechanism, install via
    the inventory layer with an npm prefix of `$HOME/.npm-global` so updates
@@ -103,7 +107,7 @@ issued session).
 ## Auth model — subscription, not API tokens
 
 For harnesses that ship a subscription/OAuth login flow (claude, codex,
-gemini, …) the standard mandates that flow over any API-key env-var
+agy, …) the standard mandates that flow over any API-key env-var
 mechanism. The implications:
 
 - The image **does not** carry an `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` /
@@ -131,7 +135,7 @@ SSH login, prints a per-harness auth status table:
 Harness auth status:
   ✓ claude     (~/.claude/credentials.json, age 4d)
   ✓ codex      (~/.config/codex/auth.json, age 4d)
-  ✗ gemini     not logged in — run: gemini login
+  ✗ agy        not logged in — run: agy
   ✗ opencode   not logged in — run: opencode auth login
 ```
 
@@ -186,8 +190,9 @@ removed:
 harnesses:
   claude: latest
   codex: latest
-  gemini: latest
   opencode: 0.4.2
+  # Binary-distributed harnesses with no self-update (e.g. agy/antigravity)
+  # do NOT belong here — they are refreshed by image rebuild.
 
 # Per-harness MCP servers. Each entry is appended to that harness's mcp.json
 # during reconcile, idempotently (existing entries with the same name are
@@ -204,7 +209,6 @@ mcp-servers:
     - name: context7
       command: npx
       args: ["-y", "@upstash/context7-mcp"]
-  gemini: []
   opencode: []
 
 # Per-harness skills/plugins. Reconcile clones (or pulls) git refs into the
@@ -218,7 +222,6 @@ skills:
       source: git+https://github.com/derio-net/super-fr
       ref: main
   codex: []
-  gemini: []
   opencode: []
 ```
 
@@ -242,7 +245,7 @@ concern. What the standard does require:
    `$HOME/.claude/` for that working directory — that's claude-code's own
    behaviour, restated here so spec authors don't fight it.
 3. **Missing per-repo config is non-fatal.** A repo set up only for claude
-   (no `.codex/`, no `.gemini/`) must remain usable by codex and gemini,
+   (no `.codex/`, no agy config) must remain usable by codex and agy,
    which fall back to their `$HOME` defaults.
 4. **No cross-harness pollution.** The standard does not introduce shared
    files like `~/.agent-skills/` that multiple harnesses must read.
@@ -279,9 +282,11 @@ Minimum requirements for a new `*-shell` image to claim compliance:
 
 ## Open questions tracked on this doc
 
-- Self-update behaviour of `codex`, `gemini`, `opencode` — to be confirmed
-  per upstream. If any lacks a self-update mechanism, this doc gains a
-  per-harness workaround section.
+- Self-update behaviour of `codex`, `opencode` — to be confirmed per
+  upstream. If any lacks a self-update mechanism, this doc gains a
+  per-harness workaround section. (`agy`/antigravity is already known to have
+  **no** self-update and no version pin → refreshed by image rebuild, and is
+  intentionally excluded from the inventory `harnesses:` key.)
 - Whether `superpowers` (and similar) ship MCP servers, claude-code
   plugins, or both, and how that distinction maps to the
   `mcp-servers` vs `skills` inventory keys.

--- a/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/01.yaml
+++ b/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/01.yaml
@@ -56,18 +56,20 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-15T08:44:51+00:00'
+      note: Direct curl|bash blocked by security classifier; de-risked by inspecting
+        install.sh instead
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-15T08:44:52+00:00'
+      note: 'Strategy: install.sh supports --dir flag → install straight to /usr/local/bin
+        (no scratch-HOME/relocate). Binary agy; no version pin (R3 accepted).'
     P1.T1.S3:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-06-15T08:44:54+00:00'
+      note: N/A — nothing installed locally (inspection only)
   completion:
-    at: null
+    at: '2026-06-15T08:44:55+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/01.yaml
+++ b/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/01.yaml
@@ -1,0 +1,73 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Validate the agy install mechanism (spike)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Run the vendor install script in the devcontainer and record reality
+  steps:
+  - id: P1.T1.S1
+    text: |-
+      Run the antigravity install script against a scratch HOME and observe
+      exactly what it produces. This de-risks the Dockerfile (spec risk R2)
+      and confirms the binary name / install path / version reporting.
+
+      ```bash
+      rm -rf /tmp/agy-spike && mkdir -p /tmp/agy-spike
+      curl -fsSL https://antigravity.google/cli/install.sh | HOME=/tmp/agy-spike bash 2>&1 | tail -20
+      echo "--- tree ---"
+      find /tmp/agy-spike -maxdepth 4 -type f 2>/dev/null
+      echo "--- version ---"
+      /tmp/agy-spike/.local/bin/agy --version 2>&1 | head -3
+      ```
+
+      Expected: a binary named `agy` lands under `/tmp/agy-spike/.local/bin/`
+      and `agy --version` prints a version string. Record the ACTUAL path and
+      version observed.
+  - id: P1.T1.S2
+    text: |-
+      Decide the Dockerfile install strategy from the spike result and write
+      it down in this step's notes (it becomes the basis for Phase 3):
+
+      - If `HOME=<scratch>` was respected → the Dockerfile can install with a
+        scratch HOME then relocate the binary to `/usr/local/bin/agy`.
+      - If the script ignored HOME / wrote elsewhere → record where it wrote
+        and adjust the relocate source accordingly.
+      - If the script requires unavailable network/tooling in the spike →
+        fall back to the documented install (`curl … | bash` as root, then
+        `install -m 0755 ~/.local/bin/agy /usr/local/bin/agy`), and flag that
+        the CI build is the real gate.
+
+      Expected: a one-paragraph note recording the confirmed install command +
+      relocate path to use in Phase 3, plus the observed `agy --version`.
+  - id: P1.T1.S3
+    text: |-
+      Clean up the spike so it leaves no trace.
+
+      ```bash
+      rm -rf /tmp/agy-spike
+      echo "spike cleaned"
+      ```
+
+      Expected: prints `spike cleaned`.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/02.yaml
+++ b/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/02.yaml
@@ -1,0 +1,140 @@
+schema_version: 2
+phase:
+  number: 2
+  title: Swap the MOTD auth detector gemini→agy (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: RED — update the bats test to expect agy
+  steps:
+  - id: P2.T1.S1
+    text: |-
+      Edit `multi-agent-shell/tests/test_motd.bats`:
+
+      1. In the "no creds" test, replace the `✗ gemini` assertion with
+         `✗ agy`, and add an assertion that the agy line hints the bare
+         command (not "agy login"):
+
+         ```bash
+         [[ "$output" == *"✗ agy"* ]]
+         [[ "$output" == *"run: agy"* ]]
+         [[ "$output" != *"run: agy login"* ]]
+         ```
+
+      2. Add a new test that an agy credential file present → `✓ agy`:
+
+         ```bash
+         @test "agy creds present: shows ✓ for agy" {
+           mkdir -p "$TMP_HOME/.gemini/antigravity-cli"
+           echo 'enc' > "$TMP_HOME/.gemini/antigravity-cli/credentials.enc"
+           run bash "$MOTD"
+           [ "$status" -eq 0 ]
+           [[ "$output" == *"✓ agy"* ]]
+           [[ "$output" == *"✗ codex"* ]]
+         }
+         ```
+
+      Expected: file edited; `git diff --stat` shows the bats file changed.
+  - id: P2.T1.S2
+    text: |-
+      Install bats on-demand (devcontainer is minimal) and run the test to
+      confirm RED.
+
+      ```bash
+      command -v bats >/dev/null || sudo apt-get update -qq && sudo apt-get install -y -qq bats
+      cd multi-agent-shell && bats tests/test_motd.bats || true
+      ```
+
+      Expected: the agy assertions FAIL (the MOTD still emits `gemini`,
+      not `agy`).
+- number: 2
+  title: GREEN — update both MOTD scripts
+  steps:
+  - id: P2.T2.S1
+    text: |-
+      Edit `multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh`:
+
+      1. Extend `check()` to take an optional 3rd arg = login-command hint,
+         defaulting to `"$1 login"`, and print `run: <hint>`:
+
+         ```sh
+         check() {
+           # $1=name $2=path (relative to $HOME) $3=login hint (default "$1 login")
+           hint="${3:-$1 login}"
+           if [ -e "$HOME/$2" ]; then
+             mtime=$(stat -c %Y "$HOME/$2" 2>/dev/null)
+             if [ -n "$mtime" ]; then
+               age_days=$(( ( $(date +%s) - mtime ) / 86400 ))
+               printf '  ✓ %-9s (~/%s, age %sd)\n' "$1" "$2" "$age_days"
+             else
+               printf '  ✓ %-9s (~/%s, age ?)\n' "$1" "$2"
+             fi
+           else
+             printf '  ✗ %-9s not logged in — run: %s\n' "$1" "$hint"
+           fi
+         }
+         ```
+
+      2. Replace the harness check lines: drop `gemini`, add `agy` with the
+         bare-command hint; also correct opencode's hint to its real command:
+
+         ```sh
+         check claude   .claude/credentials.json
+         check codex    .config/codex/auth.json
+         check agy      .gemini/antigravity-cli/credentials.enc   agy
+         check opencode .local/share/opencode/auth.json           "opencode auth login"
+         ```
+
+      Expected: file edited; no `gemini` remains in the script.
+  - id: P2.T2.S2
+    text: |-
+      Apply the identical `check()` + harness-line change to
+      `infra-shell/rootfs/etc/profile.d/50-infra-shell-motd.sh` (it is a
+      near-duplicate of the multi-agent-shell MOTD). infra-shell has no bats
+      suite, so verify by running it against a temp HOME:
+
+      ```bash
+      TMPH=$(mktemp -d) ; HOME=$TMPH bash infra-shell/rootfs/etc/profile.d/50-infra-shell-motd.sh ; rm -rf "$TMPH"
+      ```
+
+      Expected: output shows `✗ agy … run: agy` and no `gemini`.
+  - id: P2.T2.S3
+    text: |-
+      Run the bats suite to confirm GREEN, and shellcheck both scripts.
+
+      ```bash
+      cd multi-agent-shell && bats tests/test_motd.bats
+      cd .. && command -v shellcheck >/dev/null || sudo apt-get install -y -qq shellcheck
+      shellcheck -s sh multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh \
+                       infra-shell/rootfs/etc/profile.d/50-infra-shell-motd.sh
+      ```
+
+      Expected: all bats tests PASS; shellcheck reports no errors.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/02.yaml
+++ b/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/02.yaml
@@ -115,26 +115,26 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T08:47:02+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T08:47:03+00:00'
       note: null
     P2.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T08:47:04+00:00'
       note: null
     P2.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T08:47:06+00:00'
       note: null
     P2.T2.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T08:47:07+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-15T08:47:09+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/03.yaml
+++ b/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/03.yaml
@@ -17,19 +17,23 @@ tasks:
       1. Remove `ARG GEMINI_CLI_VERSION=0.44.1` (line ~26).
       2. Remove the `@google/gemini-cli@${GEMINI_CLI_VERSION} \` line from the
          `npm install -g` RUN (leaving codex + opencode).
-      3. Add a new RUN after that npm install, using the install command +
-         relocate path confirmed in Phase 1. Baseline shape:
+      3. Add a new RUN after that npm install. Phase 1 confirmed (by inspecting
+         install.sh) that the installer supports a `--dir` flag — install
+         straight to the global PATH, no scratch-HOME/relocate needed:
 
          ```dockerfile
          # antigravity CLI (agy) — replaces gemini CLI (deprecating 2026-06-18).
          # Binary-distributed (no npm), no self-update subcommand: updated by
          # image rebuild, NOT the inventory harnesses: key. Auth is interactive
-         # OAuth on first run (no API key). See docs/standards/multi-harness-shells.md.
-         RUN curl -fsSL https://antigravity.google/cli/install.sh | HOME=/tmp/agy bash \
-          && install -m 0755 /tmp/agy/.local/bin/agy /usr/local/bin/agy \
-          && rm -rf /tmp/agy \
+         # OAuth on first run (no API key). install.sh --dir places the binary on
+         # the global PATH. See docs/standards/multi-harness-shells.md.
+         RUN curl -fsSL https://antigravity.google/cli/install.sh \
+               | bash -s -- --dir /usr/local/bin </dev/null \
           && agy --version
          ```
+
+         (`</dev/null` keeps the installer's `agy install` env-setup step
+         non-interactive in the build.)
 
       4. Update the comment block (lines ~15-24) so it no longer implies all
          harnesses are npm/self-updating: note agy is script-installed and
@@ -53,14 +57,16 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-15T08:48:30+00:00'
+      note: Used install.sh --dir /usr/local/bin (Phase-1 finding); removed GEMINI_CLI_VERSION
+        ARG + npm line
     P3.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-15T08:48:31+00:00'
+      note: No functional gemini refs remain; one intentional migration-context comment
+        kept
   completion:
-    at: null
+    at: '2026-06-15T08:48:33+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/03.yaml
+++ b/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/03.yaml
@@ -1,0 +1,66 @@
+schema_version: 2
+phase:
+  number: 3
+  title: Swap the Dockerfile install gemini→agy
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Replace the gemini npm install with the agy binary install
+  steps:
+  - id: P3.T1.S1
+    text: |-
+      Edit `multi-agent-shell/Dockerfile`:
+
+      1. Remove `ARG GEMINI_CLI_VERSION=0.44.1` (line ~26).
+      2. Remove the `@google/gemini-cli@${GEMINI_CLI_VERSION} \` line from the
+         `npm install -g` RUN (leaving codex + opencode).
+      3. Add a new RUN after that npm install, using the install command +
+         relocate path confirmed in Phase 1. Baseline shape:
+
+         ```dockerfile
+         # antigravity CLI (agy) — replaces gemini CLI (deprecating 2026-06-18).
+         # Binary-distributed (no npm), no self-update subcommand: updated by
+         # image rebuild, NOT the inventory harnesses: key. Auth is interactive
+         # OAuth on first run (no API key). See docs/standards/multi-harness-shells.md.
+         RUN curl -fsSL https://antigravity.google/cli/install.sh | HOME=/tmp/agy bash \
+          && install -m 0755 /tmp/agy/.local/bin/agy /usr/local/bin/agy \
+          && rm -rf /tmp/agy \
+          && agy --version
+         ```
+
+      4. Update the comment block (lines ~15-24) so it no longer implies all
+         harnesses are npm/self-updating: note agy is script-installed and
+         refreshed by image rebuild.
+
+      Expected: `grep -n gemini multi-agent-shell/Dockerfile` returns nothing;
+      the agy RUN is present.
+  - id: P3.T1.S2
+    text: |-
+      Lint the Dockerfile (hadolint if available, else a syntax sanity check)
+      and confirm no gemini/GEMINI references remain.
+
+      ```bash
+      command -v hadolint >/dev/null && hadolint multi-agent-shell/Dockerfile || echo "hadolint not present — skipping"
+      grep -niE 'gemini' multi-agent-shell/Dockerfile && echo "FAIL: gemini remains" || echo "OK: no gemini in Dockerfile"
+      ```
+
+      Expected: final line prints `OK: no gemini in Dockerfile`. (The real
+      build gate is the CI smoke job, Phase 5 / R2 — local docker build is out
+      of the devcontainer's scope.)
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/03.yaml
+++ b/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/03.yaml
@@ -27,13 +27,17 @@ tasks:
          # image rebuild, NOT the inventory harnesses: key. Auth is interactive
          # OAuth on first run (no API key). install.sh --dir places the binary on
          # the global PATH. See docs/standards/multi-harness-shells.md.
-         RUN curl -fsSL https://antigravity.google/cli/install.sh \
-               | bash -s -- --dir /usr/local/bin </dev/null \
+         RUN mkdir -p /tmp/agy-home \
+          && curl -fsSL https://antigravity.google/cli/install.sh -o /tmp/agy-install.sh \
+          && HOME=/tmp/agy-home bash /tmp/agy-install.sh --dir /usr/local/bin </dev/null \
+          && rm -rf /tmp/agy-install.sh /tmp/agy-home \
           && agy --version
          ```
 
-         (`</dev/null` keeps the installer's `agy install` env-setup step
-         non-interactive in the build.)
+         Download-then-run (not `curl | bash`) so a curl/TLS failure fails the
+         build directly (no pipefail under `/bin/sh`); throwaway `$HOME` absorbs
+         the installer's shell-rc edits; `</dev/null` keeps `agy install`
+         non-interactive; `agy --version` gates install + executability.
 
       4. Update the comment block (lines ~15-24) so it no longer implies all
          harnesses are npm/self-updating: note agy is script-installed and

--- a/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/04.yaml
+++ b/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/04.yaml
@@ -62,18 +62,18 @@ tasks:
 state:
   steps:
     P4.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T08:53:25+00:00'
       note: null
     P4.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T08:53:27+00:00'
       note: null
     P4.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T08:53:28+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-15T08:53:29+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/04.yaml
+++ b/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/04.yaml
@@ -1,0 +1,79 @@
+schema_version: 2
+phase:
+  number: 4
+  title: Update manifest, standard, READMEs & inventory examples
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: multi-agent-shell README — manifest, build args, prose, inventory
+  steps:
+  - id: P4.T1.S1
+    text: |-
+      Edit `multi-agent-shell/README.md`:
+
+      1. Manifest table: replace the `gemini` row with an `agy` row:
+         `| `agy` (antigravity) | install script `curl …/install.sh \| bash` →
+         `/usr/local/bin/agy` | `agy` (first run prompts OAuth) |
+         `~/.gemini/antigravity-cli/credentials.enc` *(best-effort — see spec R1)* |
+         **image rebuild (no self-update)** |`.
+      2. Build-args table: delete the `GEMINI_CLI_VERSION` row.
+      3. Prose harness lists (lines ~4, ~15): `claude`, `codex`, `agy`, `opencode`.
+      4. Inventory examples: remove `gemini:` from `harnesses:`, `mcp-servers:`,
+         and `skills:` blocks (per spec D1 — agy is not an inventory-managed
+         harness). Add a one-line note under the manifest that agy is updated
+         by image rebuild and is intentionally absent from `harnesses:`.
+
+      Expected: `grep -ni gemini multi-agent-shell/README.md` returns nothing.
+- number: 2
+  title: Standard doc + infra-shell README + root README
+  steps:
+  - id: P4.T2.S1
+    text: |-
+      Edit `docs/standards/multi-harness-shells.md`:
+
+      - L5 applies-to list, L106 auth-model prose, L245 per-repo-fallback
+        prose: replace `gemini` with `agy`.
+      - L61 `$HOME` layout: replace the `.config/gemini/` entry with
+        `~/.gemini/antigravity-cli/   # agy (antigravity) settings + credentials.enc`.
+      - L134 MOTD example: `  ✗ agy        not logged in — run: agy`.
+      - Inventory examples (L189/207/221): remove the `gemini:` lines.
+      - L282 open-question: resolve the gemini self-update item — note agy has
+        no self-update (updated by image rebuild).
+      - In the "Harness manifest" section, add a sentence that a bootstrap
+        "shim" may be a vendor binary installer, not only `npm i -g`.
+
+      Expected: `grep -ni gemini docs/standards/multi-harness-shells.md` returns nothing.
+  - id: P4.T2.S2
+    text: |-
+      Edit the two remaining doc references:
+
+      - `infra-shell/README.md` L4: `(\`claude\`, \`codex\`, \`agy\`, …)`.
+      - `README.md` (repo root) L12: image description
+        `claude + codex + agy + opencode`.
+
+      ```bash
+      grep -ni gemini infra-shell/README.md README.md && echo "FAIL" || echo "OK: clean"
+      ```
+
+      Expected: prints `OK: clean`.
+state:
+  steps:
+    P4.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/05.yaml
+++ b/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/05.yaml
@@ -1,0 +1,76 @@
+schema_version: 2
+phase:
+  number: 5
+  title: CI smoke assertions + residual-gemini sweep
+  tag: agentic
+  depends_on:
+  - 2
+  - 3
+  - 4
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Update build.yaml smoke loops
+  steps:
+  - id: P5.T1.S1
+    text: |-
+      Edit `.github/workflows/build.yaml`:
+
+      - L618 comment `codex/gemini/opencode baked here` → `codex/agy/opencode`.
+      - Both smoke loops (L619 multi-agent-shell, L844 infra-shell):
+        `for h in claude codex gemini opencode;` → `for h in claude codex agy opencode;`.
+
+      ```bash
+      grep -n 'for h in' .github/workflows/build.yaml
+      ```
+
+      Expected: both loops now read `claude codex agy opencode`.
+- number: 2
+  title: Final residual-gemini sweep
+  steps:
+  - id: P5.T2.S1
+    text: |-
+      Confirm the only remaining `gemini` references are the intentional
+      historical records (the 2026-05-12 spec and the 2026-06-01 plan dir).
+
+      ```bash
+      grep -rniE 'gemini|@google/gemini-cli|\.config/gemini' . \
+        --include='*.sh' --include='*.md' --include='*.yaml' --include='*.yml' \
+        --include='*.bats' --include='Dockerfile' \
+        | grep -vE 'docs/superpowers/(specs/2026-05-12|plans/2026-06-01)' \
+        | grep -vE 'docs/superpowers/specs/2026-06-15-antigravity' \
+        || echo "OK: only historical gemini refs remain"
+      ```
+
+      Expected: prints `OK: only historical gemini refs remain` (the 2026-06-15
+      spec legitimately mentions gemini when describing the swap; it is
+      excluded above).
+  - id: P5.T2.S2
+    text: |-
+      Run the full local test surface one more time as a regression gate.
+
+      ```bash
+      cd multi-agent-shell && bats tests/test_motd.bats && cd ..
+      shellcheck -s sh multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh \
+                       infra-shell/rootfs/etc/profile.d/50-infra-shell-motd.sh
+      ```
+
+      Expected: all bats tests PASS; shellcheck clean.
+state:
+  steps:
+    P5.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P5.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/05.yaml
+++ b/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/05.yaml
@@ -30,21 +30,22 @@ tasks:
   steps:
   - id: P5.T2.S1
     text: |-
-      Confirm the only remaining `gemini` references are the intentional
-      historical records (the 2026-05-12 spec and the 2026-06-01 plan dir).
+      Confirm no FUNCTIONAL gemini-CLI references remain in the source tree.
+      The naive `grep gemini` over-matches: agy's credential path legitimately
+      lives under `~/.gemini/antigravity-cli/`, and this swap's own spec + plan
+      describe the change. So the sweep targets the stale FUNCTIONAL tokens and
+      excludes the historical records, this swap's spec/plan dir, and lines that
+      co-occur with `antigravity` (agy's real path).
 
       ```bash
-      grep -rniE 'gemini|@google/gemini-cli|\.config/gemini' . \
+      grep -rniE '@google/gemini-cli|\.config/gemini|GEMINI_CLI_VERSION|check gemini|gemini login|for h in.*gemini|`gemini`|gemini:( |$)' . \
         --include='*.sh' --include='*.md' --include='*.yaml' --include='*.yml' \
         --include='*.bats' --include='Dockerfile' \
-        | grep -vE 'docs/superpowers/(specs/2026-05-12|plans/2026-06-01)' \
-        | grep -vE 'docs/superpowers/specs/2026-06-15-antigravity' \
-        || echo "OK: only historical gemini refs remain"
+        | grep -vE 'docs/superpowers/(specs/2026-05-12|plans/2026-06-01|specs/2026-06-15-antigravity|plans/2026-06-15-antigravity)' \
+        || echo "OK: no functional gemini-CLI refs remain"
       ```
 
-      Expected: prints `OK: only historical gemini refs remain` (the 2026-06-15
-      spec legitimately mentions gemini when describing the swap; it is
-      excluded above).
+      Expected: prints `OK: no functional gemini-CLI refs remain`.
   - id: P5.T2.S2
     text: |-
       Run the full local test surface one more time as a regression gate.
@@ -59,18 +60,18 @@ tasks:
 state:
   steps:
     P5.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T08:55:16+00:00'
       note: null
     P5.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T08:55:17+00:00'
       note: null
     P5.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T08:55:19+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-15T08:55:20+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-15-antigravity-cli-swap
+spec: docs/superpowers/specs/2026-06-15-antigravity-cli-swap-design.md
+target_repo: derio-net/agent-images
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-06-15'

--- a/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/_prose.md
+++ b/docs/superpowers/plans/2026-06-15-antigravity-cli-swap/_prose.md
@@ -1,0 +1,69 @@
+# Plan: Replace gemini CLI with antigravity CLI (`agy`) in multi-agent-shell
+
+**Spec:** [`docs/superpowers/specs/2026-06-15-antigravity-cli-swap-design.md`](../../specs/2026-06-15-antigravity-cli-swap-design.md)
+**Issue:** [#119](https://github.com/derio-net/agent-images/issues/119)
+
+## Goal
+
+Swap the deprecating **gemini CLI** for the **antigravity CLI** (`agy`) across
+`multi-agent-shell` (and the references `infra-shell` inherits), before gemini
+CLI is removed upstream (~2026-06-18). Harnesses become `claude`, `codex`,
+`agy`, `opencode`.
+
+## Why this is not a like-for-like rename
+
+`agy` differs from gemini CLI in three load-bearing ways, all driving the plan:
+
+1. **Binary-distributed, not npm.** Installed via `curl …/install.sh | bash`
+   (binary `agy` → `~/.local/bin/agy`), not `npm i -g`. The Dockerfile gets a
+   dedicated install RUN that relocates the binary to `/usr/local/bin/agy`
+   (Phase 3), validated first by a spike (Phase 1).
+2. **No self-update, no version pin.** `agy` has no `update` subcommand and the
+   installer documents no pin. So `agy` is updated by **image rebuild** and is
+   **not** an inventory `harnesses:` entry (spec deviation D1). It is removed
+   from the inventory examples rather than renamed into them.
+3. **Different auth UX + credential path.** Auth is interactive OAuth on first
+   run of `agy` (no `agy login`, no API key). Credentials land at
+   `~/.gemini/antigravity-cli/credentials.enc` (best-effort — spec risk R1,
+   resolved post-merge). The MOTD detector gets an optional login-hint arg so
+   the `✗ agy` line reads `run: agy` (Phase 2).
+
+## Constraints (operator)
+
+- **No API key in the environment** — persistent agents; never set
+  `ANTIGRAVITY_API_KEY`. Subscription-OAuth only.
+- **Auth is interactive** — human completes OAuth once per pod; creds persist
+  on the PV.
+
+## Phase map
+
+| Phase | What | Depends on | Verified by |
+|---|---|---|---|
+| 1 | Spike: run the install script, confirm binary/path/version | — | observed `agy --version` |
+| 2 | MOTD detector swap (TDD) — both MOTD scripts | — | bats RED→GREEN + shellcheck |
+| 3 | Dockerfile install swap | 1 | grep-clean + lint (CI build is the real gate) |
+| 4 | Manifest, standard, READMEs, inventory examples | 1 | grep-clean per file |
+| 5 | CI smoke loops + residual-gemini sweep | 2,3,4 | grep sweep + full bats/shellcheck |
+
+## TDD note
+
+The genuinely unit-testable surface is the MOTD detector (Phase 2), driven
+RED→GREEN via `multi-agent-shell/tests/test_motd.bats`. The Dockerfile change
+has no local unit test — its gate is the CI `smoke-test-multi-agent-shell` /
+`infra-shell` jobs (`agy --version` as UID 1000), since the devcontainer has no
+docker-in-docker. Phase 1's spike de-risks the install command before it is
+committed to the Dockerfile.
+
+## Out of scope (left as historical record)
+
+`docs/superpowers/specs/2026-05-12-agent-shells-batch-design.md` and
+`docs/superpowers/plans/2026-06-01-agent-shells-batch/` keep their `gemini`
+references — they record what was built then (spec deviation D2).
+
+## Post-merge
+
+A Test Plan (in the spec) is operator-driven after merge: build the image, run
+`agy` interactively, complete OAuth, and confirm the real credential path —
+resolving risk R1. If the path differs from
+`~/.gemini/antigravity-cli/credentials.enc`, the fix is a one-line update to the
+two MOTD scripts + the manifest row (they are coupled by design).

--- a/docs/superpowers/specs/2026-06-15-antigravity-cli-swap-design.md
+++ b/docs/superpowers/specs/2026-06-15-antigravity-cli-swap-design.md
@@ -196,3 +196,9 @@ the operator confirms the OAuth-gated steps.
 `infra-shell/rootfs/etc/profile.d/50-infra-shell-motd.sh`,
 `infra-shell/README.md`, `infra-shell/tests/*` (if present),
 `README.md`, `.github/workflows/build.yaml`.
+
+## Implementation Plans
+
+| Plan | Repo | File | Depends on |
+|------|------|------|------------|
+| 2026-06-15-antigravity-cli-swap | `derio-net/agent-images` | `2026-06-15-antigravity-cli-swap` | — |

--- a/docs/superpowers/specs/2026-06-15-antigravity-cli-swap-design.md
+++ b/docs/superpowers/specs/2026-06-15-antigravity-cli-swap-design.md
@@ -1,0 +1,198 @@
+# Design: Replace gemini CLI with antigravity CLI (`agy`) in multi-agent-shell
+
+**Issue:** [#119](https://github.com/derio-net/agent-images/issues/119)
+**Date:** 2026-06-15
+**Branch:** `feat/antigravity-cli-swap`
+**Status:** Draft → implementation
+
+## Context & goal
+
+Google's **gemini CLI is being replaced by the antigravity CLI** (`agy`) and the
+gemini CLI deprecates upstream ~**2026-06-18** (≈3 days out). The
+`multi-agent-shell` image bakes `@google/gemini-cli` as one of its four
+harnesses (`claude`, `codex`, `gemini`, `opencode`) and the *multi-harness shell
+standard* lists `gemini` as a canonical harness. We must swap `gemini` → the
+antigravity CLI across the image, its manifest/docs/tests, the MOTD auth
+detector, and the standard — before gemini CLI disappears upstream.
+
+`infra-shell` builds **FROM** `multi-agent-shell`, so it inherits the harness
+binaries and carries its own MOTD copy + CI smoke assertions that also reference
+gemini.
+
+## The antigravity CLI — researched facts (2026-06-15)
+
+| Property | gemini CLI (current) | antigravity CLI (`agy`) |
+|---|---|---|
+| Distribution | npm: `@google/gemini-cli` | **shell installer**: `curl -fsSL https://antigravity.google/cli/install.sh \| bash` (not npm) |
+| Binary name | `gemini` | **`agy`** (installer drops it at `~/.local/bin/agy`) |
+| Auth | `gemini` first-run → OAuth | `agy` first-run → Google OAuth; **headless prints a URL + one-time code** |
+| API-key option | `GEMINI_API_KEY` | `ANTIGRAVITY_API_KEY` — **must NOT be used** (see constraints) |
+| Config dir | `~/.config/gemini/` | `~/.gemini/antigravity-cli/settings.json` |
+| Credential file | `~/.config/gemini/auth.json` | **`~/.gemini/antigravity-cli/credentials.enc`** (encrypted; key derived from OS keychain / Secret Service on Linux) — *best-effort, see risk R1* |
+| Self-update | `gemini update` / inventory pin | **none** — no `agy update` subcommand; updates by re-running the install script (i.e. image rebuild). `agy changelog` only reports versions. |
+| Version pin | `@google/gemini-cli@<ver>` | **no documented pin mechanism** in the install script — installs latest |
+| Migration | — | `agy plugin import gemini`; non-destructive, reads existing `~/.gemini/` |
+
+Sources: antigravity.google docs/CLI guides, Google Cloud Community
+"Getting Started with Antigravity CLI", gemini→agy migration guides
+(inventivehq, pasqualepillitteri). Cross-checked across ≥4 sources.
+
+## Operator constraints (locked)
+
+1. **No API key in the environment.** These are persistent agents; do not add
+   `ANTIGRAVITY_API_KEY` to the image, the Dockerfile, or any pod `env:`. This
+   matches the standard's subscription-OAuth mandate (no `*_API_KEY` for these
+   harnesses).
+2. **Auth is interactive.** A human runs `agy` once on first SSH and completes
+   the OAuth flow (headless: open the printed URL + code on a laptop). The
+   credential persists on the PV. No automated/token auth.
+
+## Q&A decisions (operator, 2026-06-15)
+
+| # | Decision | Choice |
+|---|---|---|
+| 1 | Naming across docs/tests/MOTD/inventory | **Use `agy` everywhere** (the real binary). README labels it "antigravity (`agy`)". No `antigravity→agy` symlink. |
+| 2 | Devcontainer profile | **Single `dev` profile, no secrets** (already scaffolded). |
+| 3 | Replacement scope | **Hard-replace gemini.** Harnesses become `claude`, `codex`, `agy`, `opencode`. |
+| 4 | Post-merge Test Plan | **Yes** — verify the real image on a pod (build + `agy --version` + interactive OAuth + confirm which credential file lands). |
+
+## Design
+
+### Harness model for `agy` — a "bootstrap-only, rebuild-updated" harness
+
+`agy` does **not** satisfy two properties the standard expects of a harness
+(self-update path; `<h> login` auth command). The standard explicitly handles
+this (`docs/standards/multi-harness-shells.md` §"Harness manifest", lines
+97–101: "If an upstream CLI does not satisfy properties 2 or 3, the image-level
+spec must call out the gap and propose a workaround"). The workaround:
+
+- **Bootstrap install:** run the vendor install script at build time and place
+  the `agy` binary on the global PATH (`/usr/local/bin/agy`), matching where the
+  npm `-g` harnesses land. The standard's "bootstrap shim" slot is satisfied by
+  a binary install rather than `npm i -g`.
+- **Update path:** **image rebuild** (re-run the install script). `agy` has no
+  self-update and no npm pin, so it is reserved to the image-rebuild lane the
+  standard already defines ("Image rebuilds are reserved for: changing the
+  bootstrap shim itself…").
+- **Therefore `agy` is NOT an inventory `harnesses:` pin entry.** The inventory
+  handler runs `<h> update`, which `agy` lacks. `agy` is removed from the
+  `harnesses:` examples and not re-added. (See Deviation D1.)
+- **Auth command:** `agy` (first run), not `agy login`.
+- **Credential file (MOTD contract):** `~/.gemini/antigravity-cli/credentials.enc`
+  — flagged best-effort (R1), same hedge the README already applies to
+  `opencode`.
+
+### Change inventory (the full gemini footprint → agy)
+
+| # | File | Current | New |
+|---|---|---|---|
+| C1 | `multi-agent-shell/Dockerfile` | `ARG GEMINI_CLI_VERSION=0.44.1`; `@google/gemini-cli@${GEMINI_CLI_VERSION}` inside the one `npm install -g` RUN | Drop the gemini ARG + npm line; add a separate `RUN` that installs `agy` via the vendor script into `/usr/local/bin/agy` and asserts `agy --version`. Update the comment block (lines 15–24) to note agy is script-installed/rebuild-updated, not npm/self-update. |
+| C2 | `multi-agent-shell/README.md` | manifest row `gemini`; build-arg row; inventory examples (`harnesses`, `mcp-servers`, `skills`) with `gemini`; prose "four harnesses … gemini"; first-boot runbook | Replace the `gemini` manifest row with an `agy` row (bootstrap = install script; auth = `agy`; cred = `~/.gemini/antigravity-cli/credentials.enc` *best-effort*; update = **image rebuild — no self-update**). Drop the `GEMINI_CLI_VERSION` build-arg row. Drop `gemini` from inventory `harnesses:`/`mcp-servers:`/`skills:` examples (D1). Update prose harness lists to `claude`, `codex`, `agy`, `opencode`. |
+| C3 | `multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh` | `check gemini .config/gemini/auth.json` | `check agy .gemini/antigravity-cli/credentials.enc`. Extend `check` to accept an optional 3rd arg = login-hint command so the `✗` line reads "run: agy" (not "run: agy login"); default stays `<name> login` for the others. |
+| C4 | `multi-agent-shell/tests/test_motd.bats` | asserts `✗ gemini`; claude-only test | Assert `✗ agy` (no-creds); add a test that an `agy` credentials file present → `✓ agy`; assert the `✗ agy` line shows "run: agy". |
+| C5 | `multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/install-inventory.sh` | generic `harnesses:` handler (covers gemini) | **No code change** — the handler is generic. agy simply isn't listed in inventory examples. (If an operator adds `agy:` anyway, the existing "CLI not on PATH"/`run` failure path logs a warning — acceptable, documented in README.) |
+| C6 | `docs/standards/multi-harness-shells.md` | `gemini` in: applies-to list (L5), `$HOME` layout `.config/gemini/` (L61), auth-model prose (L106), MOTD example `gemini login` (L134), inventory examples (L189/207/221), per-repo-fallback prose (L245), self-update open-question (L282) | Replace each `gemini` mention with `agy` where it's a harness reference (L5, L106, L245). Replace the `.config/gemini/` layout entry with `~/.gemini/antigravity-cli/` (L61). Update the MOTD example to `✗ agy … run: agy` (L134). Drop `gemini` from inventory examples (L189/207/221) per D1. Resolve the L282 open-question (agy = no self-update → image rebuild). Add a one-line note that a bootstrap "shim" may be a vendor binary installer (not only `npm i -g`). |
+| C7 | `infra-shell/rootfs/etc/profile.d/50-infra-shell-motd.sh` | `check gemini .config/gemini/auth.json` (L31) | same edit as C3 (agy cred path + login-hint). **Note:** the `check` function body here must get the same optional-3rd-arg change as C3 (the two MOTD scripts are near-duplicates). |
+| C8 | `infra-shell/README.md` | inheritance line "(`claude`, `codex`, `gemini`, …)" (L4) | `(claude, codex, agy, …)`. |
+| C9 | `infra-shell/tests/` | — | **No file** — infra-shell ships no local bats tests (confirmed: only `Dockerfile`, `README.md`, `rootfs/`). infra-shell's MOTD is covered solely by the CI smoke job (C11, L844). No change. |
+| C10 | `README.md` (repo root) | image table: "claude + codex + gemini + opencode" (L12) | "claude + codex + agy + opencode". |
+| C11 | `.github/workflows/build.yaml` | comment "codex/gemini/opencode baked here" (L618); `for h in claude codex gemini opencode` (L619 multi-agent-shell, L844 infra-shell smoke) | Update the L618 comment and both smoke loops to `claude codex agy opencode`. |
+
+### Explicitly out of scope / left unchanged
+
+- `docs/superpowers/specs/2026-05-12-agent-shells-batch-design.md` **and**
+  `docs/superpowers/plans/2026-06-01-agent-shells-batch/` (01.yaml, 03.yaml,
+  _prose.md) — **historical/shipped spec + plan** that record what was built
+  then. We do not rewrite history; they keep their `gemini` references as an
+  accurate record of the original build. (Deviation D2.)
+- `agent-shell-base/Dockerfile`, `base/` — confirmed no gemini; no change.
+- agy MCP-server / skills inventory wiring — agy stores MCP/skills under
+  `~/.gemini/antigravity-cli/`, not the generic `~/.<harness>/` convention the
+  inventory handler assumes. Wiring agy into `mcp-servers:`/`skills:` is a
+  **separate follow-up**, not part of this swap. (Deviation D1.)
+
+## Deviations from the issue's literal "rename gemini → antigravity"
+
+- **D1 — agy is not a like-for-like inventory harness.** The issue lists
+  "Inventory installer (`harnesses:` key) — rename/replace `gemini` with
+  `antigravity`." Because `agy` has no `update` subcommand and no npm pin, it
+  cannot be a managed `harnesses:` pin. We instead **remove** gemini from the
+  inventory examples and document agy's update path as image-rebuild. The
+  generic installer code is untouched.
+- **D2 — historical spec untouched.** The 2026-05-12 agent-shells-batch spec is
+  a record, not a living doc; left as-is.
+- **D3 — binary name `agy`, label "antigravity".** Per Q&A #1 we use the real
+  binary `agy` as the harness key/command everywhere; "antigravity" appears only
+  as the friendly product name in prose.
+
+## Risks
+
+- **R1 (highest) — credential file path is unverified.** Sources disagree:
+  `~/.gemini/antigravity-cli/credentials.enc` (encrypted file) vs OS-keyring-only
+  storage. On a **headless container** Linux Secret Service may be absent, so the
+  encrypted file may not be written, may not decrypt across restarts, or the
+  token may live only in a keyring that does not persist on the PV. The MOTD
+  path (C3/C7) is a best-effort guess. **The post-merge Test Plan resolves this**
+  by observing what actually lands after a real `agy` login on a pod; if it
+  differs, the fix is a one-line MOTD + manifest update (both already coupled).
+- **R2 — build-time install script behavior.** `install.sh` auto-detects the
+  environment, writes to `$HOME/.local/bin`, and edits `~/.bashrc`/`~/.profile`.
+  Running it as root at build time and relocating the binary to `/usr/local/bin`
+  must be verified; the CI smoke `agy --version` is the gate. Mitigation: pass a
+  scratch `HOME`, relocate the binary, `rm -rf` the scratch dir, assert version.
+- **R3 — no version pin → non-reproducible builds.** `agy` installs latest.
+  Accepted: this matches the `claude` bootstrap (also latest); reproducibility
+  for agy is traded for tracking upstream. Noted in the manifest.
+- **R4 — keyring/persistence across restarts.** Tied to R1; if creds don't
+  survive restart, operators re-run `agy` interactively. Captured in the Test
+  Plan; no image change can fix a missing keyring, but it must be known.
+
+## Testing strategy (pre-merge, TDD)
+
+1. **MOTD bats (C3/C4):** drive `test_motd.bats` — RED first (assert `✗ agy`
+   and the "run: agy" hint, and `✓ agy` when the credential file exists), then
+   edit the MOTD script to green. Run in the devcontainer with `bats` installed
+   on-demand. Mirror for infra-shell (C7/C9).
+2. **shellcheck** the edited `.sh` files (install on-demand).
+3. **CI build + smoke** (`.github/workflows/build.yaml`): the real gate for the
+   Dockerfile change — builds the image and runs `agy --version` as UID 1000
+   (C11). This catches R2. Local full-image build is out of the devcontainer's
+   scope (no docker-in-docker); CI owns it.
+4. **Doc consistency:** grep the tree for residual `gemini` / `@google/gemini-cli`
+   / `.config/gemini` and confirm only the intentional historical spec remains.
+
+## Test Plan (post-merge — operator-driven)
+
+Run after the PR merges and CI publishes the image. The agent runs what it can;
+the operator confirms the OAuth-gated steps.
+
+1. **Image builds & agy present.** Confirm the CI `smoke-test-multi-agent-shell`
+   (and `infra-shell`) jobs are green and that the smoke loop ran `agy --version`
+   cleanly as UID 1000.
+2. **Pull onto a real pod / local docker.** `docker run` (or exec into the
+   deployed pod) and confirm `agy --version` and `command -v agy` →
+   `/usr/local/bin/agy`.
+3. **Interactive auth.** Run `agy` as the agent user; complete the headless
+   OAuth (open the printed URL + one-time code on a laptop). Confirm login
+   succeeds.
+4. **Resolve R1 — observe the real credential path.** After login, inspect what
+   landed: `ls -la ~/.gemini/antigravity-cli/` (expect `credentials.enc` +
+   `settings.json`); also check for any OS-keyring artifact. **If the credential
+   file path differs from `~/.gemini/antigravity-cli/credentials.enc`, update C3
+   + C7 (MOTD) and the README/standard manifest row** — they are coupled and the
+   fix is one line each.
+5. **MOTD reflects login.** Re-SSH (or re-source the profile.d drop-in) and
+   confirm the auth table shows `✓ agy (~/.gemini/antigravity-cli/…)`.
+6. **Persistence across restart.** Restart the container/pod; confirm `agy`
+   still authenticated (credential survived on the PV) — resolves R4. If not,
+   document that agy requires re-auth per pod and note the keyring gap.
+
+## Affected files summary
+
+`multi-agent-shell/Dockerfile`, `multi-agent-shell/README.md`,
+`multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh`,
+`multi-agent-shell/tests/test_motd.bats`,
+`docs/standards/multi-harness-shells.md`,
+`infra-shell/rootfs/etc/profile.d/50-infra-shell-motd.sh`,
+`infra-shell/README.md`, `infra-shell/tests/*` (if present),
+`README.md`, `.github/workflows/build.yaml`.

--- a/infra-shell/README.md
+++ b/infra-shell/README.md
@@ -1,7 +1,7 @@
 # infra-shell
 
 SSH-able shell image carrying the four agent-CLI harnesses inherited from
-[`multi-agent-shell`](../multi-agent-shell/) (`claude`, `codex`, `gemini`,
+[`multi-agent-shell`](../multi-agent-shell/) (`claude`, `codex`, `agy`,
 `opencode`) **plus** cluster-admin tooling (`kubectl`, `talosctl`,
 `omnictl`). Implements the
 [multi-harness shell standard](../docs/standards/multi-harness-shells.md)

--- a/infra-shell/rootfs/etc/profile.d/50-infra-shell-motd.sh
+++ b/infra-shell/rootfs/etc/profile.d/50-infra-shell-motd.sh
@@ -10,7 +10,8 @@
 echo "Harness auth status:"
 
 check() {
-  # $1=name $2=path (relative to $HOME)
+  # $1=name $2=path (relative to $HOME) $3=login-command hint (default "$1 login")
+  hint="${3:-$1 login}"
   if [ -e "$HOME/$2" ]; then
     # stat may fail on an unreadable/dangling target; degrade to "?" rather
     # than emit a shell arithmetic error on login.
@@ -22,11 +23,14 @@ check() {
       printf '  ✓ %-9s (~/%s, age ?)\n' "$1" "$2"
     fi
   else
-    printf '  ✗ %-9s not logged in — run: %s login\n' "$1" "$1"
+    printf '  ✗ %-9s not logged in — run: %s\n' "$1" "$hint"
   fi
 }
 
+# agy (antigravity) auth is interactive on first run of `agy` (no `agy login`),
+# and its credential lands at ~/.gemini/antigravity-cli/credentials.enc
+# (best-effort path — confirmed post-merge per the spec's Test Plan).
 check claude   .claude/credentials.json
 check codex    .config/codex/auth.json
-check gemini   .config/gemini/auth.json
-check opencode .local/share/opencode/auth.json
+check agy      .gemini/antigravity-cli/credentials.enc   agy
+check opencode .local/share/opencode/auth.json           "opencode auth login"

--- a/multi-agent-shell/Dockerfile
+++ b/multi-agent-shell/Dockerfile
@@ -34,10 +34,20 @@ RUN npm install -g --omit=dev \
 # vendor install script, has NO self-update subcommand and NO version-pin
 # mechanism, so it is refreshed by IMAGE REBUILD — not the inventory
 # `harnesses:` key. Auth is interactive Google OAuth on first run of `agy`
-# (no `agy login`, no API key); the credential persists on the PV. The
-# installer's `--dir` flag drops the binary straight onto the global PATH.
-RUN curl -fsSL https://antigravity.google/cli/install.sh \
-      | bash -s -- --dir /usr/local/bin </dev/null \
+# (no `agy login`, no API key); the credential persists on the PV.
+#
+# Install via download-then-run (not `curl | bash`) so a curl/TLS failure
+# fails the build directly instead of being masked by the pipe — `/bin/sh`
+# here has no pipefail. The installer's `--dir` flag drops the binary
+# straight onto the global PATH (no relocate needed); a throwaway $HOME
+# absorbs the installer's shell-rc edits so they don't bloat root's home,
+# and both scratch paths are removed in the same layer. `agy --version`
+# gates that the binary installed and is executable (CI smoke re-checks it
+# as UID 1000).
+RUN mkdir -p /tmp/agy-home \
+ && curl -fsSL https://antigravity.google/cli/install.sh -o /tmp/agy-install.sh \
+ && HOME=/tmp/agy-home bash /tmp/agy-install.sh --dir /usr/local/bin </dev/null \
+ && rm -rf /tmp/agy-install.sh /tmp/agy-home \
  && agy --version
 
 COPY --chown=root:root rootfs/ /

--- a/multi-agent-shell/Dockerfile
+++ b/multi-agent-shell/Dockerfile
@@ -12,23 +12,33 @@ ARG AGENT_GID=1000
 
 USER root
 
-# Per docs/standards/multi-harness-shells.md — bake the three additional
+# Per docs/standards/multi-harness-shells.md — bake the additional
 # subscription/OAuth harness bootstrap shims. claude is inherited from
 # agent-base (npm i -g @anthropic-ai/claude-code) and the inherited shim's
-# self-update target is $HOME/.local/bin/. Each new shim follows the same
-# convention: the operator runs `<h> login` once on first SSH; the CLI
-# self-updates or is refreshed via inventory reconcile thereafter.
+# self-update target is $HOME/.local/bin/. The npm-distributed shims
+# (codex, opencode) follow the same convention: the operator runs `<h> login`
+# once on first SSH; the CLI self-updates or is refreshed via inventory
+# reconcile thereafter.
 #
 # Pins captured during plan execution (npm view <pkg> version on
 # 2026-06-01). These pins float forward via the inventory `harnesses:`
 # key; the Dockerfile shim is only a bootstrap.
 ARG CODEX_VERSION=0.136.0
-ARG GEMINI_CLI_VERSION=0.44.1
 ARG OPENCODE_VERSION=1.15.13
 RUN npm install -g --omit=dev \
       @openai/codex@${CODEX_VERSION} \
-      @google/gemini-cli@${GEMINI_CLI_VERSION} \
       opencode-ai@${OPENCODE_VERSION}
+
+# antigravity CLI (agy) — replaces the gemini CLI (deprecating upstream
+# 2026-06-18). Unlike the npm harnesses, agy is binary-distributed via a
+# vendor install script, has NO self-update subcommand and NO version-pin
+# mechanism, so it is refreshed by IMAGE REBUILD — not the inventory
+# `harnesses:` key. Auth is interactive Google OAuth on first run of `agy`
+# (no `agy login`, no API key); the credential persists on the PV. The
+# installer's `--dir` flag drops the binary straight onto the global PATH.
+RUN curl -fsSL https://antigravity.google/cli/install.sh \
+      | bash -s -- --dir /usr/local/bin </dev/null \
+ && agy --version
 
 COPY --chown=root:root rootfs/ /
 

--- a/multi-agent-shell/README.md
+++ b/multi-agent-shell/README.md
@@ -1,7 +1,7 @@
 # multi-agent-shell
 
 SSH-able shell image carrying four agent-CLI harnesses
-(`claude`, `codex`, `gemini`, `opencode`). The load-bearing reference
+(`claude`, `codex`, `agy`, `opencode`). The load-bearing reference
 implementation of the
 [multi-harness shell standard](../docs/standards/multi-harness-shells.md):
 per-harness state under `$HOME` on the per-pod PV, no API tokens in the
@@ -12,7 +12,7 @@ SSH login.
 Intended consumers:
 
 - The n8n sidecar use case — workflow nodes `exec` into this shell to invoke
-  `claude -p`, `codex`, `gemini`, or `opencode` against a shared pod
+  `claude -p`, `codex`, `agy`, or `opencode` against a shared pod
   filesystem with PV-resident OAuth credentials.
 - `infra-shell` (Phase 3 of the agent-shells-batch plan) builds **FROM**
   this image and adds cluster-admin tooling.
@@ -21,15 +21,16 @@ Intended consumers:
 
 Per the standard's "Harness manifest" section, every harness baked into this
 image is declared below. The bootstrap install only puts the CLI on PATH;
-the operator runs `<h> login` once on first SSH and the OAuth credential
-lands on the PV. Updates flow via `<h> update` (CLI self-update) or via the
-inventory `harnesses:` key on each reconcile.
+the operator runs the auth command once on first SSH and the OAuth credential
+lands on the PV. For the npm harnesses, updates flow via `<h> update` (CLI
+self-update) or the inventory `harnesses:` key on each reconcile; `agy` is the
+exception — it has no self-update and is refreshed by image rebuild (see note).
 
 | Harness | Bootstrap | Auth command | Credential file (on PV) | Update command |
 |---|---|---|---|---|
 | `claude` | `npm i -g @anthropic-ai/claude-code` (inherited from `agent-base`) | `claude login` | `~/.claude/credentials.json` | `claude update` |
 | `codex` | `npm i -g @openai/codex@${CODEX_VERSION}` | `codex login` | `~/.config/codex/auth.json` | `codex update` (or inventory `harnesses: codex: <ver>`) |
-| `gemini` | `npm i -g @google/gemini-cli@${GEMINI_CLI_VERSION}` | `gemini` (first run prompts the OAuth flow) | `~/.config/gemini/auth.json` | inventory `harnesses: gemini: <ver>` |
+| `agy` (antigravity) | `curl -fsSL …/install.sh \| bash -s -- --dir /usr/local/bin` (replaces gemini CLI) | `agy` (first run prompts the OAuth flow) | `~/.gemini/antigravity-cli/credentials.enc` *(best-effort — confirmed post-merge, see notes)* | **image rebuild** (no self-update; not inventory-managed) |
 | `opencode` | `npm i -g opencode-ai@${OPENCODE_VERSION}` | `opencode auth login` | `~/.local/share/opencode/auth.json` | inventory `harnesses: opencode: <ver>` |
 
 Notes:
@@ -40,6 +41,14 @@ Notes:
 - **`opencode` credential path is a best-effort default** until first
   operator login confirms upstream's chosen location; if it differs, fix
   here and in the MOTD detector — both must agree.
+- **`agy` (antigravity) is a bootstrap-only harness.** It is
+  binary-distributed (no npm), has no `agy update` subcommand and no
+  version-pin mechanism, so it is updated by **image rebuild** and is
+  intentionally **absent from the inventory `harnesses:` key**. Its
+  credential path (`~/.gemini/antigravity-cli/credentials.enc`) is
+  best-effort and confirmed the first time an operator runs `agy` — if it
+  differs, fix the manifest row and both MOTD detectors together. Auth is
+  interactive OAuth on first run of `agy` (no `agy login`, no API key).
 - **No `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / etc. in the image or in
   Frank's `env:` block for this image.** The subscription-OAuth flows replace
   API-key auth per the standard.
@@ -71,8 +80,9 @@ cargo:
 harnesses:
   claude: latest
   codex: latest
-  gemini: latest
   opencode: 1.15.13
+  # NB: agy (antigravity) is NOT listed here — it has no `agy update`
+  # subcommand and is refreshed by image rebuild, not inventory reconcile.
 
 # Per-harness MCP servers. Each entry is merged into the harness's
 # mcp.json by .name (idempotent — re-running reconcile produces no
@@ -83,7 +93,6 @@ mcp-servers:
       command: npx
       args: ["-y", "@upstash/context7-mcp"]
   codex: []
-  gemini: []
   opencode: []
 
 # Per-harness skills/plugins. Reconcile clones (or fast-forwards to ref)
@@ -94,7 +103,6 @@ skills:
       source: git+https://github.com/obra/superpowers
       ref: main
   codex: []
-  gemini: []
   opencode: []
 ```
 
@@ -159,8 +167,10 @@ cat /var/lib/multi-agent-shell/last-reconcile.motd
 |---|---|---|
 | `BASE_SHA` | `latest` | The `agent-shell-base` tag/SHA to inherit from. CI passes the SHA of the same workflow run. |
 | `CODEX_VERSION` | `0.136.0` | `@openai/codex` npm pin. |
-| `GEMINI_CLI_VERSION` | `0.44.1` | `@google/gemini-cli` npm pin. |
 | `OPENCODE_VERSION` | `1.15.13` | `opencode-ai` npm pin. |
+
+`agy` (antigravity) has no build-arg pin — it is installed at the latest
+version by the vendor script (the installer exposes no version flag).
 
 `AGENT_USER`, `AGENT_HOME`, `AGENT_UID`, `AGENT_GID` are inherited from
 `agent-shell-base` (defaults: `agent`, `/home/agent`, `1000`, `1000`).

--- a/multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh
+++ b/multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh
@@ -10,7 +10,8 @@
 echo "Harness auth status:"
 
 check() {
-  # $1=name $2=path (relative to $HOME)
+  # $1=name $2=path (relative to $HOME) $3=login-command hint (default "$1 login")
+  hint="${3:-$1 login}"
   if [ -e "$HOME/$2" ]; then
     # stat may fail on an unreadable/dangling target; degrade to "?" rather
     # than emit a shell arithmetic error on login.
@@ -22,11 +23,14 @@ check() {
       printf '  ✓ %-9s (~/%s, age ?)\n' "$1" "$2"
     fi
   else
-    printf '  ✗ %-9s not logged in — run: %s login\n' "$1" "$1"
+    printf '  ✗ %-9s not logged in — run: %s\n' "$1" "$hint"
   fi
 }
 
+# agy (antigravity) auth is interactive on first run of `agy` (no `agy login`),
+# and its credential lands at ~/.gemini/antigravity-cli/credentials.enc
+# (best-effort path — confirmed post-merge per the spec's Test Plan).
 check claude   .claude/credentials.json
 check codex    .config/codex/auth.json
-check gemini   .config/gemini/auth.json
-check opencode .local/share/opencode/auth.json
+check agy      .gemini/antigravity-cli/credentials.enc   agy
+check opencode .local/share/opencode/auth.json           "opencode auth login"

--- a/multi-agent-shell/tests/test_motd.bats
+++ b/multi-agent-shell/tests/test_motd.bats
@@ -16,8 +16,15 @@ teardown() { rm -rf "$TMP_HOME"; }
   [ "$status" -eq 0 ]
   [[ "$output" == *"✗ claude"* ]]
   [[ "$output" == *"✗ codex"* ]]
-  [[ "$output" == *"✗ gemini"* ]]
+  [[ "$output" == *"✗ agy"* ]]
   [[ "$output" == *"✗ opencode"* ]]
+}
+
+@test "agy hint is the bare command, not 'agy login'" {
+  run bash "$MOTD"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"run: agy"* ]]
+  [[ "$output" != *"run: agy login"* ]]
 }
 
 @test "claude creds present: shows ✓ for claude only" {
@@ -26,5 +33,14 @@ teardown() { rm -rf "$TMP_HOME"; }
   run bash "$MOTD"
   [ "$status" -eq 0 ]
   [[ "$output" == *"✓ claude"* ]]
+  [[ "$output" == *"✗ codex"* ]]
+}
+
+@test "agy creds present: shows ✓ for agy" {
+  mkdir -p "$TMP_HOME/.gemini/antigravity-cli"
+  echo 'enc' > "$TMP_HOME/.gemini/antigravity-cli/credentials.enc"
+  run bash "$MOTD"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✓ agy"* ]]
   [[ "$output" == *"✗ codex"* ]]
 }


### PR DESCRIPTION
## Summary

Replaces the deprecating **gemini CLI** with the **antigravity CLI** (`agy`) in `multi-agent-shell` and the references `infra-shell` inherits, before gemini CLI is removed upstream (~2026-06-18). The four harnesses become **`claude`, `codex`, `agy`, `opencode`**.

Closes #119.

`agy` is **not** a like-for-like swap, which shaped the change:
- **Binary-distributed, not npm.** Installed via the vendor script to `/usr/local/bin/agy` (not `@google/gemini-cli`).
- **No self-update, no version pin.** Refreshed by **image rebuild** — so `agy` is intentionally **absent from the inventory `harnesses:` key** (it has no `agy update`).
- **Different auth + credential path.** Interactive Google OAuth on first run of `agy` (no `agy login`, **no API key** — per operator constraint); credential at `~/.gemini/antigravity-cli/credentials.enc`.

### What changed
- **`multi-agent-shell/Dockerfile`** — drop `@google/gemini-cli` npm install + `GEMINI_CLI_VERSION` ARG; install `agy` via download-then-run with `--dir /usr/local/bin`.
- **MOTD detector** (`multi-agent-shell` + `infra-shell`) — `check agy ~/.gemini/antigravity-cli/credentials.enc`; `check()` gains an optional login-hint arg so the `✗` line reads `run: agy` (and corrects `opencode` to `opencode auth login`).
- **`multi-agent-shell/tests/test_motd.bats`** — assert `✗ agy`, the bare `run: agy` hint, and `✓ agy` when the cred file exists.
- **Docs** — README manifest/build-args/inventory examples, `docs/standards/multi-harness-shells.md`, `infra-shell/README.md`, root `README.md`.
- **CI** — both harness smoke loops in `.github/workflows/build.yaml` → `agy`.

### Artifacts
- **Spec:** `docs/superpowers/specs/2026-06-15-antigravity-cli-swap-design.md`
- **Plan:** `docs/superpowers/plans/2026-06-15-antigravity-cli-swap/` (5 phases, all complete)
- Also bundles the repo's first `.devcontainer/dev` profile (scaffolded for isolated runs).

### Deliberate deviations (documented in the spec)
- **D1** — `agy` removed from inventory `harnesses:`/`mcp-servers:`/`skills:` examples rather than renamed in (no self-update → not inventory-managed).
- **D2** — the historical `2026-05-12` spec and `2026-06-01` plan keep their gemini references (records of past work).
- **D3** — uses the real binary name `agy` everywhere, labelled "antigravity".

## Verification (local)
- `bats multi-agent-shell/tests/test_motd.bats` → **4/4 pass**
- `shellcheck` both MOTD scripts → **clean**
- functional gemini-CLI sweep → **none remain** (agy's `~/.gemini/antigravity-cli/` path legitimately contains "gemini")
- The Docker image build + `agy --version` smoke (as UID 1000) runs in **CI** — the devcontainer has no docker-in-docker, so CI is the build gate.

## Code review
A senior-reviewer pass returned **Ready to merge: Yes** (no Critical/Important). The three Minor findings — all on the Dockerfile install RUN — were fixed in `9fbc809`:
1. **Masked pipe failure** → switched from `curl | bash` to **download-then-run** so a curl/TLS failure fails the build directly.
2. **Partial R2 mitigation** → install now runs under a throwaway `$HOME` with `rm -rf` cleanup in the same layer, so the installer's shell-rc edits don't bloat root's home; the `--dir` simplification is now explained in a comment.
3. **Executability** → gated by `agy --version` at build + the CI smoke (`docker exec … agy --version` as UID 1000).

## Test Plan — post-merge, operator-driven

Run after merge + CI publishes the image. The agent runs what it can; the operator confirms the OAuth-gated steps.

1. **Image builds & agy present.** Confirm the CI `smoke-test-multi-agent-shell` (and `infra-shell`) jobs are green and that the smoke loop ran `agy --version` cleanly as UID 1000.
2. **Pull onto a real pod / local docker.** `docker run` (or exec into the deployed pod) and confirm `agy --version` and `command -v agy` → `/usr/local/bin/agy`.
3. **Interactive auth.** Run `agy` as the agent user; complete the headless OAuth (open the printed URL + one-time code on a laptop). Confirm login succeeds.
4. **Resolve R1 — observe the real credential path.** After login, inspect what landed: `ls -la ~/.gemini/antigravity-cli/` (expect `credentials.enc` + `settings.json`); also check for any OS-keyring artifact. **If the credential file path differs from `~/.gemini/antigravity-cli/credentials.enc`, update the two MOTD scripts + the README/standard manifest row** — they are coupled and the fix is one line each.
5. **MOTD reflects login.** Re-SSH (or re-source the profile.d drop-in) and confirm the auth table shows `✓ agy (~/.gemini/antigravity-cli/…)`.
6. **Persistence across restart.** Restart the container/pod; confirm `agy` still authenticated (credential survived on the PV). If not, document that agy requires re-auth per pod and note the keyring gap.

## Known risks (tracked in the spec)
- **R1** — credential path is best-effort (encrypted file vs OS-keyring); resolved by step 4 above.
- **R3** — no version pin; `agy` installs latest (matches the `claude` bootstrap). Accepted.
- **R4** — keyring persistence on headless containers unverified; covered by step 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
