### PR TITLE
agent-session: cold-start reliability (readiness gate + verified submit)

### DIFF
--- a/docs/superpowers/plans/2026-06-16-agent-session-coldstart/01.yaml
+++ b/docs/superpowers/plans/2026-06-16-agent-session-coldstart/01.yaml
@@ -1,0 +1,119 @@
+schema_version: 2
+phase:
+  number: 1
+  title: agent-session cold-start reliability (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: RED — extend FAKE_TMUX (capture-pane + dropped-Enter) and add failing tests
+  steps:
+  - id: P1.T1.S1
+    text: |
+      In `multi-agent-shell/tests/test_agent_session.py` extend the `FAKE_TMUX` stub so the
+      cold-start behaviours are simulable (the current stub has no `capture-pane` handler and
+      no way to model a dropped Enter):
+        * `capture-pane`: serve a test-controlled pane. Maintain a capture counter file; while
+          the counter is below `FAKE_COLD_CAPTURES` (default 0) emit an EMPTY pane (cold —
+          REPL not ready); otherwise emit a "ready" pane: a line containing the `❯` prompt
+          glyph, then the input-box content from `box.txt` on that same `❯ ` line (so an
+          unsubmitted message is visible next to the prompt), then a `⏵⏵ auto mode on` line.
+        * `send-keys Enter`: honour `FAKE_DROP_FIRST_ENTER` (default 0) — while an enter
+          counter is below it, DROP the Enter (write the first ~40 chars of `pending.txt` into
+          `box.txt`, simulating the message stuck in the input box) and write NO output file;
+          once at/above it, submit normally (clear `box.txt`, write the nonce output file as
+          today). With both new envs unset the stub behaves EXACTLY as before (existing tests
+          unchanged). Run `cd multi-agent-shell && uv run --with pytest python -m pytest tests/
+          -q`. Expected: GREEN (the stub change alone keeps all current tests passing).
+  - id: P1.T1.S2
+    text: |
+      Add the RED tests (new behaviour not yet implemented):
+        * `test_waits_for_ready_before_submit`: run with `FAKE_COLD_CAPTURES=3` and
+          `session_exists=False`; assert `status == "ok"` (the readiness gate polled past the
+          cold captures so the submit landed) AND the capture counter file shows >= 3 captures
+          (it actually polled). Without the gate the first Enter would fire into the empty pane.
+        * `test_readiness_gate_times_out_gracefully`: `FAKE_COLD_CAPTURES=10000`,
+          `AGENT_SESSION_READY_TIMEOUT_S=0.3`, `session_exists=False`; assert the process
+          RETURNS within a few seconds (does not hang) — best-effort proceed after timeout.
+        * `test_verified_submit_retries_dropped_enter`: `FAKE_DROP_FIRST_ENTER=1`,
+          `session_exists=True`; assert `status == "ok"` and `payload == PAYLOAD` (the retry
+          Enter submitted what the first, dropped, Enter did not) AND the calls log shows TWO
+          `send-keys ... Enter` lines.
+        * `test_warm_submit_does_not_double_enter`: default envs, `session_exists=True`; assert
+          exactly ONE `send-keys Enter` (no spurious retry when the box cleared on first Enter).
+        * `test_pretrust_seeds_auto_mode_flag`: `session_exists=False`; assert the written
+          `~/.claude.json` projects entry has `hasSeenAutoModeEntryWarning is True` (alongside
+          the existing `hasTrustDialogAccepted`).
+      Run the suite. Expected: FAIL (RED — readiness gate / verified-submit / flag not yet
+      implemented).
+- number: 2
+  title: GREEN — A1 readiness gate in ensure_session
+  steps:
+  - id: P1.T2.S1
+    text: |
+      In `multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session` add a
+      readiness gate. New env `READY_TIMEOUT_S = float(_env("AGENT_SESSION_READY_TIMEOUT_S",
+      "STOA_READY_TIMEOUT_S", "30"))`. Add `wait_ready(session_id, timeout_s=READY_TIMEOUT_S)`:
+      poll `tmux("capture-pane", "-p", "-t", session_id).stdout` every `POLL_S`; return True
+      when the pane contains the claude REPL prompt marker `❯` (empirically the cold→ready
+      signal — at 0.5–2s the pane is EMPTY, the `❯` prompt + `⏵⏵ auto mode on` render together
+      ~6s in); also return True on the version-drift fallback (pane non-empty AND unchanged
+      across two consecutive polls). On timeout, print a stderr WARN and return False
+      (best-effort — never hang a request). Call `wait_ready(session_id)` at the END of the
+      `if tmux("has-session", ...).returncode != 0:` block in `ensure_session` (gate ONLY on a
+      freshly-created session — a warm session is already ready, so warm turns are untouched).
+      Run the suite. Expected: the two readiness tests GREEN; verified-submit + flag tests
+      still RED.
+- number: 3
+  title: GREEN — A3 verified submit
+  steps:
+  - id: P1.T3.S1
+    text: |
+      Make `submit(session_id, text)` self-healing. After the existing `send-keys Enter`, add a
+      single verified retry: `time.sleep(SETTLE_S)`, re-capture the pane, and if the input box
+      still holds the message press Enter once more. Detect an unsubmitted box with a helper
+      `_input_box_has_text(pane)`: find the line containing `❯` and return True if there is
+      non-whitespace text AFTER the glyph (after submission the `❯` line is empty; a dropped
+      Enter leaves the message there). Single retry only — no unbounded loop. This is the
+      load-bearing fix: it catches both a cold pane and any first-run auto-mode interstitial
+      that swallows the first Enter, independent of the A1 marker being right. Run the suite.
+      Expected: verified-submit + warm-no-double-enter tests GREEN; flag test still RED.
+- number: 4
+  title: GREEN — A2 pretrust seeds the auto-mode-entry flag
+  steps:
+  - id: P1.T4.S1
+    text: |
+      In `pretrust()`, alongside `…["hasTrustDialogAccepted"] = True`, also set the project
+      entry's `hasSeenAutoModeEntryWarning = True` so a fresh profile's first `--permission-mode
+      auto` entry shows no Enter-swallowing interstitial. Best-effort / defence-in-depth: the
+      exact key is the live `~/.claude.json` source of truth (candidate confirmed against a
+      local claude config) and A3's verified-submit is the actual guarantee if the key name
+      drifts. Run the full suite `cd multi-agent-shell && uv run --with pytest python -m pytest
+      tests/ -q`. Expected: ALL GREEN (new cold-start tests + every pre-existing driver test).
+state:
+  steps:
+    P1.T1.S1:
+      state: x
+      ticked_at: '2026-06-16T21:38:01+00:00'
+      note: null
+    P1.T1.S2:
+      state: x
+      ticked_at: '2026-06-16T21:38:03+00:00'
+      note: null
+    P1.T2.S1:
+      state: x
+      ticked_at: '2026-06-16T21:38:05+00:00'
+      note: null
+    P1.T3.S1:
+      state: x
+      ticked_at: '2026-06-16T21:38:07+00:00'
+      note: null
+    P1.T4.S1:
+      state: x
+      ticked_at: '2026-06-16T21:38:09+00:00'
+      note: null
+  completion:
+    at: '2026-06-16T21:38:11+00:00'
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-16-agent-session-coldstart/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-16-agent-session-coldstart/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-16-agent-session-coldstart
+spec: derio-net/frank:docs/superpowers/specs/2026-06-16--obs--alert-agent-telegram-ux-design.md
+target_repo: derio-net/agent-images
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-06-16'

--- a/docs/superpowers/plans/2026-06-16-agent-session-coldstart/_prose.md
+++ b/docs/superpowers/plans/2026-06-16-agent-session-coldstart/_prose.md
@@ -1,0 +1,34 @@
+# agent-session cold-start reliability (Thread A)
+
+The baked `agent-session` driver creates a tmux session and returns immediately, then pastes +
+Enters after a fixed 0.5s. Empirically (captured against a real claude cold boot) the pane is
+**completely empty** at 0.5–2s and the REPL prompt (`❯`) only renders ~6s in — so the first Enter is
+dropped and the first turn times out. Warm turns work. This is the sole functional gap behind "the
+agent doesn't answer the first DM".
+
+Three changes, one file, stdlib-only, mirroring the existing tmux-mock test harness:
+
+- **A1 readiness gate** (`wait_ready` in `ensure_session`, on session creation only): poll
+  `capture-pane` until the `❯` prompt renders (or a non-empty pane goes stable — version-drift
+  insurance), capped by `AGENT_SESSION_READY_TIMEOUT_S` (~30s) then best-effort proceed. Covers
+  every lazily-created session id, not just one pre-warmed default.
+- **A3 verified submit**: after the Enter, re-capture; if the message still sits in the input box,
+  press Enter once more (single retry). The load-bearing fix — catches a cold pane AND any first-run
+  auto-mode interstitial, regardless of whether the A1 marker is exactly right.
+- **A2 pretrust flag**: seed `hasSeenAutoModeEntryWarning` next to the existing
+  `hasTrustDialogAccepted`. Best-effort defence-in-depth; A3 is the guarantee.
+
+## Why the `❯` marker, not pane-stability
+
+The empirical capture showed the bottom status line (claude-mem token counts, worktree list) keeps
+mutating for seconds *after* the REPL accepts input — so "pane unchanged across two polls" would wait
+too long or never settle. The `❯` prompt glyph is the stable cold→ready signal; stability is only a
+fallback for an agent/version that doesn't render it.
+
+## Sequencing
+
+This gates the frank `2026-06-16--obs--alert-agent-telegram-ux` plan's live smoke test only. Merge
+this → CI builds a new `multi-agent-shell` tag → the frank PR bumps its `deployment.yaml` image SHA
+to that tag → operator merges frank → the post-merge Test Plan proves a cold DM is answered with the
+⚡/👍 reactions. The bridge UX changes do not require this image to function (the bridge talks to the
+driver over HTTP; this change is internal to the driver).

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
@@ -46,7 +46,7 @@ PORT = int(_env("AGENT_SESSION_PORT", "STOA_SESSION_PORT", "8765"))
 # The claude REPL input-prompt glyph: empirically the cold→ready signal (the pane
 # is EMPTY for the first ~5s of boot, then the ❯ prompt + "auto mode" status line
 # render together). Used as the primary readiness marker.
-READY_MARKER = "❯"   # ❯
+READY_MARKER = "❯"
 
 
 # Per-agent launch profiles: the interactive launch command (never -p /
@@ -109,8 +109,12 @@ def ensure_session(session_id, agent=DEFAULT_AGENT):
         tmux("new-session", "-d", "-s", session_id, launch_command(agent))
         # Cold-start gate: a just-launched REPL is not yet accepting input (the
         # pane is empty for several seconds). Block until it is, so the first
-        # submit's Enter is not dropped. Only on creation — a warm session is
-        # already ready.
+        # submit's Enter is not dropped. Gated on creation only, to spare warm
+        # turns the poll. CAVEAT: under the threaded server a SECOND send for the
+        # same session_id may see has-session==0 (this branch just created it)
+        # and skip the gate while the pane is still booting — submit()'s verified
+        # retry is the backstop for that race (and for a genuinely-wedged session
+        # an unconditional gate would only add a dead 30s before the real timeout).
         wait_ready(session_id)
 
 
@@ -121,8 +125,10 @@ def _pane(session_id):
 def wait_ready(session_id, timeout_s=READY_TIMEOUT_S):
     # Poll the pane until the REPL accepts input: the ❯ prompt marker is the
     # primary signal; a non-empty pane that is unchanged across two polls is the
-    # version-drift fallback (an agent/version that doesn't render ❯). On timeout
-    # proceed best-effort — never hang the request.
+    # version-drift fallback (an agent/version that doesn't render ❯) — note it
+    # CAN return early if a version paints a static splash frame for ≥2 polls
+    # before accepting input; submit()'s verified retry backstops a too-early
+    # proceed. On timeout proceed best-effort — never hang the request.
     deadline = time.monotonic() + timeout_s
     last = None
     while time.monotonic() < deadline:
@@ -141,7 +147,9 @@ def wait_ready(session_id, timeout_s=READY_TIMEOUT_S):
 def _input_box_has_text(pane):
     # After a clean submit the ❯ prompt line is empty; a dropped Enter leaves the
     # message sitting after the glyph. Non-whitespace after ❯ ⇒ still unsubmitted.
-    for line in pane.splitlines():
+    # Scan from the BOTTOM: the input box is the last ❯ line — a ❯ in the
+    # transcript above (echoed output) must not be mistaken for the input line.
+    for line in reversed(pane.splitlines()):
         if READY_MARKER in line:
             return bool(line.split(READY_MARKER, 1)[1].strip())
     return False
@@ -157,6 +165,11 @@ def submit(session_id, text):
     # Verified submit: if the Enter was dropped (cold TUI / a first-run
     # interstitial), the message is still in the input box — press Enter once
     # more. Single retry, self-healing, independent of the readiness marker.
+    # NB: this can also fire if the Enter DID submit but the TUI hasn't repainted
+    # the now-empty box within SETTLE_S (loaded node) — the extra keypress is then
+    # a bare Enter into an empty prompt. Harmless for claude (empty submit; and
+    # send() keys off the output FILE, not the pane), but unverified for the
+    # codex/antigravity profiles.
     time.sleep(SETTLE_S)
     if _input_box_has_text(_pane(session_id)):
         tmux("send-keys", "-t", session_id, "Enter")

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
@@ -38,7 +38,15 @@ POLL_S = float(_env("AGENT_SESSION_POLL_S", "STOA_POLL_S", "2"))
 # Delay between pasting the message and pressing Enter — the TUI needs to
 # render the paste before the submit, or the Enter is dropped.
 SETTLE_S = float(_env("AGENT_SESSION_SETTLE_S", "STOA_SETTLE_S", "0.5"))
+# Max wait for a freshly-created session's REPL to start accepting input before
+# the first submit (cold-start gate). On timeout we proceed best-effort.
+READY_TIMEOUT_S = float(_env("AGENT_SESSION_READY_TIMEOUT_S", "STOA_READY_TIMEOUT_S", "30"))
 PORT = int(_env("AGENT_SESSION_PORT", "STOA_SESSION_PORT", "8765"))
+
+# The claude REPL input-prompt glyph: empirically the cold→ready signal (the pane
+# is EMPTY for the first ~5s of boot, then the ❯ prompt + "auto mode" status line
+# render together). Used as the primary readiness marker.
+READY_MARKER = "❯"   # ❯
 
 
 # Per-agent launch profiles: the interactive launch command (never -p /
@@ -76,7 +84,12 @@ def pretrust():
     except (OSError, json.JSONDecodeError):
         d = {}
     home = os.path.expanduser("~")
-    d.setdefault("projects", {}).setdefault(home, {})["hasTrustDialogAccepted"] = True
+    proj = d.setdefault("projects", {}).setdefault(home, {})
+    proj["hasTrustDialogAccepted"] = True
+    # Seed the first-run auto-mode-entry warning so `--permission-mode auto` shows
+    # no interstitial that could swallow the first Enter. Best-effort defence in
+    # depth — submit()'s verified retry is the actual guarantee if the key drifts.
+    proj["hasSeenAutoModeEntryWarning"] = True
     try:
         with open(path, "w") as fh:
             json.dump(d, fh)
@@ -94,6 +107,44 @@ def ensure_session(session_id, agent=DEFAULT_AGENT):
     if tmux("has-session", "-t", session_id).returncode != 0:
         pretrust()
         tmux("new-session", "-d", "-s", session_id, launch_command(agent))
+        # Cold-start gate: a just-launched REPL is not yet accepting input (the
+        # pane is empty for several seconds). Block until it is, so the first
+        # submit's Enter is not dropped. Only on creation — a warm session is
+        # already ready.
+        wait_ready(session_id)
+
+
+def _pane(session_id):
+    return tmux("capture-pane", "-p", "-t", session_id).stdout or ""
+
+
+def wait_ready(session_id, timeout_s=READY_TIMEOUT_S):
+    # Poll the pane until the REPL accepts input: the ❯ prompt marker is the
+    # primary signal; a non-empty pane that is unchanged across two polls is the
+    # version-drift fallback (an agent/version that doesn't render ❯). On timeout
+    # proceed best-effort — never hang the request.
+    deadline = time.monotonic() + timeout_s
+    last = None
+    while time.monotonic() < deadline:
+        pane = _pane(session_id)
+        if READY_MARKER in pane:
+            return True
+        if pane.strip() and pane == last:
+            return True
+        last = pane
+        time.sleep(POLL_S)
+    print(f"agent-session: session {session_id} not ready after {timeout_s}s; proceeding",
+          file=sys.stderr)
+    return False
+
+
+def _input_box_has_text(pane):
+    # After a clean submit the ❯ prompt line is empty; a dropped Enter leaves the
+    # message sitting after the glyph. Non-whitespace after ❯ ⇒ still unsubmitted.
+    for line in pane.splitlines():
+        if READY_MARKER in line:
+            return bool(line.split(READY_MARKER, 1)[1].strip())
+    return False
 
 
 def submit(session_id, text):
@@ -103,6 +154,12 @@ def submit(session_id, text):
     tmux("paste-buffer", "-d", "-p", "-b", "agent-session-msg", "-t", session_id)
     time.sleep(SETTLE_S)
     tmux("send-keys", "-t", session_id, "Enter")
+    # Verified submit: if the Enter was dropped (cold TUI / a first-run
+    # interstitial), the message is still in the input box — press Enter once
+    # more. Single retry, self-healing, independent of the readiness marker.
+    time.sleep(SETTLE_S)
+    if _input_box_has_text(_pane(session_id)):
+        tmux("send-keys", "-t", session_id, "Enter")
 
 
 def read_turn(session_id):

--- a/multi-agent-shell/tests/test_agent_session.py
+++ b/multi-agent-shell/tests/test_agent_session.py
@@ -67,12 +67,33 @@ if cmd == "paste-buffer":
     open(p("pending.txt"), "w").write(buf); sys.exit(0)
 if cmd == "send-keys":
     if "Enter" in a and os.environ.get("FAKE_NO_REPLY") != "1":
-        msg = open(p("pending.txt")).read() if os.path.exists(p("pending.txt")) else ""
-        m = re.search(r"to the file (\S+)", msg)
-        if m:
-            outfile = m.group(1)
-            os.makedirs(os.path.dirname(outfile), exist_ok=True)
-            open(outfile, "w").write(os.environ.get("FAKE_PAYLOAD", "{}"))
+        ec = p("enter.count")
+        k = int(open(ec).read() or "0") if os.path.exists(ec) else 0
+        open(ec, "w").write(str(k + 1))
+        if k < int(os.environ.get("FAKE_DROP_FIRST_ENTER", "0")):
+            # Dropped Enter (cold TUI / first-run interstitial): the message stays
+            # stuck in the input box instead of submitting.
+            pend = open(p("pending.txt")).read() if os.path.exists(p("pending.txt")) else ""
+            open(p("box.txt"), "w").write(pend[:40])
+        else:
+            open(p("box.txt"), "w").write("")   # submitted → input box clears
+            msg = open(p("pending.txt")).read() if os.path.exists(p("pending.txt")) else ""
+            m = re.search(r"to the file (\S+)", msg)
+            if m:
+                outfile = m.group(1)
+                os.makedirs(os.path.dirname(outfile), exist_ok=True)
+                open(outfile, "w").write(os.environ.get("FAKE_PAYLOAD", "{}"))
+    sys.exit(0)
+if cmd == "capture-pane":
+    cc = p("capture.count")
+    n = int(open(cc).read() or "0") if os.path.exists(cc) else 0
+    open(cc, "w").write(str(n + 1))
+    if n < int(os.environ.get("FAKE_COLD_CAPTURES", "0")):
+        sys.stdout.write("")            # cold boot: REPL not ready → empty pane
+    else:
+        box = open(p("box.txt")).read() if os.path.exists(p("box.txt")) else ""
+        # ready pane: the ❯ prompt (with any unsubmitted box text after it) + status line
+        sys.stdout.write("some history\n❯ " + box + "\n⏵⏵ auto mode on\n")
     sys.exit(0)
 sys.exit(0)
 '''
@@ -204,6 +225,70 @@ def test_unknown_agent_falls_back_to_claude(harness):
     harness.run(dict(SEND_REQ, agent="nope-not-an-agent"), session_exists=False)
     newlog = (harness.fdir / "new.log").read_text()
     assert "claude --permission-mode auto" in newlog
+
+
+# --- Cold-start reliability (A1 readiness gate, A3 verified submit, A2 flag) ----
+
+def _enter_count(harness):
+    log = (harness.fdir / "calls.log").read_text()
+    return len([l for l in log.splitlines() if l.startswith("send-keys") and "Enter" in l])
+
+
+def test_waits_for_ready_before_submit(tmp_path):
+    # A1: a fresh session whose pane is empty for the first 3 captures (cold boot)
+    # must NOT submit until the REPL prompt renders — the readiness gate polls past
+    # the cold captures, so the submit lands and the turn completes.
+    h = _make_harness(tmp_path)
+    h.env["FAKE_COLD_CAPTURES"] = "3"
+    e = dict(h.env)
+    (h.fdir / "has.code").write_text("1")   # session missing → created → gated
+    out = json.loads(subprocess.run(
+        [sys.executable, str(h.drv), "send", json.dumps(SEND_REQ)],
+        capture_output=True, text=True, env=e, timeout=30).stdout)
+    assert out["status"] == "ok"
+    assert int((h.fdir / "capture.count").read_text()) >= 3, "must have polled the cold pane"
+
+
+def test_readiness_gate_times_out_gracefully(tmp_path):
+    # A1: if the pane never becomes ready, the gate must time out and proceed
+    # best-effort (never hang the request).
+    h = _make_harness(tmp_path)
+    h.env["FAKE_COLD_CAPTURES"] = "100000"
+    h.env["AGENT_SESSION_READY_TIMEOUT_S"] = "0.3"
+    e = dict(h.env)
+    (h.fdir / "has.code").write_text("1")
+    res = subprocess.run([sys.executable, str(h.drv), "send", json.dumps(SEND_REQ)],
+                         capture_output=True, text=True, env=e, timeout=15)
+    out = json.loads(res.stdout)   # returns (does not hang) — submit still ran
+    assert out["status"] == "ok"
+
+
+def test_verified_submit_retries_dropped_enter(tmp_path):
+    # A3: the first Enter is dropped (cold TUI / interstitial) leaving the message
+    # in the input box — the verified submit must re-press Enter so it lands.
+    h = _make_harness(tmp_path)
+    h.env["FAKE_DROP_FIRST_ENTER"] = "1"
+    e = dict(h.env)
+    (h.fdir / "has.code").write_text("0")   # warm session → no readiness gate
+    out = json.loads(subprocess.run(
+        [sys.executable, str(h.drv), "send", json.dumps(SEND_REQ)],
+        capture_output=True, text=True, env=e, timeout=30).stdout)
+    assert out["status"] == "ok" and out["payload"] == PAYLOAD
+    assert _enter_count(h) == 2, "must retry Enter exactly once when the box didn't clear"
+
+
+def test_warm_submit_does_not_double_enter(harness):
+    # A3: when the first Enter submits cleanly, there must be NO spurious retry.
+    harness.run(SEND_REQ)   # warm session, default envs
+    assert _enter_count(harness) == 1
+
+
+def test_pretrust_seeds_auto_mode_flag(harness):
+    # A2: pretrust seeds the auto-mode-entry warning flag alongside the trust flag,
+    # so a fresh profile's first --permission-mode auto entry swallows no Enter.
+    harness.run(SEND_REQ, session_exists=False)
+    proj = json.loads((harness.home / ".claude.json").read_text()).get("projects", {})
+    assert proj.get(str(harness.home), {}).get("hasSeenAutoModeEntryWarning") is True
 
 
 def test_s6_service_run_gated_on_serve_flag():

--- a/multi-agent-shell/tests/test_agent_session.py
+++ b/multi-agent-shell/tests/test_agent_session.py
@@ -92,8 +92,11 @@ if cmd == "capture-pane":
         sys.stdout.write("")            # cold boot: REPL not ready → empty pane
     else:
         box = open(p("box.txt")).read() if os.path.exists(p("box.txt")) else ""
-        # ready pane: the ❯ prompt (with any unsubmitted box text after it) + status line
-        sys.stdout.write("some history\n❯ " + box + "\n⏵⏵ auto mode on\n")
+        # ready pane: the ❯ prompt (with any unsubmitted box text after it) + status line.
+        # FAKE_HISTORY_PROMPT adds a transcript line that ALSO contains ❯ above the
+        # input box — the driver must read the LAST ❯ line (the box), not this one.
+        history = "echoed ❯ old input\n" if os.environ.get("FAKE_HISTORY_PROMPT") == "1" else "some history\n"
+        sys.stdout.write(history + "❯ " + box + "\n⏵⏵ auto mode on\n")
     sys.exit(0)
 sys.exit(0)
 '''
@@ -281,6 +284,21 @@ def test_warm_submit_does_not_double_enter(harness):
     # A3: when the first Enter submits cleanly, there must be NO spurious retry.
     harness.run(SEND_REQ)   # warm session, default envs
     assert _enter_count(harness) == 1
+
+
+def test_verified_submit_ignores_transcript_prompt_glyph(tmp_path):
+    # A3 hardening: a ❯ in the transcript (echoed output) above an EMPTY input box
+    # must not be mistaken for an unsubmitted message — the box is the LAST ❯ line.
+    # With a top-down scan this would spuriously retry; bottom-up reads the empty box.
+    h = _make_harness(tmp_path)
+    h.env["FAKE_HISTORY_PROMPT"] = "1"
+    e = dict(h.env)
+    (h.fdir / "has.code").write_text("0")   # warm; clean first-Enter submit clears the box
+    out = json.loads(subprocess.run(
+        [sys.executable, str(h.drv), "send", json.dumps(SEND_REQ)],
+        capture_output=True, text=True, env=e, timeout=30).stdout)
+    assert out["status"] == "ok"
+    assert _enter_count(h) == 1, "a transcript ❯ must not trigger the verified-submit retry"
 
 
 def test_pretrust_seeds_auto_mode_flag(harness):


### PR DESCRIPTION
📦 Repo: derio-net/agent-images
📋 Plan: docs/superpowers/plans/2026-06-16-agent-session-coldstart
📐 Spec: derio-net/frank:docs/superpowers/specs/2026-06-16--obs--alert-agent-telegram-ux-design.md (Thread A)

**Goal (from plan):** Make the baked `agent-session` driver survive a cold session so the agentic alert-agent actually answers the first Telegram DM.

## The bug

`ensure_session` created a tmux session (`claude --permission-mode auto`) and returned immediately; `submit()` pasted + pressed Enter after a fixed `SETTLE_S=0.5s`. A **cold claude pane is empty for ~5s** while the TUI boots — captured empirically (pane blank at 0.5s/2s; the `❯` prompt + `⏵⏵ auto mode on` status line render together ~6s in) — so the first Enter was dropped and the first turn timed out. Warm turns worked; this is the sole functional gap behind "the agent doesn't answer the first DM".

## Fixes (one file, stdlib-only)

- **A1 readiness gate** — `wait_ready(session_id)` polls `tmux capture-pane` until the `❯` REPL prompt renders (primary marker; non-empty-and-stable-across-two-polls is the version-drift fallback), capped by `AGENT_SESSION_READY_TIMEOUT_S` (~30s) then best-effort proceed. Gated on session **creation** only — warm turns pay no poll.
- **A3 verified submit** (load-bearing) — after the Enter, re-capture; if the input box still holds the message (`_input_box_has_text`, scanning the pane **bottom-up**), press Enter once more (single retry). Independent of A1; catches a cold pane AND any first-run interstitial.
- **A2** — `pretrust()` also seeds `hasSeenAutoModeEntryWarning` (best-effort; A3 is the guarantee).

## Tests

21 tests (16 pre-existing + 5 cold-start), via the extended PATH-injected `FAKE_TMUX` stub (cold/ready pane + dropped-Enter modelling). **RED verified against HEAD**: the three behaviour-introducing tests fail without the fix.

## Code review

Fresh-eyes review: **With fixes** (no Critical/Important blockers). Addressed:
- **Bottom-anchored input-box scan** (Minor → code fix) — `_input_box_has_text` now scans `reversed()` so a transcript `❯` can't be mistaken for the input line; new test `test_verified_submit_ignores_transcript_prompt_glyph` proves it. ✅
- **Concurrent-creation gate gap** (Important) — under the threaded server a 2nd same-session `send` can skip the gate. *Documented + reasoning recorded:* A3 backstops it, and unconditional gating would add a dead ~30s to a genuinely-wedged session; in this deployment the bridge is a single synchronous consumer and the sidecars use distinct session_ids, so same-session concurrency is near-theoretical. Comment added, not re-architected.
- **Slow-repaint double-Enter** (Important) — *documented:* a lagging repaint can make the box look unsubmitted → a bare empty-submit, which is a harmless no-op for claude (result keys off the output **file**, not the pane); flagged as unverified for codex/antigravity.
- **Stability-fallback early-return** (Minor) — comment acknowledges the risk; A3 backstops.
- **Real-claude smoke before "Deployed"** (Minor/rec) — covered by the companion frank PR's post-merge Test Plan (cold DM answered with ⚡→👍).

## Cross-repo (merge order)

**Merge this first.** CI builds a new `multi-agent-shell` tag → the companion **frank PR derio-net/frank#568** (alert-agent Telegram UX) bumps its `deployment.yaml` image SHA to that tag (its back-loaded `[manual]` Phase 3) → operator merges frank → post-merge Test Plan validates the real cold-start end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
