### PR TITLE
feat(multi-agent-shell): bake the agent-session interface into the image (Part A, gating)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -641,6 +641,17 @@ jobs:
             echo "::endgroup::"
           done
 
+          # agent-session contract (Part A): the baked driver is on PATH, the
+          # s6 longrun is present + gated on AGENT_SESSION_SERVE, and
+          # `agent-session serve` binds 127.0.0.1 cleanly. A clean bind keeps
+          # serving until `timeout` kills it at 2s (rc 124 = success); a bind
+          # failure raises and exits non-124 fast.
+          docker exec mas-smoke command -v agent-session
+          docker exec mas-smoke test -x /etc/services.d/agent-session-server/run
+          docker exec mas-smoke grep -q AGENT_SESSION_SERVE /etc/services.d/agent-session-server/run
+          docker exec mas-smoke bash -lc 'timeout 2 agent-session serve; rc=$?; [ "$rc" = 124 ] || { echo "✗ agent-session serve did not bind+stay up (rc=$rc)"; exit 1; }'
+          echo "✓ agent-session on PATH, s6 service gated, serve binds"
+
           # Inventory installer reconciles cleanly against the empty inventory
           # and writes a MOTD drop-in. failed=0 proves no section errored.
           docker exec mas-smoke /usr/local/bin/multi-agent-shell-reconcile

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -646,7 +646,7 @@ jobs:
           # `agent-session serve` binds 127.0.0.1 cleanly. A clean bind keeps
           # serving until `timeout` kills it at 2s (rc 124 = success); a bind
           # failure raises and exits non-124 fast.
-          docker exec mas-smoke command -v agent-session
+          docker exec mas-smoke bash -lc 'command -v agent-session'
           docker exec mas-smoke test -x /etc/services.d/agent-session-server/run
           docker exec mas-smoke grep -q AGENT_SESSION_SERVE /etc/services.d/agent-session-server/run
           docker exec mas-smoke bash -lc 'timeout 2 agent-session serve; rc=$?; [ "$rc" = 124 ] || { echo "✗ agent-session serve did not bind+stay up (rc=$rc)"; exit 1; }'
@@ -918,6 +918,12 @@ jobs:
       - smoke-test-hermes-agent-shell
       - smoke-test-infra-shell
     runs-on: ubuntu-latest
+    # Only notify frank when the MAIN image tag actually moved: a push to main
+    # or the vk repository_dispatch rebuild. A manual workflow_dispatch (used to
+    # validate a feature BRANCH image before merge) must NOT bump frank — its
+    # handler sed-pins frank's prod manifests to the dispatched SHA and opens a
+    # PR, which would pin production to an unmerged branch build.
+    if: github.event_name == 'push' || github.event_name == 'repository_dispatch'
     permissions: {}
     steps:
       - env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,6 +43,25 @@ jobs:
         working-directory: kali
         run: uv run pytest tests/ -v
 
+  # The baked agent-session driver (multi-agent-shell/rootfs/.../agent-session)
+  # is exercised by a tmux-mock pytest suite ported from frank. Mirrors the
+  # test-kali Python step; gates the frank dispatch alongside test-kali.
+  test-multi-agent-shell:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+      - name: Sync Python deps
+        run: uv sync --group dev
+      - name: Run multi-agent-shell Python tests
+        working-directory: multi-agent-shell
+        run: uv run pytest tests/ -v
+
   build-base:
     runs-on: ubuntu-latest
     outputs:
@@ -877,6 +896,7 @@ jobs:
   dispatch-frank:
     needs:
       - test-kali
+      - test-multi-agent-shell
       - build-children
       - smoke-test-vk-local
       - smoke-test-secure-agent-kali

--- a/docs/superpowers/plans/2026-06-15-agent-session-extract/01.yaml
+++ b/docs/superpowers/plans/2026-06-15-agent-session-extract/01.yaml
@@ -53,26 +53,26 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:30:33+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:30:35+00:00'
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:30:36+00:00'
       note: null
     P1.T2.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:30:38+00:00'
       note: null
     P1.T2.S3:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:30:39+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-15T21:30:41+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-agent-session-extract/02.yaml
+++ b/docs/superpowers/plans/2026-06-15-agent-session-extract/02.yaml
@@ -26,14 +26,14 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:33:42+00:00'
       note: null
     P2.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:33:44+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-15T21:33:45+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-agent-session-extract/03.yaml
+++ b/docs/superpowers/plans/2026-06-15-agent-session-extract/03.yaml
@@ -29,14 +29,18 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:37:26+00:00'
       note: null
     P3.T1.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-15T21:37:28+00:00'
+      note: 'Service assertion done in pytest (test_s6_service_*) + a CI runtime serve-binds
+        smoke in smoke-test-multi-agent-shell, not bats: bats is wired into neither
+        CI nor the dev container, so it cannot be run green; pytest is the CI-executed
+        surface and the spec mandates the CI serve-binds smoke. run script execs directly
+        (no s6-setuidgid) to mirror sshd under cap-drop=ALL.'
   completion:
-    at: null
+    at: '2026-06-15T21:37:30+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-agent-session-extract/04.yaml
+++ b/docs/superpowers/plans/2026-06-15-agent-session-extract/04.yaml
@@ -41,14 +41,20 @@ state:
       ticked_at: '2026-06-15T21:38:46+00:00'
       note: null
     P4.T2.S1:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-15T22:25:49+00:00'
+      note: Branch build run 27579103277 green. build-multi-agent-shell published
+        ghcr.io/derio-net/multi-agent-shell:e24446ea0758e97b3f0eac736735b0863a485d45
+        (github.sha = branch HEAD; frank's bump handler pins by SHA, so this SHA tag
+        is the consumable gate — not a branch-name tag). dispatch-frank skipped via
+        new event guard so the branch build never bumps frank prod.
     P4.T2.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: x
