### PR TITLE
fix(multi-agent-shell): correct agy credential path to antigravity-oauth-token (#119)

### DIFF
--- a/docs/standards/multi-harness-shells.md
+++ b/docs/standards/multi-harness-shells.md
@@ -59,7 +59,7 @@ $HOME/
 ├── .config/                  # XDG-Base-Dir per-harness configs that follow XDG
 │   ├── codex/                # auth.json, settings.json (TBD per upstream)
 │   └── opencode/             # (TBD per upstream)
-├── .gemini/antigravity-cli/  # agy (antigravity) settings.json + credentials.enc
+├── .gemini/antigravity-cli/  # agy (antigravity) settings.json + antigravity-oauth-token
 │                             #   (agy reuses the ~/.gemini dir; not XDG)
 ├── .claude/                  # claude-code; canonical layout — see below
 │   ├── credentials.json

--- a/infra-shell/rootfs/etc/profile.d/50-infra-shell-motd.sh
+++ b/infra-shell/rootfs/etc/profile.d/50-infra-shell-motd.sh
@@ -28,9 +28,10 @@ check() {
 }
 
 # agy (antigravity) auth is interactive on first run of `agy` (no `agy login`),
-# and its credential lands at ~/.gemini/antigravity-cli/credentials.enc
-# (best-effort path — confirmed post-merge per the spec's Test Plan).
+# and the OAuth token lands at ~/.gemini/antigravity-cli/antigravity-oauth-token
+# (confirmed 2026-06-15 by completing a real login in this image — a plain file,
+# not an OS-keyring entry, so this presence check works on a headless pod).
 check claude   .claude/credentials.json
 check codex    .config/codex/auth.json
-check agy      .gemini/antigravity-cli/credentials.enc   agy
-check opencode .local/share/opencode/auth.json           "opencode auth login"
+check agy      .gemini/antigravity-cli/antigravity-oauth-token   agy
+check opencode .local/share/opencode/auth.json                   "opencode auth login"

--- a/multi-agent-shell/README.md
+++ b/multi-agent-shell/README.md
@@ -30,7 +30,7 @@ exception — it has no self-update and is refreshed by image rebuild (see note)
 |---|---|---|---|---|
 | `claude` | `npm i -g @anthropic-ai/claude-code` (inherited from `agent-base`) | `claude login` | `~/.claude/credentials.json` | `claude update` |
 | `codex` | `npm i -g @openai/codex@${CODEX_VERSION}` | `codex login` | `~/.config/codex/auth.json` | `codex update` (or inventory `harnesses: codex: <ver>`) |
-| `agy` (antigravity) | `curl -fsSL …/install.sh \| bash -s -- --dir /usr/local/bin` (replaces gemini CLI) | `agy` (first run prompts the OAuth flow) | `~/.gemini/antigravity-cli/credentials.enc` *(best-effort — confirmed post-merge, see notes)* | **image rebuild** (no self-update; not inventory-managed) |
+| `agy` (antigravity) | `curl -fsSL …/install.sh \| bash -s -- --dir /usr/local/bin` (replaces gemini CLI) | `agy` (first run prompts the OAuth flow) | `~/.gemini/antigravity-cli/antigravity-oauth-token` | **image rebuild** (no self-update; not inventory-managed) |
 | `opencode` | `npm i -g opencode-ai@${OPENCODE_VERSION}` | `opencode auth login` | `~/.local/share/opencode/auth.json` | inventory `harnesses: opencode: <ver>` |
 
 Notes:
@@ -44,11 +44,12 @@ Notes:
 - **`agy` (antigravity) is a bootstrap-only harness.** It is
   binary-distributed (no npm), has no `agy update` subcommand and no
   version-pin mechanism, so it is updated by **image rebuild** and is
-  intentionally **absent from the inventory `harnesses:` key**. Its
-  credential path (`~/.gemini/antigravity-cli/credentials.enc`) is
-  best-effort and confirmed the first time an operator runs `agy` — if it
-  differs, fix the manifest row and both MOTD detectors together. Auth is
-  interactive OAuth on first run of `agy` (no `agy login`, no API key).
+  intentionally **absent from the inventory `harnesses:` key**. Its OAuth
+  token lands at `~/.gemini/antigravity-cli/antigravity-oauth-token`
+  (confirmed 2026-06-15 by completing a real login in this image — a plain
+  file, not an OS keyring, so the MOTD presence check works on a headless
+  pod). Auth is interactive OAuth on first run of `agy` (no `agy login`, no
+  API key).
 - **No `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` / etc. in the image or in
   Frank's `env:` block for this image.** The subscription-OAuth flows replace
   API-key auth per the standard.

--- a/multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh
+++ b/multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh
@@ -28,9 +28,10 @@ check() {
 }
 
 # agy (antigravity) auth is interactive on first run of `agy` (no `agy login`),
-# and its credential lands at ~/.gemini/antigravity-cli/credentials.enc
-# (best-effort path — confirmed post-merge per the spec's Test Plan).
+# and the OAuth token lands at ~/.gemini/antigravity-cli/antigravity-oauth-token
+# (confirmed 2026-06-15 by completing a real login in this image — a plain file,
+# not an OS-keyring entry, so this presence check works on a headless pod).
 check claude   .claude/credentials.json
 check codex    .config/codex/auth.json
-check agy      .gemini/antigravity-cli/credentials.enc   agy
-check opencode .local/share/opencode/auth.json           "opencode auth login"
+check agy      .gemini/antigravity-cli/antigravity-oauth-token   agy
+check opencode .local/share/opencode/auth.json                   "opencode auth login"

--- a/multi-agent-shell/tests/test_motd.bats
+++ b/multi-agent-shell/tests/test_motd.bats
@@ -38,7 +38,7 @@ teardown() { rm -rf "$TMP_HOME"; }
 
 @test "agy creds present: shows ✓ for agy" {
   mkdir -p "$TMP_HOME/.gemini/antigravity-cli"
-  echo 'enc' > "$TMP_HOME/.gemini/antigravity-cli/credentials.enc"
+  echo 'token' > "$TMP_HOME/.gemini/antigravity-cli/antigravity-oauth-token"
   run bash "$MOTD"
   [ "$status" -eq 0 ]
   [[ "$output" == *"✓ agy"* ]]


### PR DESCRIPTION
## What & why

Post-merge Test Plan follow-up for #119 (resolves **risk R1**). By completing a real `agy` OAuth in the published `multi-agent-shell:latest` image, the actual credential file is:

```
~/.gemini/antigravity-cli/antigravity-oauth-token
```

**not** `credentials.enc` (the filename earlier sourced from upstream web docs was wrong). Two findings:
- It's a **plain file on disk** (not an OS-keyring entry) → the MOTD presence-check works on a headless pod (also clears **risk R4**).
- With the wrong filename, the MOTD would never show `✓ agy`. Fixed.

## Changes (path corrected everywhere it appears)
- `multi-agent-shell` + `infra-shell` MOTD detectors (`check agy …`)
- `multi-agent-shell/tests/test_motd.bats` (the `✓ agy` fixture)
- `multi-agent-shell/README.md` manifest row + note (dropped the now-resolved "best-effort" hedge)
- `docs/standards/multi-harness-shells.md` `$HOME` layout

## Verification
- `bats tests/test_motd.bats` → **4/4 pass**
- `shellcheck` both MOTD scripts → **clean**
- **End-to-end:** ran the updated MOTD against the **real token file** the `agy` binary produced during the OAuth → renders `✓ agy (~/.gemini/antigravity-cli/antigravity-oauth-token)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)