### PR TITLE
docs: plan — bake agent-session interface into multi-agent-shell (Part A, gating)

### DIFF
--- a/docs/superpowers/plans/2026-06-15-agent-session-extract/01.yaml
+++ b/docs/superpowers/plans/2026-06-15-agent-session-extract/01.yaml
@@ -1,0 +1,78 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Bake agent-session into the image + genericize env (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Pytest port (modeled on kali/tests), reading the baked path — RED
+  steps:
+  - id: P1.T1.S1
+    text: |
+      The repo already has pytest (`pyproject.toml` + `kali/tests/test_*.py`; the `dev` profile
+      runs "pytest locally"); `multi-agent-shell/tests/` is bats-only today. Add
+      `multi-agent-shell/tests/test_agent_session.py` modeled on `kali/tests/` (mirror its
+      conftest/invocation style). Port the tmux-mock cases from frank
+      `scripts/tests/test_agent_session_driver.py` — the FAKE_TMUX PATH-injection harness,
+      bracketed-paste submit, per-turn nonce-file read, turn counter, timeout, and the HTTP
+      `serve` test — but point the driver-source fixture at the BAKED file
+      `multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session` (not the n8n
+      ConfigMap). Run `uv run --with pytest pytest multi-agent-shell/tests/test_agent_session.py
+      -q`. Expected: FAIL/colluction-error (RED — the baked file does not exist yet).
+  - id: P1.T1.S2
+    text: |
+      Wire pytest for multi-agent-shell into CI the same way kali's python tests run (check
+      `.github/workflows/` for the existing pytest invocation; extend its path filter / matrix
+      to include `multi-agent-shell/tests/`). No new test framework — extend the existing one.
+- number: 2
+  title: Move + genericize the driver into rootfs — GREEN
+  steps:
+  - id: P1.T2.S1
+    text: |
+      Extract the driver Python from frank `apps/n8n-01/manifests/agent-session-driver.yaml`
+      (`data["agent-session"]`) into
+      `multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session` as a plain
+      executable script (`#!/usr/bin/env python3`, stdlib-only — verified: fcntl/json/os/
+      secrets/subprocess/sys/time, runs on the image's python3).
+  - id: P1.T2.S2
+    text: |
+      Genericize the env vars to `AGENT_SESSION_*` with deprecated-alias fallback — each
+      `os.environ.get` reads the new name, falling back to the `STOA_*` source var if unset:
+      `AGENT_SESSION_TURN_DIR←STOA_TURN_DIR`, `_OUT_DIR←STOA_OUT_DIR`, `_PORT←STOA_SESSION_PORT`,
+      `_POLL_S←STOA_POLL_S`, `_SETTLE_S←STOA_SETTLE_S`, `_NAME←STOA_SESSION_NAME`. Add an alias
+      test asserting a `STOA_*`-only env still drives the same behaviour.
+  - id: P1.T2.S3
+    text: |
+      In `multi-agent-shell/Dockerfile`, `chmod +x` the baked driver and symlink it onto PATH
+      (mirror the existing `ln -sf … /usr/local/bin/multi-agent-shell-reconcile` line):
+      `ln -sf /usr/local/lib/multi-agent-shell/agent-session /usr/local/bin/agent-session`.
+      Run `uv run --with pytest pytest multi-agent-shell/tests/test_agent_session.py -q`.
+      Expected: GREEN.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S3:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-agent-session-extract/02.yaml
+++ b/docs/superpowers/plans/2026-06-15-agent-session-extract/02.yaml
@@ -1,0 +1,39 @@
+schema_version: 2
+phase:
+  number: 2
+  title: Configurable per-agent launch profile (TDD)
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Dispatch tests then generalize ensure_session
+  steps:
+  - id: P2.T1.S1
+    text: |
+      Add per-agent dispatch tests (none exist — the driver hardcodes claude): assert
+      `ensure_session` launches the configured agent's CLI — `claude` (default) →
+      `claude --permission-mode auto`; `antigravity` → the `agy` launch profile; `codex` →
+      the `codex` launch profile (assert via the FAKE_TMUX recorded new-session command). RED.
+  - id: P2.T1.S2
+    text: |
+      Generalize `ensure_session` with a per-agent launch-profile table keyed on the `agent`
+      field (already plumbed through the API), default `claude`. Each profile names the launch
+      command + its auto-approve flag + (where the harness differs) how it writes the per-turn
+      output file. claude is the fully-wired+verified default; antigravity/codex profiles land
+      but full verification of each is a follow-up (note in README). Run. Expected: GREEN.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-agent-session-extract/03.yaml
+++ b/docs/superpowers/plans/2026-06-15-agent-session-extract/03.yaml
@@ -1,0 +1,42 @@
+schema_version: 2
+phase:
+  number: 3
+  title: Baked s6 longrun (AGENT_SESSION_SERVE gate)
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: s6 service mirroring the sshd precedent
+  steps:
+  - id: P3.T1.S1
+    text: |
+      Add `multi-agent-shell/rootfs/etc/services.d/agent-session-server/run` mirroring the
+      existing sshd service EXACTLY (`#!/command/with-contenv bash`, a sibling `finish`
+      script). The run script: if `[ "${AGENT_SESSION_SERVE:-0}" = 1 ]`, pre-trust the
+      workspace (the bootstrap's `~/.claude.json hasTrustDialogAccepted` step) then
+      `exec s6-setuidgid "$AGENT_USER" agent-session serve`; else `exec sleep infinity` (the
+      service exists but idles when not opted in — default off). s6 supervises restarts, so NO
+      `while/sleep` loop.
+  - id: P3.T1.S2
+    text: |
+      In the Dockerfile, add `/etc/services.d/agent-session-server/run` (+ `finish`) to the
+      existing `chmod +x` list (alongside the sshd run script). Add a bats assertion (extend
+      `multi-agent-shell/tests/test_install_inventory.bats` or a new `.bats`) that the run
+      script exists, is executable, and is gated on `AGENT_SESSION_SERVE`. Run the bats suite.
+      Expected: PASS.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-agent-session-extract/04.yaml
+++ b/docs/superpowers/plans/2026-06-15-agent-session-extract/04.yaml
@@ -1,0 +1,54 @@
+schema_version: 2
+phase:
+  number: 4
+  title: README contract + branch image build
+  tag: agentic
+  depends_on:
+  - 1
+  - 2
+  - 3
+  tracking_issue: null
+tasks:
+- number: 1
+  title: Document the contract
+  steps:
+  - id: P4.T1.S1
+    text: |
+      Document the `agent-session` contract in `multi-agent-shell/README.md`: the
+      `serve`/`send` API (`POST /session/send {session_id, agent, message, timeout_s?} →
+      {…, turn, payload}`, `GET /healthz`), the `AGENT_SESSION_SERVE=1` opt-in, the
+      `AGENT_SESSION_*` env vars (+ the deprecated `STOA_*` aliases), and the per-agent profile
+      table (claude default / antigravity / codex, with the verification-status note).
+- number: 2
+  title: Build + verify the branch-tagged image
+  steps:
+  - id: P4.T2.S1
+    text: |
+      Trigger the branch build: `gh workflow run build.yaml --ref feat/agent-session-extract`
+      (agent-images CI builds on push:main, so a branch needs the manual dispatch). Watch it:
+      `gh run watch <id>`. **Confirm the workflow publishes a BRANCH-tagged multi-agent-shell
+      image** (not a main tag) — that tag is the gate frank's two plans consume. Record the tag.
+  - id: P4.T2.S2
+    text: |
+      Smoke the built image: `agent-session` is on PATH and `agent-session serve` binds, e.g.
+      `docker run --rm <branch-image> bash -lc 'command -v agent-session && timeout 2
+      agent-session serve; echo exit=$?'` (a clean bind then timeout is success). Expected:
+      agent-session present + serve binds.
+state:
+  steps:
+    P4.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P4.T2.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-agent-session-extract/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-15-agent-session-extract/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-15-agent-session-extract
+spec: derio-net/frank:docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md
+target_repo: derio-net/agent-images
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-06-15'

--- a/docs/superpowers/plans/2026-06-15-agent-session-extract/_prose.md
+++ b/docs/superpowers/plans/2026-06-15-agent-session-extract/_prose.md
@@ -1,0 +1,41 @@
+# agent-session extraction → multi-agent-shell image (agent-images — Plan A)
+
+**Status:** Planned
+**Spec:** `derio-net/frank:docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md` (Part A)
+**Repo:** derio-net/agent-images
+
+## Why
+
+The persistent-agent driver (`agent-session`) is currently a ConfigMap copy-pasted inside frank's
+`apps/n8n-01/`. A second consumer (the alert-agent) and a third are coming. This bakes it **into the
+multi-agent-shell image** (beside `notify-telegram.sh`) as a versioned, reusable contract every
+consumer shares — and is the **gating deliverable**: frank's two plans consume the resulting image tag.
+
+## What it produces
+
+A new `multi-agent-shell` image tag carrying:
+- `/usr/local/lib/multi-agent-shell/agent-session` (+ `/usr/local/bin` symlink) — the driver,
+  stdlib-only, genericized `STOA_*`→`AGENT_SESSION_*` (with deprecated aliases).
+- A **configurable per-agent launch profile** (claude default; antigravity/codex selectable) — the
+  `agent` field is already in the API; `ensure_session` is generalized off its hardcoded claude.
+- A baked **s6 longrun** (`/etc/services.d/agent-session-server/run`, sshd precedent) that serves the
+  `agent-session` HTTP endpoint when `AGENT_SESSION_SERVE=1` (default off; consumers opt in) — no
+  postStart hook needed by consumers.
+- The contract documented in the image README; pytest tests (modeled on the existing `kali/tests/`
+  pytest, since `multi-agent-shell/tests/` is bats-only) + per-agent-dispatch + alias coverage.
+
+## Phase map
+
+1. **Bake + genericize (TDD)** — pytest port reading the baked path RED; move driver into rootfs +
+   `AGENT_SESSION_*` aliases + Dockerfile symlink GREEN.
+2. **Per-agent launch profile (TDD)** — dispatch tests RED; generalize `ensure_session` GREEN.
+3. **s6 longrun** — `AGENT_SESSION_SERVE`-gated service mirroring sshd; bats smoke.
+4. **README + branch image** — document the contract; `gh workflow run build.yaml --ref` and
+   **confirm a branch-tagged image publishes** (the tag frank consumes).
+
+## Notes
+
+- Cross-repo spec ref (`derio-net/frank:…`) — `fr plan self-review` may warn it doesn't resolve in
+  this repo; that's expected for a cross-repo spec, not an error.
+- agent-images CI builds on `push:main` (paths-ignore `docs/**`); a branch is validated via the
+  manual `workflow_dispatch` (`--ref`). Confirm the dispatch publishes a branch tag, not a main tag.


### PR DESCRIPTION
## Plan A (gating) — bake the `agent-session` interface into multi-agent-shell

Planning doc for extracting the persistent-agent driver out of frank's `apps/n8n-01` ConfigMap and **baking it into the `multi-agent-shell` image** as a reusable, versioned contract. **Docs only;** execution dispatched after merge.

- **Plan:** `docs/superpowers/plans/2026-06-15-agent-session-extract/` (4 phases): bake driver into rootfs + genericize `STOA_*→AGENT_SESSION_*` (aliases); configurable per-agent launch profile (claude default / antigravity / codex); baked s6 longrun gated on `AGENT_SESSION_SERVE=1`; pytest port (modeled on `kali/tests/`) + README contract + branch image build.
- **Spec (cross-repo):** `derio-net/frank:docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md`.

**Gating deliverable** — frank's two plans (alert-agent + n8n migration) consume the resulting `multi-agent-shell` image tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