+      ticked_at: '2026-06-15T22:25:50+00:00'
+      note: 'serve-binds smoke green in CI (smoke-test-multi-agent-shell) AND locally
+        against the published image: agent-session on PATH at /usr/local/bin/agent-session,
+        serve bound + stayed up (rc=124).'
   completion:
-    at: null
+    at: '2026-06-15T22:25:52+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-15-agent-session-extract/04.yaml
+++ b/docs/superpowers/plans/2026-06-15-agent-session-extract/04.yaml
@@ -37,8 +37,8 @@ tasks:
 state:
   steps:
     P4.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-15T21:38:46+00:00'
       note: null
     P4.T2.S1:
       state: ' '

--- a/multi-agent-shell/Dockerfile
+++ b/multi-agent-shell/Dockerfile
@@ -63,6 +63,8 @@ RUN install -d -o ${AGENT_UID} -g ${AGENT_GID} -m 0755 \
       /var/lib/multi-agent-shell \
  && chmod +x \
       /etc/cont-init.d/40-shell-inventory \
+      /etc/services.d/agent-session-server/run \
+      /etc/services.d/agent-session-server/finish \
       /etc/profile.d/40-multi-agent-shell-paths.sh \
       /etc/profile.d/45-multi-agent-shell-reconcile-motd.sh \
       /etc/profile.d/50-multi-agent-shell-motd.sh \

--- a/multi-agent-shell/Dockerfile
+++ b/multi-agent-shell/Dockerfile
@@ -70,9 +70,12 @@ RUN install -d -o ${AGENT_UID} -g ${AGENT_GID} -m 0755 \
       /usr/local/lib/multi-agent-shell/install-inventory.sh \
       /usr/local/lib/multi-agent-shell/notify-telegram.sh \
       /usr/local/lib/multi-agent-shell/lib.sh \
+      /usr/local/lib/multi-agent-shell/agent-session \
  && /usr/local/lib/multi-agent-shell/install-base-runtimes.sh \
  && ln -sf /usr/local/lib/multi-agent-shell/install-inventory.sh \
-           /usr/local/bin/multi-agent-shell-reconcile
+           /usr/local/bin/multi-agent-shell-reconcile \
+ && ln -sf /usr/local/lib/multi-agent-shell/agent-session \
+           /usr/local/bin/agent-session
 
 USER ${AGENT_USER}
 WORKDIR ${AGENT_HOME}

--- a/multi-agent-shell/README.md
+++ b/multi-agent-shell/README.md
@@ -199,6 +199,73 @@ Failures fire to `@agent_zero_cc_bot` via `FRANK_C2_TELEGRAM_BOT_TOKEN` +
 `FRANK_C2_TELEGRAM_CHAT_ID` env vars (same Infisical-backed Secret used by
 the other shells). Fail-silent if either env is empty.
 
+## agent-session — persistent-agent interface
+
+`agent-session` (baked at
+`/usr/local/lib/multi-agent-shell/agent-session`, symlinked onto `PATH`)
+drives a **running** interactive agent session over HTTP — never `claude -p`.
+It is the reusable, versioned contract every consumer shares (n8n, the
+alert-agent, …); stdlib-only Python, no extra deps.
+
+How it drives the session: submit the message via tmux **bracketed paste**
+(multi-line safe), then read the reply from a **per-turn nonce file** the
+agent is asked to write (the file appearing + parsing IS the completion
+signal — robust to TUI soft-wrapping). A locked, atomic per-session turn
+counter is the continuity evidence.
+
+### Serving (opt-in)
+
+A baked **s6 longrun** (`/etc/services.d/agent-session-server`) serves the
+endpoint **only when `AGENT_SESSION_SERVE=1`** (default off — a plain
+interactive shell is unaffected; consumers opt in). s6 supervises restarts;
+there is no postStart hook or restart loop to wire up. `agent-session send
+'<json>'` runs the same core as a CLI for debug/manual use.
+
+### API
+
+```
+POST /session/send   {session_id, agent, message, timeout_s?}
+                  -> {session_id, agent, status, turn, payload}
+GET  /healthz        -> 200 {"status":"ok"}
+```
+
+Bound on `127.0.0.1:${AGENT_SESSION_PORT:-8765}` (pod-local; same netns as the
+consumer — never the wildcard address). `status` is `ok` or `timeout` (the
+per-turn file never appeared); on timeout `payload` is `null`, so a consumer
+can fall back to a deterministic render.
+
+### Environment
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `AGENT_SESSION_SERVE` | `0` | `1` starts the baked serve longrun |
+| `AGENT_SESSION_PORT` | `8765` | loopback port the HTTP server binds |
+| `AGENT_SESSION_TURN_DIR` | `~/.agent-session` | per-session turn counters |
+| `AGENT_SESSION_OUT_DIR` | `~/.agent-session/out` | per-turn output files |
+| `AGENT_SESSION_POLL_S` | `2` | output-file poll interval (s) |
+| `AGENT_SESSION_SETTLE_S` | `0.5` | paste→Enter settle delay (s) |
+
+Each `AGENT_SESSION_*` var falls back to the legacy `STOA_*` name
+(`STOA_TURN_DIR`, `STOA_OUT_DIR`, `STOA_SESSION_PORT`, `STOA_POLL_S`,
+`STOA_SETTLE_S`) when unset — a **deprecated alias kept for one migration
+cycle** so a consumer mid-migration never breaks.
+
+### Per-agent launch profiles
+
+`ensure_session` auto-creates the session by launching the configured `agent`
+(the `agent` field in the request), defaulting to `claude`:
+
+| `agent` | Launch command | Status |
+|---------|----------------|--------|
+| `claude` (default) | `claude --permission-mode auto` | wired + verified |
+| `codex` | `codex --full-auto` | config-selectable — **auto-approve invocation not yet verified live (follow-up)** |
+| `antigravity` | `agy --yolo` | config-selectable — **auto-approve invocation not yet verified live (follow-up)** |
+
+An unrecognized `agent` falls back to the verified `claude` profile. The auto-
+approve flag lets the session write its per-turn output file without a prompt
+(short of a full permissions bypass). Correcting a `codex`/`antigravity` flag
+is a one-line edit to the `LAUNCH_PROFILES` table in the driver.
+
 ## Plan / spec
 
 - Standard: [`docs/standards/multi-harness-shells.md`](../docs/standards/multi-harness-shells.md)

