### PR TITLE
fix(shells): npm-global presence check by name, not tagged spec

### DIFF
--- a/.devcontainer/dev/devcontainer.json
+++ b/.devcontainer/dev/devcontainer.json
@@ -1,0 +1,22 @@
+{
+  "name": "agent-images — dev",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {}
+  },
+  "postCreateCommand": "pipx install uv 2>/dev/null || true; uv tool install 'git+https://github.com/derio-net/super-fr#subdirectory=packages/fr' || true",
+  "workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
+  "workspaceFolder": "${localWorkspaceFolder}",
+  "runArgs": [
+    "--env-file",
+    "${localEnv:HOME}/.config/fr/secrets/agent-images/dev.env"
+  ],
+  "customizations": {
+    "fr": {
+      "profile": "dev",
+      "purpose": "Day-to-day dev on agent-images: edit Dockerfiles/docs/shell, run bats MOTD tests + pytest locally; GitHub ops on host"
+    }
+  }
+}

--- a/.devcontainer/fr-profiles.yaml
+++ b/.devcontainer/fr-profiles.yaml
@@ -1,0 +1,6 @@
+profiles:
+  dev:
+    purpose: 'Day-to-day dev on agent-images: edit Dockerfiles/docs/shell, run bats
+      MOTD tests + pytest locally; GitHub ops on host'
+    secrets: []
+default: dev

--- a/hermes-agent-shell/rootfs/usr/local/lib/hermes-agent-shell/install-inventory.sh
+++ b/hermes-agent-shell/rootfs/usr/local/lib/hermes-agent-shell/install-inventory.sh
@@ -122,7 +122,14 @@ fi
 if command -v npm >/dev/null 2>&1; then
     while IFS= read -r pkg; do
         [[ -z "$pkg" ]] && continue
-        if npm ls -g "$pkg" --depth=0 >/dev/null 2>&1; then
+        # Presence check by package NAME, not the full spec. A version/tag
+        # selector (e.g. `claude-flow@alpha`) makes `npm ls -g pkg@tag` exit
+        # non-zero even when the package IS installed, re-installing it every
+        # boot (and risking a stale-retired-dir ENOTEMPTY deadlock). Strip a
+        # trailing @selector, preserving a leading @scope (`@openai/codex`).
+        name="$pkg"
+        [[ "${pkg#@}" == *@* ]] && name="${pkg%@*}"
+        if npm ls -g "$name" --depth=0 >/dev/null 2>&1; then
             already+=1
             echo "= npm $pkg"
             continue

--- a/hermes-agent-shell/tests/test_install_inventory.bats
+++ b/hermes-agent-shell/tests/test_install_inventory.bats
@@ -16,6 +16,52 @@ setup() {
 
 teardown() { rm -rf "$TMP_HOME"; }
 
+# Put no-op stubs for the other section managers on PATH so a focused
+# npm-global test doesn't accrue spurious failures from `assert_manager`.
+stub_managers() {
+  mkdir -p "$HOME/.local/bin"
+  for m in mise pipx; do
+    printf '#!/bin/sh\nexit 0\n' > "$HOME/.local/bin/$m"
+    chmod +x "$HOME/.local/bin/$m"
+  done
+}
+
+@test "npm-global: a present package declared with a dist-tag is skipped, not reinstalled" {
+  # Regression for frank ruflo-shell ENOTEMPTY deadlock: the guard used to
+  # pass the full `pkg@tag` spec to `npm ls -g`, which never matches a
+  # dist-tag locally, so an already-installed `claude-flow@alpha` was
+  # reinstalled on every boot (and eventually deadlocked on a stale npm
+  # retired dir). The presence check must be by package NAME.
+  stub_managers
+  # Stub npm: claude-flow IS installed, but `npm ls -g claude-flow@alpha`
+  # (the tagged spec) does not resolve — exactly real npm behaviour.
+  export NPM_LOG="$HOME/npm-install.log"
+  cat > "$HOME/.local/bin/npm" <<STUB
+#!/bin/sh
+case "\$1" in
+  ls)
+    case "\$3" in
+      claude-flow)   exit 0 ;;   # present, queried by name
+      claude-flow@*) exit 1 ;;   # tagged spec never matches (the bug trigger)
+      *)             exit 1 ;;
+    esac ;;
+  install) echo "install \$*" >> "$NPM_LOG"; exit 0 ;;
+esac
+exit 1
+STUB
+  chmod +x "$HOME/.local/bin/npm"
+  cat > "$HOME/inventory.yaml" <<'YAML'
+npm-global:
+  - "claude-flow@alpha"
+YAML
+  run env PATH="$HOME/.local/bin:$PATH" INVENTORY="$HOME/inventory.yaml" bash "$INSTALLER"
+  [ "$status" -eq 0 ]
+  # Must be reported as already-present and NOT reinstalled.
+  [[ "$output" == *"= npm claude-flow@alpha"* ]]
+  [ ! -f "$NPM_LOG" ]
+  echo "$output" | grep -qE 'failed=0'
+}
+
 # Seed a local bare git repo with one commit on `main` and echo its path.
 # Used as a network-free skill source.
 seed_bare_repo() {

--- a/infra-shell/rootfs/usr/local/lib/infra-shell/install-inventory.sh
+++ b/infra-shell/rootfs/usr/local/lib/infra-shell/install-inventory.sh
@@ -122,7 +122,14 @@ fi
 if command -v npm >/dev/null 2>&1; then
     while IFS= read -r pkg; do
         [[ -z "$pkg" ]] && continue
-        if npm ls -g "$pkg" --depth=0 >/dev/null 2>&1; then
+        # Presence check by package NAME, not the full spec. A version/tag
+        # selector (e.g. `claude-flow@alpha`) makes `npm ls -g pkg@tag` exit
+        # non-zero even when the package IS installed, re-installing it every
+        # boot (and risking a stale-retired-dir ENOTEMPTY deadlock). Strip a
+        # trailing @selector, preserving a leading @scope (`@openai/codex`).
+        name="$pkg"
+        [[ "${pkg#@}" == *@* ]] && name="${pkg%@*}"
+        if npm ls -g "$name" --depth=0 >/dev/null 2>&1; then
             already+=1
             echo "= npm $pkg"
             continue

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/install-inventory.sh
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/install-inventory.sh
@@ -122,7 +122,14 @@ fi
 if command -v npm >/dev/null 2>&1; then
     while IFS= read -r pkg; do
         [[ -z "$pkg" ]] && continue
-        if npm ls -g "$pkg" --depth=0 >/dev/null 2>&1; then
+        # Presence check by package NAME, not the full spec. A version/tag
+        # selector (e.g. `claude-flow@alpha`) makes `npm ls -g pkg@tag` exit
+        # non-zero even when the package IS installed, re-installing it every
+        # boot (and risking a stale-retired-dir ENOTEMPTY deadlock). Strip a
+        # trailing @selector, preserving a leading @scope (`@openai/codex`).
+        name="$pkg"
+        [[ "${pkg#@}" == *@* ]] && name="${pkg%@*}"
+        if npm ls -g "$name" --depth=0 >/dev/null 2>&1; then
             already+=1
             echo "= npm $pkg"
             continue

--- a/paperclip-shell/rootfs/usr/local/lib/paperclip-shell/install-inventory.sh
+++ b/paperclip-shell/rootfs/usr/local/lib/paperclip-shell/install-inventory.sh
@@ -114,7 +114,14 @@ fi
 if command -v npm >/dev/null 2>&1; then
     while IFS= read -r pkg; do
         [[ -z "$pkg" ]] && continue
-        if npm ls -g "$pkg" --depth=0 >/dev/null 2>&1; then
+        # Presence check by package NAME, not the full spec. A version/tag
+        # selector (e.g. `claude-flow@alpha`) makes `npm ls -g pkg@tag` exit
+        # non-zero even when the package IS installed, re-installing it every
+        # boot (and risking a stale-retired-dir ENOTEMPTY deadlock). Strip a
+        # trailing @selector, preserving a leading @scope (`@openai/codex`).
+        name="$pkg"
+        [[ "${pkg#@}" == *@* ]] && name="${pkg%@*}"
+        if npm ls -g "$name" --depth=0 >/dev/null 2>&1; then
             already+=1
             echo "= npm $pkg"
             continue

--- a/ruflo-shell/rootfs/usr/local/lib/ruflo-shell/install-inventory.sh
+++ b/ruflo-shell/rootfs/usr/local/lib/ruflo-shell/install-inventory.sh
@@ -106,7 +106,14 @@ fi
 if command -v npm >/dev/null 2>&1; then
     while IFS= read -r pkg; do
         [[ -z "$pkg" ]] && continue
-        if npm ls -g "$pkg" --depth=0 >/dev/null 2>&1; then
+        # Presence check by package NAME, not the full spec. A version/tag
+        # selector (e.g. `claude-flow@alpha`) makes `npm ls -g pkg@tag` exit
+        # non-zero even when the package IS installed, re-installing it every
+        # boot (and risking a stale-retired-dir ENOTEMPTY deadlock). Strip a
+        # trailing @selector, preserving a leading @scope (`@openai/codex`).
+        name="$pkg"
+        [[ "${pkg#@}" == *@* ]] && name="${pkg%@*}"
+        if npm ls -g "$name" --depth=0 >/dev/null 2>&1; then
             already+=1
             echo "= npm $pkg"
             continue


### PR DESCRIPTION
## Root cause

The `install-inventory.sh` reconciler guards each npm-global package with `npm ls -g "$pkg"`, passing the **full spec** including any version/tag selector. For a dist-tagged entry like `claude-flow@alpha`:

```
npm ls -g claude-flow@alpha   → exit 1   (dist-tag not resolvable locally; guard fails)
npm ls -g claude-flow         → exit 0   (present, by name)
npm ls -g @openai/codex       → exit 0   (scoped name, no version selector — fine)
```

So `claude-flow` was reinstalled on **every boot**. On a persistent home PVC that compounded into a hard failure: an interrupted reinstall left npm's *deterministically-named* retired dir (`.claude-flow-<hash>`) behind, and every later install collided with it → **`ENOTEMPTY`** → permanent boot-time failure, alerting via Telegram since **Jun 6** on `ruflo-shell`.

Only `ruflo`'s inventory uses a version selector, so it's the only shell that triggered the deadlock — but all five images carry the identical guard.

## Fix

Derive the bare package **name** (strip a trailing `@version`/`@tag`, preserving a leading `@scope`) for the `npm ls -g` presence check; still install the full spec. This realizes the documented *"skip if present at any version"* intent.

```bash
name="$pkg"
[[ "${pkg#@}" == *@* ]] && name="${pkg%@*}"
if npm ls -g "$name" --depth=0 >/dev/null 2>&1; then ...
```

Verified across spec shapes: `claude-flow@alpha`→`claude-flow`, `@openai/codex`→`@openai/codex`, `@scope/pkg@1.2.3`→`@scope/pkg`, `ripgrep@13`→`ripgrep`.

Applied to all 5 shell images (ruflo, hermes, multi-agent, infra, paperclip).

## Test

Adds a bats regression to `hermes-agent-shell/tests/test_install_inventory.bats` (`npm-global: a present package declared with a dist-tag is skipped, not reinstalled`). Red→green verified locally:
- unfixed → `not ok` (package reinstalled)
- fixed → `ok` (skipped)

Note: that bats suite parses YAML via the image's `/usr/bin/python3` and overrides `$HOME` in setup — needs pyyaml available HOME-independently (CI: `python3-yaml`; locally run with `PYTHONPATH` to a site that has it). Pre-existing dependency, shared by the whole suite; flagged here for whoever wires these into CI.

## Live remediation (already done, out of band)

The orphaned `.claude-flow-ufsFGjVA` retired dir was removed from the live ruflo-shell PVC and the reconcile re-run (`failed=0`, MOTD cleared). This PR prevents recurrence. The ruflo image still needs a rebuild + bump in `frank` to pick up the durable guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)