--- a/multi-agent-shell/rootfs/etc/services.d/agent-session-server/finish
+++ b/multi-agent-shell/rootfs/etc/services.d/agent-session-server/finish
@@ -1,0 +1,3 @@
+#!/command/with-contenv bash
+echo "[s6] agent-session-server exited code=$1 (signal=$2)"
+exit 0

--- a/multi-agent-shell/rootfs/etc/services.d/agent-session-server/run
+++ b/multi-agent-shell/rootfs/etc/services.d/agent-session-server/run
@@ -1,0 +1,24 @@
+#!/command/with-contenv bash
+# Baked agent-session HTTP server (POST 127.0.0.1/session/send). Mirrors the
+# sshd s6 service precedent: `#!/command/with-contenv bash`, a sibling finish
+# script, and exec'd directly — s6 supervises restarts, so there is NO
+# while/sleep loop (the n8n bootstrap needed one only inside a tmux pane).
+#
+# Direct exec (no s6-setuidgid): under the live K8s securityContext
+# (runAsUser:1000, cap-drop=ALL, no-new-privileges) s6-overlay already runs as
+# the agent UID, and s6-setuidgid would call setgroups() — needing CAP_SETGID,
+# which is dropped — so it cannot be used here. The sshd run script execs
+# directly for the same reason; mirror it.
+#
+# Gated on AGENT_SESSION_SERVE=1 — DEFAULT OFF. A plain interactive shell is
+# unaffected; consumers (n8n, the alert-agent) opt in by setting the env var.
+if [ "${AGENT_SESSION_SERVE:-0}" = 1 ]; then
+  # Pre-trust the workspace in ~/.claude.json so claude never blocks on the
+  # folder-trust gate before the session is driven (matches the driver's
+  # pretrust(); belt-and-suspenders here, before serve binds).
+  python3 -c 'import json,os; p=os.path.expanduser("~/.claude.json"); d=(json.load(open(p)) if os.path.exists(p) else {}); d.setdefault("projects",{}).setdefault(os.path.expanduser("~"),{})["hasTrustDialogAccepted"]=True; json.dump(d,open(p,"w"))' 2>/dev/null || true
+  exec agent-session serve
+fi
+# Not opted in: idle so s6 treats the service as up without flapping (a bare
+# exit would make s6 restart-loop the service).
+exec sleep infinity

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""agent-session — drive a persistent agent tmux session (send/receive).
+
+A reusable, image-baked interface (beside notify-telegram.sh). Never `claude -p`:
+submit via bracketed paste; receive the structured payload from a per-turn file
+the agent writes (the file appearing + parsing is the completion signal). Emits
+{session_id, agent, status, turn, payload} with a locked, atomic per-session turn
+counter (continuity evidence). `serve` runs the HTTP endpoint consumers call;
+`send` is the same core as a CLI.
+
+Env is `AGENT_SESSION_*`; the legacy `STOA_*` names are read as deprecated
+aliases (one migration cycle) when the new var is unset. Stdlib-only so it runs
+on the image's python3 with no extra deps.
+"""
+import fcntl
+import json
+import os
+import secrets
+import subprocess
+import sys
+import time
+
+
+def _env(new, old, default):
+    # Read the genericized AGENT_SESSION_* var, falling back to the deprecated
+    # STOA_* alias if unset, then the default. Keeps a consumer mid-migration
+    # working for one cycle without setting the new name.
+    val = os.environ.get(new)
+    if val is None:
+        val = os.environ.get(old)
+    return val if val is not None else default
+
+
+HOME = os.path.expanduser("~")
+TURN_DIR = _env("AGENT_SESSION_TURN_DIR", "STOA_TURN_DIR", os.path.join(HOME, ".agent-session"))
+OUT_DIR = _env("AGENT_SESSION_OUT_DIR", "STOA_OUT_DIR", os.path.join(HOME, ".agent-session", "out"))
+POLL_S = float(_env("AGENT_SESSION_POLL_S", "STOA_POLL_S", "2"))
+# Delay between pasting the message and pressing Enter — the TUI needs to
+# render the paste before the submit, or the Enter is dropped.
+SETTLE_S = float(_env("AGENT_SESSION_SETTLE_S", "STOA_SETTLE_S", "0.5"))
+PORT = int(_env("AGENT_SESSION_PORT", "STOA_SESSION_PORT", "8765"))
+
+
+def tmux(*args, stdin=None):
+    return subprocess.run(["tmux", *args], input=stdin, capture_output=True, text=True)
+
+
+def pretrust():
+    # Mark the workspace trusted in ~/.claude.json so claude never blocks on
+    # the folder-trust gate (an abrupt kill never flushes an acceptance, so
+    # it would otherwise re-appear and hang the session). Idempotent.
+    path = os.path.expanduser("~/.claude.json")
+    try:
+        d = json.load(open(path)) if os.path.exists(path) else {}
+    except (OSError, json.JSONDecodeError):
+        d = {}
+    home = os.path.expanduser("~")
+    d.setdefault("projects", {}).setdefault(home, {})["hasTrustDialogAccepted"] = True
+    try:
+        with open(path, "w") as fh:
+            json.dump(d, fh)
+    except OSError:
+        pass
+
+
+def ensure_session(session_id, agent="claude"):
+    # Auto-create the session (interactive agent CLI, never -p) if absent, so
+    # the caller's session_id drives whatever it names. Unauthenticated until
+    # the operator logs the agent in. `claude --permission-mode auto` lets the
+    # session auto-approve safe operations (incl. writing its per-turn output
+    # file) without a prompt, short of a full permissions bypass. Concurrency-
+    # safe: a racing dup new-session errors harmlessly.
+    if tmux("has-session", "-t", session_id).returncode != 0:
+        pretrust()
+        tmux("new-session", "-d", "-s", session_id,
+             "claude --permission-mode auto")
+
+
+def submit(session_id, text):
+    # Bracketed paste so a multi-line message lands without premature submit,
+    # then a SEPARATE Enter after the paste renders.
+    tmux("load-buffer", "-b", "agent-session-msg", "-", stdin=text)
+    tmux("paste-buffer", "-d", "-p", "-b", "agent-session-msg", "-t", session_id)
+    time.sleep(SETTLE_S)
+    tmux("send-keys", "-t", session_id, "Enter")
+
+
+def read_turn(session_id):
+    path = os.path.join(TURN_DIR, session_id + ".turn")
+    try:
+        with open(path) as fh:
+            return int(fh.read().strip() or 0)
+    except (OSError, ValueError):
+        return 0
+
+
+def bump_turn(session_id):
+    # Atomic + locked: the turn counter is the contract's continuity evidence.
+    os.makedirs(TURN_DIR, exist_ok=True)
+    path = os.path.join(TURN_DIR, session_id + ".turn")
+    with open(path + ".lock", "w") as lk:
+        fcntl.flock(lk, fcntl.LOCK_EX)
+        turn = read_turn(session_id) + 1
+        tmp = path + ".tmp"
+        with open(tmp, "w") as fh:
+            fh.write(str(turn))
+        os.replace(tmp, path)
+    return turn
+
+
+def response(session_id, agent, status, turn, payload):
+    return {"session_id": session_id, "agent": agent, "status": status,
+            "turn": turn, "payload": payload}
+
+
+def send(req):
+    session_id = req["session_id"]
+    agent = req.get("agent", "claude")
+    message = req["message"]
+    timeout_s = float(req.get("timeout_s", 300))
+
+    ensure_session(session_id, agent)
+
+    # Per-turn output file (unique nonce → no stale-reply ambiguity).
+    os.makedirs(OUT_DIR, exist_ok=True)
+    nonce = secrets.token_hex(4)
+    outfile = os.path.join(OUT_DIR, "{}.{}.json".format(session_id, nonce))
+    try:
+        os.remove(outfile)
+    except OSError:
+        pass
+
+    driven = (
+        message
+        + "\n\n[agent-session] When done, write ONLY the JSON result to the file "
+        + outfile
+        + " — raw JSON, overwrite it, nothing else in that file."
+    )
+    submit(session_id, driven)
+
+    # The file appearing + parsing IS the completion signal (robust to TUI
+    # rendering / soft-wrapping). Tolerate a partial write by retrying.
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if os.path.exists(outfile):
+            try:
+                with open(outfile) as fh:
+                    payload = json.load(fh)
+            except (OSError, json.JSONDecodeError):
+                time.sleep(POLL_S)
+                continue
+            try:
+                os.remove(outfile)
+            except OSError:
+                pass
+            return response(session_id, agent, "ok", bump_turn(session_id), payload)
+        time.sleep(POLL_S)
+
+    return response(session_id, agent, "timeout", read_turn(session_id), None)
+
+
+def serve():
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    class Handler(BaseHTTPRequestHandler):
+        def _json(self, code, obj):
+            body = json.dumps(obj).encode()
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            if self.path == "/healthz":
+                self._json(200, {"status": "ok"})
+            else:
+                self._json(404, {"status": "error", "error": "not found"})
+
+        def do_POST(self):
+            if self.path != "/session/send":
+                self._json(404, {"status": "error", "error": "not found"})
+                return
+            n = int(self.headers.get("Content-Length", "0") or 0)
+            try:
+                req = json.loads(self.rfile.read(n) or b"{}")
+            except json.JSONDecodeError:
+                self._json(400, {"status": "error", "error": "bad json"})
+                return
+            self._json(200, send(req))
+
+        def log_message(self, *a):  # quiet
+            pass
+
+    # Pod-local only: the consumer shares the pod netns — bind loopback, never
+    # the wildcard address. Threaded so a long send() never head-of-line-blocks
+    # /healthz or a concurrent request.
+    try:
+        server = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
+    except OSError as exc:
+        # Surface bind failures (handler logs are silenced, not stderr):
+        # inspect via `tmux capture-pane -t agent-session-server`.
+        print(f"agent-session serve: bind 127.0.0.1:{PORT} failed: {exc}", file=sys.stderr)
+        raise
+    server.daemon_threads = True
+    server.serve_forever()
+
+
+def main(argv):
+    cmd = argv[1] if len(argv) > 1 else ""
+    if cmd == "serve":
+        serve()
+        return 0
+    if cmd == "send":
+        raw = argv[2] if len(argv) > 2 else sys.stdin.read()
+        print(json.dumps(send(json.loads(raw))))
+        return 0
+    print(json.dumps({"status": "error", "error": "usage: agent-session serve|send"}))
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
@@ -41,6 +41,27 @@ SETTLE_S = float(_env("AGENT_SESSION_SETTLE_S", "STOA_SETTLE_S", "0.5"))
 PORT = int(_env("AGENT_SESSION_PORT", "STOA_SESSION_PORT", "8765"))
 
 
+# Per-agent launch profiles: the interactive launch command (never -p /
+# one-shot) for each selectable agent. The session must auto-approve safe
+# operations so it can write its per-turn output file without a prompt.
+#   * claude  — wired + verified default.
+#   * codex / antigravity — config-selectable; their auto-approve invocation
+#     here is best-effort and NOT yet verified live (a follow-up — see the
+#     image README). This table is the single place to correct a flag.
+LAUNCH_PROFILES = {
+    "claude": "claude --permission-mode auto",
+    "codex": "codex --full-auto",
+    "antigravity": "agy --yolo",
+}
+DEFAULT_AGENT = "claude"
+
+
+def launch_command(agent):
+    # Unknown agent → fall back to the verified claude profile rather than
+    # launching nothing (which would leave send() to time out mysteriously).
+    return LAUNCH_PROFILES.get(agent, LAUNCH_PROFILES[DEFAULT_AGENT])
+
+
 def tmux(*args, stdin=None):
     return subprocess.run(["tmux", *args], input=stdin, capture_output=True, text=True)
 
@@ -63,17 +84,16 @@ def pretrust():
         pass
 
 
-def ensure_session(session_id, agent="claude"):
+def ensure_session(session_id, agent=DEFAULT_AGENT):
     # Auto-create the session (interactive agent CLI, never -p) if absent, so
-    # the caller's session_id drives whatever it names. Unauthenticated until
-    # the operator logs the agent in. `claude --permission-mode auto` lets the
-    # session auto-approve safe operations (incl. writing its per-turn output
-    # file) without a prompt, short of a full permissions bypass. Concurrency-
+    # the caller's session_id drives whatever it names. The launch command is
+    # the per-agent profile; its auto-approve flag lets the session write its
+    # per-turn output file without a prompt, short of a full permissions
+    # bypass. Unauthenticated until the operator logs the agent in. Concurrency-
     # safe: a racing dup new-session errors harmlessly.
     if tmux("has-session", "-t", session_id).returncode != 0:
         pretrust()
-        tmux("new-session", "-d", "-s", session_id,
-             "claude --permission-mode auto")
+        tmux("new-session", "-d", "-s", session_id, launch_command(agent))
 
 
 def submit(session_id, text):

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
@@ -218,8 +218,9 @@ def serve():
     try:
         server = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
     except OSError as exc:
-        # Surface bind failures (handler logs are silenced, not stderr):
-        # inspect via `tmux capture-pane -t agent-session-server`.
+        # Surface bind failures (handler logs are silenced, not stderr). Under
+        # the baked s6 longrun this stderr lands in the agent-session-server
+        # service / container logs (`docker logs` / `kubectl logs`).
         print(f"agent-session serve: bind 127.0.0.1:{PORT} failed: {exc}", file=sys.stderr)
         raise
     server.daemon_threads = True

--- a/multi-agent-shell/tests/test_agent_session.py
+++ b/multi-agent-shell/tests/test_agent_session.py
@@ -182,6 +182,28 @@ def test_deprecated_stoa_aliases_still_drive(tmp_path):
     assert (tmp_path / "turns" / (SEND_REQ["session_id"] + ".turn")).exists()
 
 
+@pytest.mark.parametrize("agent,expected_launch", [
+    ("claude", "claude --permission-mode auto"),
+    ("codex", "codex --full-auto"),
+    ("antigravity", "agy --yolo"),
+])
+def test_per_agent_launch_profile(harness, agent, expected_launch):
+    # ensure_session dispatches on the `agent` field via the launch-profile
+    # table; the FAKE_TMUX records the new-session command verbatim.
+    harness.run(dict(SEND_REQ, agent=agent), session_exists=False)
+    newlog = (harness.fdir / "new.log").read_text()
+    assert expected_launch in newlog, \
+        f"agent {agent!r} must launch via `{expected_launch}`, got: {newlog!r}"
+
+
+def test_unknown_agent_falls_back_to_claude(harness):
+    # An unrecognized agent must not crash — default to the verified claude
+    # profile rather than launching nothing.
+    harness.run(dict(SEND_REQ, agent="nope-not-an-agent"), session_exists=False)
+    newlog = (harness.fdir / "new.log").read_text()
+    assert "claude --permission-mode auto" in newlog
+
+
 def test_http_server_serves_session_send(harness):
     port = _free_port()
     (harness.fdir / "has.code").write_text("0")

--- a/multi-agent-shell/tests/test_agent_session.py
+++ b/multi-agent-shell/tests/test_agent_session.py
@@ -30,6 +30,8 @@ import pytest
 
 MAS = Path(__file__).resolve().parents[1]
 DRIVER = MAS / "rootfs/usr/local/lib/multi-agent-shell/agent-session"
+SERVICE_RUN = MAS / "rootfs/etc/services.d/agent-session-server/run"
+SERVICE_FINISH = MAS / "rootfs/etc/services.d/agent-session-server/finish"
 
 # The send/receive contract (inlined — the baked driver is a plain executable,
 # not a ConfigMap, so there is no yaml to parse and no fixture file to read).
@@ -202,6 +204,28 @@ def test_unknown_agent_falls_back_to_claude(harness):
     harness.run(dict(SEND_REQ, agent="nope-not-an-agent"), session_exists=False)
     newlog = (harness.fdir / "new.log").read_text()
     assert "claude --permission-mode auto" in newlog
+
+
+def test_s6_service_run_gated_on_serve_flag():
+    # The baked s6 longrun serves agent-session ONLY when AGENT_SESSION_SERVE=1
+    # (default off — a plain interactive shell is unaffected; consumers opt in).
+    assert SERVICE_RUN.exists(), "agent-session-server s6 run script must exist"
+    text = SERVICE_RUN.read_text()
+    assert text.startswith("#!/command/with-contenv bash"), "must mirror the sshd s6 shebang"
+    assert "AGENT_SESSION_SERVE" in text, "serve must be gated on AGENT_SESSION_SERVE"
+    assert "agent-session serve" in text, "must exec the baked agent-session serve"
+    # s6 supervises restarts, so there is NO busy while/sleep loop; when not
+    # opted in the service idles (sleep infinity) so s6 sees it as up.
+    assert "sleep infinity" in text, "must idle (not exit) when not opted in"
+    # Check for an actual `while` loop construct, ignoring the word in comments.
+    code = [l.split("#", 1)[0].strip() for l in text.splitlines()]
+    assert not any(l.startswith("while") for l in code), \
+        "s6 supervises restarts; no while/sleep loop"
+
+
+def test_s6_service_finish_mirrors_sshd():
+    assert SERVICE_FINISH.exists(), "agent-session-server s6 finish script must exist"
+    assert SERVICE_FINISH.read_text().startswith("#!/command/with-contenv bash")
 
 
 def test_http_server_serves_session_send(harness):

--- a/multi-agent-shell/tests/test_agent_session.py
+++ b/multi-agent-shell/tests/test_agent_session.py
@@ -1,0 +1,209 @@
+"""Unit tests for the baked agent-session send/receive driver.
+
+Ported from frank `scripts/tests/test_agent_session_driver.py`, re-pointed at
+the BAKED image file instead of n8n's ConfigMap. The driver drives a persistent
+agent TUI session (never `claude -p`):
+  * submits via bracketed paste — `load-buffer` (stdin) + `paste-buffer -p` +
+    a SEPARATE `send-keys Enter` after a settle delay (multi-line safe).
+  * tells the agent to WRITE the JSON to a per-turn file (unique nonce path);
+    the driver polls for that file to exist + parse, and that IS the payload.
+
+`tmux` is faked via a PATH-injected Python stub (no real tmux needed): paste
+stages the message, `send-keys Enter` makes the "agent" write the file the
+message names. Env is the genericized `AGENT_SESSION_*`; a dedicated test
+proves the deprecated `STOA_*` aliases still drive identical behaviour.
+
+Modeled on the repo's existing pytest setup (`kali/tests/test_*.py`).
+"""
+import json
+import os
+import socket
+import stat
+import subprocess
+import sys
+import time
+import types
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+MAS = Path(__file__).resolve().parents[1]
+DRIVER = MAS / "rootfs/usr/local/lib/multi-agent-shell/agent-session"
+
+# The send/receive contract (inlined — the baked driver is a plain executable,
+# not a ConfigMap, so there is no yaml to parse and no fixture file to read).
+SEND_REQ = {
+    "session_id": "agent-session-test",
+    "agent": "claude",
+    "message": "Investigate the surge and write a structured finding.",
+    "timeout_s": 300,
+}
+RECV_KEYS = {"session_id", "agent", "status", "turn", "payload"}
+PAYLOAD = {"finding": "traffic surge", "severity": "info", "sources": []}
+
+# Fake tmux: load-buffer stages the message, paste-buffer holds it, send-keys
+# Enter makes the "agent" write FAKE_PAYLOAD to the file the message names.
+# `new-session` is logged verbatim so dispatch tests can assert the launch cmd.
+FAKE_TMUX = r'''#!/usr/bin/env python3
+import sys, os, re
+D = os.environ["FAKE_DIR"]
+def p(n): return os.path.join(D, n)
+a = sys.argv[1:]
+cmd = a[0] if a else ""
+open(p("calls.log"), "a").write(cmd + " " + " ".join(a[1:]) + "\n")
+if cmd == "has-session":
+    try: code = int((open(p("has.code")).read().strip() or "0"))
+    except Exception: code = 0
+    sys.exit(code)
+if cmd == "new-session":
+    open(p("new.log"), "a").write(" ".join(a) + "\n"); sys.exit(0)
+if cmd == "load-buffer":
+    open(p("buffer.txt"), "w").write(sys.stdin.read()); sys.exit(0)
+if cmd == "paste-buffer":
+    buf = open(p("buffer.txt")).read() if os.path.exists(p("buffer.txt")) else ""
+    open(p("pending.txt"), "w").write(buf); sys.exit(0)
+if cmd == "send-keys":
+    if "Enter" in a and os.environ.get("FAKE_NO_REPLY") != "1":
+        msg = open(p("pending.txt")).read() if os.path.exists(p("pending.txt")) else ""
+        m = re.search(r"to the file (\S+)", msg)
+        if m:
+            outfile = m.group(1)
+            os.makedirs(os.path.dirname(outfile), exist_ok=True)
+            open(outfile, "w").write(os.environ.get("FAKE_PAYLOAD", "{}"))
+    sys.exit(0)
+sys.exit(0)
+'''
+
+
+def _free_port() -> int:
+    s = socket.socket(); s.bind(("127.0.0.1", 0)); port = s.getsockname()[1]; s.close()
+    return port
+
+
+def _make_harness(tmp_path, *, env_prefix="AGENT_SESSION_"):
+    """Build a driver harness. env_prefix selects the new (AGENT_SESSION_) or
+    the deprecated (STOA_) env var family so the alias path is exercisable."""
+    bindir = tmp_path / "bin"; bindir.mkdir()
+    drv = bindir / "agent-session"; drv.write_text(DRIVER.read_text())
+    drv.chmod(drv.stat().st_mode | stat.S_IEXEC)
+    faketmux = bindir / "tmux"; faketmux.write_text(FAKE_TMUX)
+    faketmux.chmod(faketmux.stat().st_mode | stat.S_IEXEC)
+    fdir = tmp_path / "fake"; fdir.mkdir()
+    home = tmp_path / "home"; home.mkdir()  # isolate HOME so pretrust() never touches real ~/.claude.json
+
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["HOME"] = str(home)
+    env["FAKE_DIR"] = str(fdir)
+    env[env_prefix + "TURN_DIR"] = str(tmp_path / "turns")
+    env[env_prefix + "OUT_DIR"] = str(tmp_path / "out")
+    env[env_prefix + "POLL_S"] = "0.05"
+    env[env_prefix + "SETTLE_S"] = "0"
+    env["FAKE_PAYLOAD"] = json.dumps(PAYLOAD)
+
+    def run(req, session_exists=True, no_reply=False):
+        (fdir / "has.code").write_text("0" if session_exists else "1")
+        e = dict(env)
+        if no_reply:
+            e["FAKE_NO_REPLY"] = "1"
+        return subprocess.run([sys.executable, str(drv), "send", json.dumps(req)],
+                              capture_output=True, text=True, env=e, timeout=30)
+
+    return types.SimpleNamespace(drv=drv, env=env, fdir=fdir, home=home, run=run)
+
+
+@pytest.fixture
+def harness(tmp_path):
+    return _make_harness(tmp_path)
+
+
+def test_receive_shape_matches_contract(harness):
+    out = json.loads(harness.run(SEND_REQ).stdout)
+    assert set(out) == RECV_KEYS, f"keys {set(out)} != contract {RECV_KEYS}"
+    assert out["status"] == "ok"
+    assert out["session_id"] == SEND_REQ["session_id"]
+    assert out["agent"] == "claude"
+    assert out["payload"] == PAYLOAD, "payload must come from the file the agent wrote"
+
+
+def test_submits_via_bracketed_paste_not_send_keys_text(harness):
+    harness.run(SEND_REQ)
+    calls = (harness.fdir / "calls.log").read_text()
+    assert "load-buffer" in calls and "paste-buffer" in calls, "must paste the message"
+    # The message must NOT be typed as send-keys literal text (the swallowed-Enter
+    # bug): the only send-keys call is the bare Enter submit.
+    sk_lines = [l for l in calls.splitlines() if l.startswith("send-keys")]
+    assert sk_lines, "must submit with send-keys Enter"
+    assert all("Enter" in l for l in sk_lines), f"send-keys must only send Enter, got {sk_lines}"
+
+
+def test_payload_from_file_not_pane(harness):
+    out = json.loads(harness.run(SEND_REQ).stdout)
+    assert out["status"] == "ok" and out["payload"] == PAYLOAD
+
+
+def test_unique_file_per_turn(harness):
+    a = json.loads(harness.run(SEND_REQ).stdout)
+    b = json.loads(harness.run(SEND_REQ).stdout)
+    assert a["status"] == "ok" and b["status"] == "ok"
+    assert b["turn"] == a["turn"] + 1
+
+
+def test_auto_creates_missing_session(harness):
+    out = json.loads(harness.run(SEND_REQ, session_exists=False).stdout)
+    assert out["status"] == "ok"
+    newlog = (harness.fdir / "new.log").read_text()
+    assert SEND_REQ["session_id"] in newlog
+    assert "--permission-mode auto" in newlog
+
+
+def test_auto_create_pretrusts_workspace(harness):
+    harness.run(SEND_REQ, session_exists=False)
+    cfg = harness.home / ".claude.json"
+    assert cfg.exists(), "pretrust must write ~/.claude.json"
+    proj = json.loads(cfg.read_text()).get("projects", {})
+    assert proj.get(str(harness.home), {}).get("hasTrustDialogAccepted") is True
+
+
+def test_timeout_when_no_file(harness):
+    req = dict(SEND_REQ, timeout_s=0.3)
+    out = json.loads(harness.run(req, no_reply=True).stdout)
+    assert out["status"] != "ok"
+
+
+def test_deprecated_stoa_aliases_still_drive(tmp_path):
+    # A consumer mid-migration that sets only the legacy STOA_* vars must get
+    # identical behaviour (the deprecated-alias fallback, kept for one cycle).
+    h = _make_harness(tmp_path, env_prefix="STOA_")
+    out = json.loads(h.run(SEND_REQ).stdout)
+    assert out["status"] == "ok" and out["payload"] == PAYLOAD
+    # The turn dir the legacy var named must be the one actually used.
+    assert (tmp_path / "turns" / (SEND_REQ["session_id"] + ".turn")).exists()
+
+
+def test_http_server_serves_session_send(harness):
+    port = _free_port()
+    (harness.fdir / "has.code").write_text("0")
+    env = dict(harness.env); env["AGENT_SESSION_PORT"] = str(port)
+    proc = subprocess.Popen([sys.executable, str(harness.drv), "serve"],
+                            env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        base = f"http://127.0.0.1:{port}"
+        for _ in range(50):
+            try:
+                with urllib.request.urlopen(base + "/healthz", timeout=1) as r:
+                    if r.status == 200:
+                        break
+            except Exception:
+                time.sleep(0.1)
+        else:
+            raise AssertionError("server did not become ready")
+        body = json.dumps(SEND_REQ).encode()
+        req = urllib.request.Request(base + "/session/send", data=body,
+                                     headers={"Content-Type": "application/json"}, method="POST")
+        with urllib.request.urlopen(req, timeout=10) as r:
+            out = json.loads(r.read())
+        assert out["status"] == "ok" and out["payload"] == PAYLOAD
+    finally:
+        proc.terminate(); proc.wait(timeout=5)


### PR DESCRIPTION
## Summary

Extracts the persistent-agent **`agent-session`** driver out of frank's n8n ConfigMap and bakes it into the `multi-agent-shell` image as a reusable, versioned contract (beside `notify-telegram.sh`). This is the **gating deliverable** of a multi-repo effort — frank's two downstream plans (alert-agent Part B, n8n-migration Part C) consume the resulting image tag.

- **Spec:** `derio-net/frank:docs/superpowers/specs/2026-06-15--obs--agentic-alert-helper-design.md` (Part A)
- **Plan:** `docs/superpowers/plans/2026-06-15-agent-session-extract/` (built on the plan from #125)

## What the image now carries

- `/usr/local/lib/multi-agent-shell/agent-session` (+ `/usr/local/bin` symlink) — the driver, **stdlib-only**, genericized `STOA_*` → `AGENT_SESSION_*` with deprecated-alias fallback (one migration cycle).
- A **configurable per-agent launch profile** (`LAUNCH_PROFILES`, keyed on the `agent` field): `claude --permission-mode auto` (default, verified); `codex --full-auto` / `agy --yolo` (config-selectable — auto-approve invocation **not yet verified live, a follow-up**); unknown → claude fallback.
- A baked **s6 longrun** `/etc/services.d/agent-session-server` serving the HTTP endpoint **only when `AGENT_SESSION_SERVE=1`** (default off; consumers opt in) — no postStart hook needed.
- The contract documented in `multi-agent-shell/README.md`.

## API

```
POST /session/send  {session_id, agent, message, timeout_s?} -> {session_id, agent, status, turn, payload}
GET  /healthz       -> 200
```

## Phases (all agentic / TDD — no manual phases)

| Phase | What | Tests |
|-------|------|-------|
| 1 | Bake + genericize driver; port tmux-mock tests to pytest; wire CI pytest job | ported driver tests + `STOA_*` alias |
| 2 | Generalize `ensure_session` onto the launch-profile table | 3 dispatch tests + fallback |
| 3 | `AGENT_SESSION_SERVE`-gated s6 longrun (mirrors sshd) | pytest service asserts + CI serve-binds smoke |
| 4 | README contract + branch image build | — |

**15 pytest tests** pass in-container and in CI (`test-multi-agent-shell`, which now gates the frank dispatch).

## Deliberate deviations from the plan (both verified by review)

1. **s6 `run` execs `agent-session serve` directly, not via `s6-setuidgid`.** Under K8s `cap-drop=ALL` + `runAsUser:1000`, s6 already runs as the agent UID and `s6-setuidgid` would call `setgroups()` (needs `CAP_SETGID`, dropped). The sshd `run` execs directly for the same reason; spec says "mirror sshd exactly."
2. **Phase-3 test is pytest + a CI runtime smoke, not bats.** bats is wired into neither CI nor the dev container (its existing `.bats` files are local-only/unenforced); pytest is the CI-executed surface and the spec mandates the CI "serve binds" smoke.

## Code review

Dispatched a read-only reviewer over the full diff + spec — **APPROVED, no blockers**; behavioral parity with the frank original confirmed across all 7 behaviors (bracketed-paste submit, nonce file, locked turn counter, timeout, serve/healthz, pretrust, agent flow).

- **Fixed:** the bind-failure diagnostic pointed at `tmux capture-pane` (correct under n8n's tmux loop) — now points at the s6 service / container logs.
- **Evaluated, no change:** missing `STOA_SESSION_NAME` alias (correctly omitted — lives in the bootstrap, not the driver; absent in the original); `KeyError` on missing request fields (identical to the original; required-field behavior).

## CI hardening surfaced by branch-build validation

Building the branch image (the plan's Phase 4) caught two CI issues, both fixed here:
- `smoke-test-multi-agent-shell` used `docker exec mas-smoke command -v …` — `command` is a bash builtin, not an executable (exit 127). Wrapped in `bash -lc`.
- **`dispatch-frank` had no event guard** → a manual `workflow_dispatch` branch build would fire `agent-images-bumped` at frank, whose handler sed-pins frank's **prod** manifests to the SHA and opens a PR — pinning production to an unmerged branch. Now guarded to `push` / `repository_dispatch` only.

## Branch image validated

Branch build [run 27579103277](https://github.com/derio-net/agent-images/actions/runs/27579103277) is **green**, `dispatch-frank` correctly **skipped**. Published `ghcr.io/derio-net/multi-agent-shell:<branch-sha>` (frank's bump handler pins by SHA). `agent-session serve` binds confirmed both in the CI smoke and locally against the published image (rc=124 = bound + stayed up).

## Test Plan

Per the operator decision, **in-plan smoke is sufficient** — Part A is verified by the Phase-4 branch build + `agent-session serve` smoke (above). The real end-to-end test lives in the downstream frank plans (which need `claude login`). No separate post-merge Test Plan.

## On merge

The main build will publish `multi-agent-shell:<main-sha>` and, via the (now-guarded) `dispatch-frank` on the `push` to main, open the normal **frank bump PR** — the intended path for frank's Part B/C plans to consume this image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)