### PR TITLE
[agent-images] agent-session persistence — liveness + --session-id + continuum gate (C/E/B)

### DIFF
--- a/agent-shell-base/etc/agent/tmux-resurrect.conf
+++ b/agent-shell-base/etc/agent/tmux-resurrect.conf
@@ -2,7 +2,15 @@ set -g @resurrect-dir '~/.tmux/resurrect'
 set -g @resurrect-capture-pane-contents 'on'
 
 set -g @continuum-save-interval '5'
-set -g @continuum-restore 'on'
+
+# Gate continuum auto-restore on AGENT_TMUX_RESTORE (default on). Agent pods
+# (alert-agent, n8n-01) set AGENT_TMUX_RESTORE=off so the agent-session driver
+# owns sessions and continuum never resurrects a DEAD bash shell that
+# ensure_session would reuse. Human shells leave it unset → restore stays on.
+# Set BEFORE continuum.tmux runs so the plugin sees it at server start.
+if-shell '[ "${AGENT_TMUX_RESTORE:-on}" = "off" ]' \
+  "set -g @continuum-restore 'off'" \
+  "set -g @continuum-restore 'on'"
 
 run-shell /usr/local/share/tmux-plugins/tmux-resurrect/resurrect.tmux
 run-shell /usr/local/share/tmux-plugins/tmux-continuum/continuum.tmux

--- a/agent-shell-base/tests/test_tmux_restore_gate.py
+++ b/agent-shell-base/tests/test_tmux_restore_gate.py
@@ -1,0 +1,35 @@
+"""Guard: tmux-continuum auto-restore must be GATED on AGENT_TMUX_RESTORE.
+
+continuum auto-restores saved sessions on every fresh tmux-server start. For a
+driver-managed agent pod that restores a DEAD bash shell which `ensure_session`
+then reuses (the alert-agent DM-into-bash failure). Agent pods (alert-agent,
+n8n-01) set AGENT_TMUX_RESTORE=off so continuum never restores; human shells
+leave it unset → restore stays on (default). Fix C is the load-bearing guarantee;
+this gate is defence + cleanliness.
+"""
+from pathlib import Path
+
+CONF = Path(__file__).resolve().parents[1] / "etc/agent/tmux-resurrect.conf"
+
+
+def test_continuum_restore_is_gated_on_env():
+    text = CONF.read_text()
+    assert "if-shell" in text, "continuum-restore must be gated via if-shell"
+    assert "AGENT_TMUX_RESTORE" in text, "gate must read AGENT_TMUX_RESTORE"
+    assert "@continuum-restore 'off'" in text, "must turn restore OFF when AGENT_TMUX_RESTORE=off"
+    assert "@continuum-restore 'on'" in text, "must keep restore ON otherwise"
+    assert "AGENT_TMUX_RESTORE:-on" in text, "must DEFAULT to on when the env is unset"
+
+
+def test_no_unconditional_restore_on():
+    # The old static always-on setter must be gone — only the if-shell branch
+    # (a double-quoted argument) may set it on.
+    lines = [l.strip() for l in CONF.read_text().splitlines()]
+    assert "set -g @continuum-restore 'on'" not in lines, \
+        "the unconditional always-on setter must be replaced by the if-shell gate"
+
+
+def test_gate_precedes_continuum_plugin():
+    text = CONF.read_text()
+    assert text.index("AGENT_TMUX_RESTORE") < text.index("continuum.tmux"), \
+        "the gate must be set BEFORE continuum.tmux runs (plugin reads it at server start)"

--- a/docs/superpowers/plans/2026-06-17-agent-session-persistence/01.yaml
+++ b/docs/superpowers/plans/2026-06-17-agent-session-persistence/01.yaml
@@ -47,18 +47,18 @@ tasks:
 state:
   steps:
     P1.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-17T20:29:03+00:00'
       note: null
     P1.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-17T20:29:05+00:00'
       note: null
     P1.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-17T20:29:06+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-17T20:29:08+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-17-agent-session-persistence/01.yaml
+++ b/docs/superpowers/plans/2026-06-17-agent-session-persistence/01.yaml
@@ -1,0 +1,64 @@
+schema_version: 2
+phase:
+  number: 1
+  title: Driver liveness check — never trust a dead existing session (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: RED — model an existing-but-dead session in FAKE_TMUX + failing tests
+  steps:
+  - id: P1.T1.S1
+    text: |
+      In `multi-agent-shell/tests/test_agent_session.py` extend `FAKE_TMUX` so a session can be
+      modelled as EXISTING but DEAD (a bash shell, no ❯). Add an env `FAKE_DEAD_SESSION` (default
+      unset): when set, `capture-pane` for an EXISTING session emits a shell pane (e.g.
+      `"agent@pod:~$ "`, NO ❯) until the session is KILLED (track a `killed` marker file written
+      on `kill-session`); after a kill+new-session it emits the normal ready `❯` pane. Add a
+      `kill-session` handler that records the killed session id. Keep all existing tests green
+      with the new envs unset. Run `cd multi-agent-shell && uv run --with pytest python -m pytest
+      tests/ -q`. Expected: GREEN (stub change only).
+  - id: P1.T1.S2
+    text: |
+      Add RED tests:
+        * `test_dead_existing_session_is_recreated`: `has.code=0` (exists) + `FAKE_DEAD_SESSION=1`;
+          assert `status==ok` and the calls log shows a `kill-session` for the id followed by a
+          `new-session` (the driver detected the dead shell and recreated it), and the reply
+          payload is PAYLOAD.
+        * `test_live_existing_session_is_reused`: `has.code=0`, pane already ready (`❯`), default
+          envs; assert `status==ok` and NO `kill-session` in the calls log (warm reuse, untouched).
+        * `test_absent_session_still_creates`: `has.code=1`; assert a `new-session` and `status==ok`
+          (regression — the creation path + wait_ready still works).
+      Run the suite. Expected: FAIL (RED — ensure_session reuses the dead session blindly).
+- number: 2
+  title: GREEN — liveness probe in ensure_session
+  steps:
+  - id: P1.T2.S1
+    text: |
+      In `…/multi-agent-shell/agent-session`, change `ensure_session` so it stops trusting bare
+      `has-session`. If the session is ABSENT → create + `wait_ready` (as today). If it EXISTS →
+      run a quick liveness probe: poll `capture-pane` for `READY_MARKER` with a SHORT bounded
+      timeout (new `READY_PROBE_S`, ~3s, env-overridable) reusing the wait_ready logic; if the pane
+      is NOT a live REPL within the probe, `tmux("kill-session","-t",session_id)` then create +
+      `wait_ready` (recreate); if live, reuse untouched. Factor the poll so wait_ready and the
+      probe share one helper (different timeouts). Run the suite. Expected: GREEN (dead recreated,
+      live reused, absent created). RED-verify by stashing the driver and re-running the 3 tests.
+state:
+  steps:
+    P1.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+    P1.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-17-agent-session-persistence/02.yaml
+++ b/docs/superpowers/plans/2026-06-17-agent-session-persistence/02.yaml
@@ -59,22 +59,24 @@ tasks:
 state:
   steps:
     P2.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-17T20:40:08+00:00'
       note: null
     P2.T2.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-17T20:40:09+00:00'
       note: null
     P2.T3.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-17T20:40:11+00:00'
       note: null
     P2.T3.S2:
-      state: ' '
-      ticked_at: null
-      note: null
+      state: '-'
+      ticked_at: '2026-06-17T20:40:12+00:00'
+      note: Live-verify deferred to operator (pod write is operator-gated); launcher
+        at /tmp/verify-e-live.sh confirms --session-id resume + captures the real
+        /context string. Code ships best-effort context_pct + auto-compact fallback.
   completion:
-    at: null
+    at: '2026-06-17T20:40:14+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-17-agent-session-persistence/02.yaml
+++ b/docs/superpowers/plans/2026-06-17-agent-session-persistence/02.yaml
@@ -1,0 +1,80 @@
+schema_version: 2
+phase:
+  number: 2
+  title: Persistent --session-id sessions + idle/clear + 60% compact (TDD)
+  tag: agentic
+  depends_on:
+  - 1
+  tracking_issue: null
+tasks:
+- number: 1
+  title: RED — tests for deterministic uuid, --session-id launch, idle /clear
+  steps:
+  - id: P2.T1.S1
+    text: |
+      Add RED tests:
+        * `test_session_uuid_is_deterministic`: a helper `session_uuid(session_id)` returns the
+          same valid UUID for a given session_id across calls and differs per id (uuid5).
+        * `test_launch_uses_session_id_uuid`: `has.code=1`; assert the recorded `new-session`
+          launch command contains `--session-id <session_uuid(SEND_REQ.session_id)>` and
+          `--permission-mode auto`.
+        * `test_idle_over_12h_clears_first`: pre-write a `last_activity` file (PVC dir) older than
+          12h for the session; `has.code=0` live; assert the driver submits a `/clear` (a paste
+          whose buffer == "/clear") BEFORE the message paste, and updates last_activity.
+        * `test_recent_activity_no_clear`: last_activity = now; assert NO `/clear` submit.
+      Run the suite. Expected: FAIL (RED — none implemented).
+- number: 2
+  title: GREEN — uuid launch + idle reset
+  steps:
+  - id: P2.T2.S1
+    text: |
+      Implement: `NAMESPACE = uuid.UUID(<fixed constant>)`; `session_uuid(sid) =
+      str(uuid.uuid5(NAMESPACE, sid))`. `launch_command(agent, session_id)` for claude →
+      `claude --session-id <session_uuid> --permission-mode auto` (thread session_id through
+      ensure_session→launch_command; non-claude profiles unchanged). Add `LAST_DIR`/`last_activity`
+      helpers (PVC, beside TURN_DIR): `read_last_activity`/`touch_last_activity`. In `send()`,
+      BEFORE submit: if `now - read_last_activity(session_id) > 12*3600`, `submit(session_id,
+      "/clear")` + brief settle; always `touch_last_activity` after the turn. Run the suite.
+      Expected: GREEN. RED-verify by stash.
+- number: 3
+  title: 60% compaction (best-effort) + live-verify markers
+  steps:
+  - id: P2.T3.S1
+    text: |
+      Add a best-effort proactive compaction: helper `context_pct(pane)` parses claude's
+      context-usage indicator from a captured pane (returns int% or None). After a successful turn,
+      if `context_pct >= 60`, `submit(session_id, "/compact")`. Test with a FAKE pane line the stub
+      emits carrying a parametrized context indicator (`FAKE_CONTEXT_PCT`): assert `/compact` is
+      submitted at 70, NOT at 40, and that a None/unparseable indicator submits nothing (fallback
+      to claude auto-compact, no crash). Run the suite. Expected: GREEN.
+  - id: P2.T3.S2
+    text: |
+      `# manual-operation` LIVE-VERIFY (cannot be unit-tested — real claude/TUI): on the running
+      pod, (a) confirm `claude --session-id <uuid> --permission-mode auto` RESUMES the same
+      conversation on a second launch (2.1.177), and (b) confirm the exact context-usage indicator
+      string/location `context_pct` must parse (`/context` output or status line) and tune the
+      parser to it. Record findings; if the indicator is unparseable, the idle-/clear + claude
+      auto-compact still bound growth (documented degrade). This step is verification only — the
+      agentic code ships with the parser's best-effort target + fallback.
+state:
+  steps:
+    P2.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T2.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P2.T3.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-17-agent-session-persistence/03.yaml
+++ b/docs/superpowers/plans/2026-06-17-agent-session-persistence/03.yaml
@@ -32,14 +32,14 @@ tasks:
 state:
   steps:
     P3.T1.S1:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-17T20:42:03+00:00'
       note: null
     P3.T1.S2:
-      state: ' '
-      ticked_at: null
+      state: x
+      ticked_at: '2026-06-17T20:42:04+00:00'
       note: null
   completion:
-    at: null
+    at: '2026-06-17T20:42:06+00:00'
     note: null
     observed_prs: []

--- a/docs/superpowers/plans/2026-06-17-agent-session-persistence/03.yaml
+++ b/docs/superpowers/plans/2026-06-17-agent-session-persistence/03.yaml
@@ -1,0 +1,45 @@
+schema_version: 2
+phase:
+  number: 3
+  title: Continuum conditional in agent-shell-base (TDD)
+  tag: agentic
+  depends_on: []
+  tracking_issue: null
+tasks:
+- number: 1
+  title: RED+GREEN — AGENT_TMUX_RESTORE gate in tmux-resurrect.conf
+  steps:
+  - id: P3.T1.S1
+    text: |
+      RED — add `agent-shell-base/tests/test_tmux_restore_gate.py` (mirror the repo's pytest
+      layout): assert `agent-shell-base/etc/agent/tmux-resurrect.conf` contains an `if-shell`
+      honoring `AGENT_TMUX_RESTORE` that sets `@continuum-restore 'off'` when it equals `off` and
+      `'on'` otherwise (default-on), and that the conditional appears BEFORE the
+      `run-shell …/continuum.tmux` line. Run `cd agent-shell-base && uv run --with pytest python -m
+      pytest tests/ -q`. Expected: FAIL (RED — conf has the static `set -g @continuum-restore 'on'`).
+  - id: P3.T1.S2
+    text: |
+      GREEN — in `agent-shell-base/etc/agent/tmux-resurrect.conf` replace
+      `set -g @continuum-restore 'on'` with:
+      BEGIN
+      if-shell '[ "${AGENT_TMUX_RESTORE:-on}" = "off" ]' \
+        "set -g @continuum-restore 'off'" \
+        "set -g @continuum-restore 'on'"
+      END
+      (kept before the `run-shell …/continuum.tmux`). Run the test. Expected: GREEN. Note in the
+      conf a comment: agent pods set AGENT_TMUX_RESTORE=off (driver-managed sessions); human shells
+      leave it unset.
+state:
+  steps:
+    P3.T1.S1:
+      state: ' '
+      ticked_at: null
+      note: null
+    P3.T1.S2:
+      state: ' '
+      ticked_at: null
+      note: null
+  completion:
+    at: null
+    note: null
+    observed_prs: []

--- a/docs/superpowers/plans/2026-06-17-agent-session-persistence/_meta.yaml
+++ b/docs/superpowers/plans/2026-06-17-agent-session-persistence/_meta.yaml
@@ -1,0 +1,6 @@
+schema_version: 2
+plan: 2026-06-17-agent-session-persistence
+spec: derio-net/frank:docs/superpowers/specs/2026-06-17--obs--alert-agent-session-reliability-design.md
+target_repo: derio-net/agent-images
+fr_version: '>=3.0.0,<4.0.0'
+created: '2026-06-17'

--- a/docs/superpowers/plans/2026-06-17-agent-session-persistence/_prose.md
+++ b/docs/superpowers/plans/2026-06-17-agent-session-persistence/_prose.md
@@ -1,0 +1,20 @@
+# agent-session persistence + liveness (agent-images)
+
+Fixes surfaced by the alert-agent live Test Plan. Three driver/base changes, gating the frank plan.
+
+- **C (Phase 1) — liveness check:** `ensure_session` must stop trusting bare `has-session`. A session
+  can exist as a DEAD bash shell (tmux-continuum restored it, or claude crashed). Probe the pane for
+  the `❯` REPL prompt within a short bounded wait; if it isn't a live claude REPL, kill + recreate.
+  This is the load-bearing fix — it makes the driver self-correcting regardless of how a dead session
+  appeared (it's what actually broke the operator's DMs).
+- **E (Phase 2) — persistence + context mgmt:** launch `claude --session-id <uuidv5(session_id)>
+  --permission-mode auto` so each named session resumes a PVC-persisted conversation across restarts
+  (memory). On a request after >12h idle, `/clear` first (fresh conversation, same stable id). When
+  context >60%, `/compact` (best-effort; the parse target + the --session-id resume behaviour are
+  live-verified on the pod — A–D don't depend on E, so it can degrade to fresh-per-launch).
+- **B (Phase 3) — continuum conditional:** `agent-shell-base` tmux config disables continuum-restore
+  when `AGENT_TMUX_RESTORE=off`, default-on so human shells are unchanged. Cleanliness on top of C.
+
+Gates the frank plan: merge → CI builds a new multi-agent-shell tag → frank sets the env on
+alert-agent + n8n-01 and bumps both image SHAs. Tests via the PATH-injected FAKE_TMUX stub; RED
+verified against HEAD.

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
@@ -15,10 +15,12 @@ on the image's python3 with no extra deps.
 import fcntl
 import json
 import os
+import re
 import secrets
 import subprocess
 import sys
 import time
+import uuid
 
 
 def _env(new, old, default):
@@ -46,6 +48,19 @@ READY_TIMEOUT_S = float(_env("AGENT_SESSION_READY_TIMEOUT_S", "STOA_READY_TIMEOU
 # or crashed claude never shows ❯, so the probe gives up fast and recreates.
 READY_PROBE_S = float(_env("AGENT_SESSION_READY_PROBE_S", "STOA_READY_PROBE_S", "3"))
 PORT = int(_env("AGENT_SESSION_PORT", "STOA_SESSION_PORT", "8765"))
+# Fix E — persistent resumable conversations. last_activity timestamps live on
+# the PVC beside the turn counter; an idle gap > IDLE_RESET_S triggers a /clear
+# (fresh conversation, SAME --session-id) before the next message. COMPACT_PCT is
+# the best-effort proactive-compaction threshold (percent of context used).
+LAST_DIR = _env("AGENT_SESSION_LAST_DIR", "STOA_LAST_DIR", os.path.join(HOME, ".agent-session", "last"))
+IDLE_RESET_S = float(_env("AGENT_SESSION_IDLE_RESET_S", "STOA_IDLE_RESET_S", str(12 * 3600)))
+COMPACT_PCT = int(_env("AGENT_SESSION_COMPACT_PCT", "STOA_COMPACT_PCT", "60"))
+
+# Fixed namespace for deriving a stable, valid UUID from a human session_id
+# (uuid5). Same session_id → same uuid → claude --session-id resumes the same
+# PVC-persisted conversation across pod restarts. Never change this constant
+# (it would orphan every existing conversation jsonl).
+SESSION_UUID_NAMESPACE = uuid.UUID("6f3b9c1e-1a2b-4c3d-8e4f-5a6b7c8d9e0f")
 
 # The claude REPL input-prompt glyph: empirically the cold→ready signal (the pane
 # is EMPTY for the first ~5s of boot, then the ❯ prompt + "auto mode" status line
@@ -68,9 +83,19 @@ LAUNCH_PROFILES = {
 DEFAULT_AGENT = "claude"
 
 
-def launch_command(agent):
-    # Unknown agent → fall back to the verified claude profile rather than
-    # launching nothing (which would leave send() to time out mysteriously).
+def session_uuid(session_id):
+    # Deterministic, valid UUID for `claude --session-id` (uuid5 → reproducible,
+    # no persisted mapping). Same session_id always resumes the same conversation.
+    return str(uuid.uuid5(SESSION_UUID_NAMESPACE, session_id))
+
+
+def launch_command(agent, session_id=None):
+    # claude gets a per-session --session-id (Fix E) so the conversation persists
+    # on the PVC and resumes across pod restarts. Other (best-effort) profiles are
+    # unchanged. Unknown agent → fall back to the verified static claude profile
+    # rather than launching nothing (which would leave send() to time out).
+    if agent == "claude" and session_id is not None:
+        return f"claude --session-id {session_uuid(session_id)} --permission-mode auto"
     return LAUNCH_PROFILES.get(agent, LAUNCH_PROFILES[DEFAULT_AGENT])
 
 
@@ -122,7 +147,7 @@ def ensure_session(session_id, agent=DEFAULT_AGENT):
 
 def _create_session(session_id, agent):
     pretrust()
-    tmux("new-session", "-d", "-s", session_id, launch_command(agent))
+    tmux("new-session", "-d", "-s", session_id, launch_command(agent, session_id))
     # Cold-start gate: a just-launched REPL is not yet accepting input (the pane
     # is empty for several seconds). Block until it is, so the first submit's
     # Enter is not dropped. CAVEAT: under the threaded server a SECOND send for
@@ -229,6 +254,50 @@ def bump_turn(session_id):
     return turn
 
 
+def read_last_activity(session_id):
+    # Unix timestamp of the last turn for this session, or None if there has
+    # never been one (a brand-new session must NOT be /clear'd — None, not 0).
+    path = os.path.join(LAST_DIR, session_id + ".last")
+    try:
+        with open(path) as fh:
+            return float(fh.read().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def touch_last_activity(session_id):
+    os.makedirs(LAST_DIR, exist_ok=True)
+    path = os.path.join(LAST_DIR, session_id + ".last")
+    tmp = path + ".tmp"
+    with open(tmp, "w") as fh:
+        fh.write(str(time.time()))
+    os.replace(tmp, path)
+
+
+_CONTEXT_PCT_RE = re.compile(r"(\d{1,3})\s*%")
+
+
+def context_pct(pane):
+    # Best-effort parse of claude's context-usage indicator → percent USED (0-100)
+    # or None when absent/unparseable. The EXACT live string/location is a
+    # live-verify item (P2.T3.S2); this targets a "context … NN%" line and inverts
+    # an explicit "left"/"remaining" wording. None → defer to claude auto-compact.
+    for line in pane.splitlines():
+        low = line.lower()
+        if "context" not in low:
+            continue
+        m = _CONTEXT_PCT_RE.search(line)
+        if not m:
+            continue
+        pct = int(m.group(1))
+        if pct > 100:
+            continue
+        if "left" in low or "remaining" in low:
+            pct = 100 - pct
+        return pct
+    return None
+
+
 def response(session_id, agent, status, turn, payload):
     return {"session_id": session_id, "agent": agent, "status": status,
             "turn": turn, "payload": payload}
@@ -241,6 +310,17 @@ def send(req):
     timeout_s = float(req.get("timeout_s", 300))
 
     ensure_session(session_id, agent)
+
+    # Idle reset (Fix E): a persisted conversation idle > IDLE_RESET_S is /clear'd
+    # first (fresh conversation, SAME --session-id) so a stale/huge context does
+    # not bleed into the new ask. A brand-new session (last_activity is None) is
+    # left alone — nothing to clear.
+    last = read_last_activity(session_id)
+    if last is not None and (time.time() - last) > IDLE_RESET_S:
+        submit(session_id, "/clear")
+        time.sleep(SETTLE_S)
+    # Mark activity for this turn regardless of outcome (bounds the next idle gap).
+    touch_last_activity(session_id)
 
     # Per-turn output file (unique nonce → no stale-reply ambiguity).
     os.makedirs(OUT_DIR, exist_ok=True)
@@ -274,7 +354,14 @@ def send(req):
                 os.remove(outfile)
             except OSError:
                 pass
-            return response(session_id, agent, "ok", bump_turn(session_id), payload)
+            turn = bump_turn(session_id)
+            # Proactive compaction (Fix E, best-effort): if the context indicator
+            # reads >= COMPACT_PCT used, /compact to bound growth. None/unparseable
+            # → defer to claude's own near-limit auto-compact (no crash).
+            pct = context_pct(_pane(session_id))
+            if pct is not None and pct >= COMPACT_PCT:
+                submit(session_id, "/compact")
+            return response(session_id, agent, "ok", turn, payload)
         time.sleep(POLL_S)
 
     return response(session_id, agent, "timeout", read_turn(session_id), None)

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
@@ -280,21 +280,21 @@ _CONTEXT_PCT_RE = re.compile(r"(\d{1,3})\s*%")
 def context_pct(pane):
     # Best-effort parse of claude's context-usage indicator → percent USED (0-100)
     # or None when absent/unparseable. The EXACT live string/location is a
-    # live-verify item (P2.T3.S2); this targets a "context … NN%" line and inverts
-    # an explicit "left"/"remaining" wording. None → defer to claude auto-compact.
+    # live-verify item (P2.T3.S2). For each "context" line, take the FIRST %-number
+    # that is <= 100 (finditer skips token counts like 200000%-of-nothing and any
+    # >100 garbage — M2); read it as % USED, unless the line says "left"/"remaining"
+    # WITHOUT "used" (then invert — M1). None → defer to claude auto-compact.
     for line in pane.splitlines():
         low = line.lower()
         if "context" not in low:
             continue
-        m = _CONTEXT_PCT_RE.search(line)
-        if not m:
-            continue
-        pct = int(m.group(1))
-        if pct > 100:
-            continue
-        if "left" in low or "remaining" in low:
-            pct = 100 - pct
-        return pct
+        for m in _CONTEXT_PCT_RE.finditer(line):
+            pct = int(m.group(1))
+            if pct > 100:
+                continue
+            if "used" not in low and ("left" in low or "remaining" in low):
+                return 100 - pct
+            return pct
     return None
 
 
@@ -304,6 +304,21 @@ def response(session_id, agent, status, turn, payload):
 
 
 def send(req):
+    # Serialize WHOLE turns per session_id across THREADS and PROCESSES (C1): the
+    # served endpoint is a ThreadingHTTPServer and the CLI `send` is a separate
+    # process, so without this a concurrent same-session call would run
+    # ensure_session's liveness probe against a MID-TURN REPL (no ❯ while it streams)
+    # and kill the in-flight session. flock (not threading.Lock) covers BOTH
+    # consumers; a different session_id locks a different file → no contention.
+    session_id = req["session_id"]
+    os.makedirs(TURN_DIR, exist_ok=True)
+    lockpath = os.path.join(TURN_DIR, session_id + ".send.lock")
+    with open(lockpath, "w") as lk:
+        fcntl.flock(lk, fcntl.LOCK_EX)
+        return _send_locked(req)
+
+
+def _send_locked(req):
     session_id = req["session_id"]
     agent = req.get("agent", "claude")
     message = req["message"]
@@ -312,15 +327,16 @@ def send(req):
     ensure_session(session_id, agent)
 
     # Idle reset (Fix E): a persisted conversation idle > IDLE_RESET_S is /clear'd
-    # first (fresh conversation, SAME --session-id) so a stale/huge context does
-    # not bleed into the new ask. A brand-new session (last_activity is None) is
-    # left alone — nothing to clear.
+    # first (fresh conversation, SAME --session-id) so a stale/huge context does not
+    # bleed into the new ask. A brand-new session (last_activity None) is left alone.
+    # NB: if Fix C just recreated a dead session this may /clear an already-fresh
+    # conversation — a harmless no-op (I1).
     last = read_last_activity(session_id)
     if last is not None and (time.time() - last) > IDLE_RESET_S:
         submit(session_id, "/clear")
-        time.sleep(SETTLE_S)
-    # Mark activity for this turn regardless of outcome (bounds the next idle gap).
-    touch_last_activity(session_id)
+        # Re-gate: confirm the prompt returned before pasting the real message, so a
+        # slow /clear can't concatenate with the message in the input box (I3).
+        wait_ready(session_id, READY_PROBE_S)
 
     # Per-turn output file (unique nonce → no stale-reply ambiguity).
     os.makedirs(OUT_DIR, exist_ok=True)
@@ -355,9 +371,15 @@ def send(req):
             except OSError:
                 pass
             turn = bump_turn(session_id)
-            # Proactive compaction (Fix E, best-effort): if the context indicator
-            # reads >= COMPACT_PCT used, /compact to bound growth. None/unparseable
-            # → defer to claude's own near-limit auto-compact (no crash).
+            # Touch on SUCCESS only (I2): a stuck/timing-out session is NOT marked
+            # active, so after IDLE_RESET_S it trips the idle /clear recovery above —
+            # "last conversation" = the last real exchange, per the operator's intent.
+            touch_last_activity(session_id)
+            # Proactive compaction (Fix E, best-effort): if the context indicator reads
+            # >= COMPACT_PCT used, /compact to bound growth; None/unparseable → defer to
+            # claude's near-limit auto-compact. Safe: payload already read+removed and
+            # turn bumped, so /compact can't corrupt THIS turn; the per-session flock
+            # serializes the NEXT turn so its ensure_session won't probe mid-compaction (N1).
             pct = context_pct(_pane(session_id))
             if pct is not None and pct >= COMPACT_PCT:
                 submit(session_id, "/compact")

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
@@ -41,6 +41,10 @@ SETTLE_S = float(_env("AGENT_SESSION_SETTLE_S", "STOA_SETTLE_S", "0.5"))
 # Max wait for a freshly-created session's REPL to start accepting input before
 # the first submit (cold-start gate). On timeout we proceed best-effort.
 READY_TIMEOUT_S = float(_env("AGENT_SESSION_READY_TIMEOUT_S", "STOA_READY_TIMEOUT_S", "30"))
+# Short bound for the liveness probe of an ALREADY-EXISTING session (Fix C). A
+# warm REPL answers on the first capture; a dead bash shell (continuum-restored)
+# or crashed claude never shows ❯, so the probe gives up fast and recreates.
+READY_PROBE_S = float(_env("AGENT_SESSION_READY_PROBE_S", "STOA_READY_PROBE_S", "3"))
 PORT = int(_env("AGENT_SESSION_PORT", "STOA_SESSION_PORT", "8765"))
 
 # The claude REPL input-prompt glyph: empirically the cold→ready signal (the pane
@@ -99,49 +103,76 @@ def pretrust():
 
 def ensure_session(session_id, agent=DEFAULT_AGENT):
     # Auto-create the session (interactive agent CLI, never -p) if absent, so
-    # the caller's session_id drives whatever it names. The launch command is
-    # the per-agent profile; its auto-approve flag lets the session write its
-    # per-turn output file without a prompt, short of a full permissions
-    # bypass. Unauthenticated until the operator logs the agent in. Concurrency-
-    # safe: a racing dup new-session errors harmlessly.
+    # the caller's session_id drives whatever it names. Concurrency-safe: a
+    # racing dup new-session errors harmlessly.
+    #
+    # Fix C — never trust a bare `has-session`. An EXISTING session also answers
+    # has-session when it is a continuum-restored bash shell or a crashed claude
+    # pane; pasting a DM into a dead bash shell yields `syntax error near (` and a
+    # full timeout. So probe an existing session for a LIVE REPL with a short
+    # bound; if it is not live, kill + recreate (generalizes the old
+    # creation-only readiness gate to cover dead/restored panes too).
     if tmux("has-session", "-t", session_id).returncode != 0:
-        pretrust()
-        tmux("new-session", "-d", "-s", session_id, launch_command(agent))
-        # Cold-start gate: a just-launched REPL is not yet accepting input (the
-        # pane is empty for several seconds). Block until it is, so the first
-        # submit's Enter is not dropped. Gated on creation only, to spare warm
-        # turns the poll. CAVEAT: under the threaded server a SECOND send for the
-        # same session_id may see has-session==0 (this branch just created it)
-        # and skip the gate while the pane is still booting — submit()'s verified
-        # retry is the backstop for that race (and for a genuinely-wedged session
-        # an unconditional gate would only add a dead 30s before the real timeout).
-        wait_ready(session_id)
+        _create_session(session_id, agent)
+        return
+    if not _is_live_repl(session_id):
+        tmux("kill-session", "-t", session_id)
+        _create_session(session_id, agent)
+
+
+def _create_session(session_id, agent):
+    pretrust()
+    tmux("new-session", "-d", "-s", session_id, launch_command(agent))
+    # Cold-start gate: a just-launched REPL is not yet accepting input (the pane
+    # is empty for several seconds). Block until it is, so the first submit's
+    # Enter is not dropped. CAVEAT: under the threaded server a SECOND send for
+    # the same session_id may race this create — submit()'s verified retry is the
+    # backstop (and for a genuinely-wedged session an unconditional gate would
+    # only add a dead 30s before the real timeout).
+    wait_ready(session_id)
 
 
 def _pane(session_id):
     return tmux("capture-pane", "-p", "-t", session_id).stdout or ""
 
 
-def wait_ready(session_id, timeout_s=READY_TIMEOUT_S):
-    # Poll the pane until the REPL accepts input: the ❯ prompt marker is the
-    # primary signal; a non-empty pane that is unchanged across two polls is the
-    # version-drift fallback (an agent/version that doesn't render ❯) — note it
-    # CAN return early if a version paints a static splash frame for ≥2 polls
-    # before accepting input; submit()'s verified retry backstops a too-early
-    # proceed. On timeout proceed best-effort — never hang the request.
+def _poll_ready(session_id, timeout_s, idle_fallback=True):
+    # Shared readiness poll. `idle_fallback` decides how a non-empty pane WITHOUT
+    # the ❯ marker is treated:
+    #   * True  (wait_ready / cold-create): a pane unchanged across two polls is
+    #     accepted as ready — version-drift tolerance for an agent that never
+    #     renders ❯. (CAN return early on a static splash frame; submit()'s
+    #     verified retry backstops a too-early proceed.)
+    #   * False (liveness probe of an EXISTING session): only ❯ counts as live. A
+    #     stable non-empty pane is exactly the dead-bash-shell case we must catch,
+    #     so the idle fallback is disabled — never mistake a dead shell for a REPL.
     deadline = time.monotonic() + timeout_s
     last = None
     while time.monotonic() < deadline:
         pane = _pane(session_id)
         if READY_MARKER in pane:
             return True
-        if pane.strip() and pane == last:
+        if idle_fallback and pane.strip() and pane == last:
             return True
         last = pane
         time.sleep(POLL_S)
-    print(f"agent-session: session {session_id} not ready after {timeout_s}s; proceeding",
-          file=sys.stderr)
     return False
+
+
+def wait_ready(session_id, timeout_s=READY_TIMEOUT_S):
+    # Cold-create gate: proceed best-effort on timeout — never hang the request.
+    ok = _poll_ready(session_id, timeout_s, idle_fallback=True)
+    if not ok:
+        print(f"agent-session: session {session_id} not ready after {timeout_s}s; proceeding",
+              file=sys.stderr)
+    return ok
+
+
+def _is_live_repl(session_id):
+    # Quick, STRICT liveness probe for an existing session (Fix C): a live claude
+    # REPL renders ❯ within READY_PROBE_S; a dead bash shell / crashed pane never
+    # does. idle_fallback=False so a stable shell prompt is NOT counted as live.
+    return _poll_ready(session_id, READY_PROBE_S, idle_fallback=False)
 
 
 def _input_box_has_text(pane):

--- a/multi-agent-shell/tests/test_agent_session.py
+++ b/multi-agent-shell/tests/test_agent_session.py
@@ -54,6 +54,17 @@ def p(n): return os.path.join(D, n)
 a = sys.argv[1:]
 cmd = a[0] if a else ""
 open(p("calls.log"), "a").write(cmd + " " + " ".join(a[1:]) + "\n")
+def _target(args):
+    if "-t" in args:
+        i = args.index("-t")
+        if i + 1 < len(args):
+            return args[i + 1]
+    return ""
+if cmd == "kill-session":
+    # Record the killed session id so capture-pane can flip a DEAD session to a
+    # ready REPL after the driver recreates it (Fix C liveness recreate path).
+    open(p("killed.log"), "a").write(_target(a) + "\n")
+    sys.exit(0)
 if cmd == "has-session":
     try: code = int((open(p("has.code")).read().strip() or "0"))
     except Exception: code = 0
@@ -88,7 +99,14 @@ if cmd == "capture-pane":
     cc = p("capture.count")
     n = int(open(cc).read() or "0") if os.path.exists(cc) else 0
     open(cc, "w").write(str(n + 1))
-    if n < int(os.environ.get("FAKE_COLD_CAPTURES", "0")):
+    tgt = _target(a)
+    killed = bool(tgt) and os.path.exists(p("killed.log")) and tgt in open(p("killed.log")).read().split()
+    if os.environ.get("FAKE_DEAD_SESSION") == "1" and not killed:
+        # An EXISTING but DEAD session (continuum-restored bash shell / crashed
+        # claude): a stable shell prompt, NO ❯, until the driver KILLS + recreates
+        # it — after the kill marker the recreated session renders the ready ❯.
+        sys.stdout.write("agent@pod:~$ \n")
+    elif n < int(os.environ.get("FAKE_COLD_CAPTURES", "0")):
         sys.stdout.write("")            # cold boot: REPL not ready → empty pane
     else:
         box = open(p("box.txt")).read() if os.path.exists(p("box.txt")) else ""
@@ -307,6 +325,60 @@ def test_pretrust_seeds_auto_mode_flag(harness):
     harness.run(SEND_REQ, session_exists=False)
     proj = json.loads((harness.home / ".claude.json").read_text()).get("projects", {})
     assert proj.get(str(harness.home), {}).get("hasSeenAutoModeEntryWarning") is True
+
+
+# --- Fix C: driver liveness check (never trust a dead existing session) -------
+
+def test_dead_existing_session_is_recreated(tmp_path):
+    # has-session reports the session EXISTS, but its pane is a dead bash shell
+    # (continuum-restored / crashed claude — no ❯). The driver must detect this,
+    # kill the dead session, recreate it, and submit to the fresh REPL.
+    h = _make_harness(tmp_path)
+    h.env["FAKE_DEAD_SESSION"] = "1"
+    h.env["AGENT_SESSION_READY_PROBE_S"] = "0.3"   # short bound so the probe gives up fast
+    e = dict(h.env)
+    (h.fdir / "has.code").write_text("0")          # session EXISTS (but dead)
+    out = json.loads(subprocess.run(
+        [sys.executable, str(h.drv), "send", json.dumps(SEND_REQ)],
+        capture_output=True, text=True, env=e, timeout=30).stdout)
+    assert out["status"] == "ok" and out["payload"] == PAYLOAD
+    calls = (h.fdir / "calls.log").read_text().splitlines()
+    sid = SEND_REQ["session_id"]
+    kill_idx = next((i for i, l in enumerate(calls)
+                     if l.startswith("kill-session") and sid in l), None)
+    new_idx = next((i for i, l in enumerate(calls)
+                    if l.startswith("new-session") and sid in l), None)
+    assert kill_idx is not None, f"dead session must be killed; calls={calls}"
+    assert new_idx is not None and new_idx > kill_idx, \
+        f"must recreate AFTER killing the dead session; calls={calls}"
+
+
+def test_live_existing_session_is_reused(tmp_path):
+    # A live ❯ REPL that already exists must be reused untouched — no kill, no
+    # recreate (warm path, no added latency beyond a single readiness capture).
+    h = _make_harness(tmp_path)
+    e = dict(h.env)
+    (h.fdir / "has.code").write_text("0")          # exists + (default) ready ❯ pane
+    out = json.loads(subprocess.run(
+        [sys.executable, str(h.drv), "send", json.dumps(SEND_REQ)],
+        capture_output=True, text=True, env=e, timeout=30).stdout)
+    assert out["status"] == "ok"
+    calls = (h.fdir / "calls.log").read_text()
+    assert "kill-session" not in calls, f"a live session must not be killed; calls={calls!r}"
+
+
+def test_absent_session_still_creates(tmp_path):
+    # Regression: a genuinely-absent session still takes the create + wait_ready
+    # path (Fix C must not break the original cold-create flow).
+    h = _make_harness(tmp_path)
+    e = dict(h.env)
+    (h.fdir / "has.code").write_text("1")          # session ABSENT
+    out = json.loads(subprocess.run(
+        [sys.executable, str(h.drv), "send", json.dumps(SEND_REQ)],
+        capture_output=True, text=True, env=e, timeout=30).stdout)
+    assert out["status"] == "ok"
+    assert SEND_REQ["session_id"] in (h.fdir / "new.log").read_text()
+    assert "kill-session" not in (h.fdir / "calls.log").read_text()
 
 
 def test_s6_service_run_gated_on_serve_flag():

--- a/multi-agent-shell/tests/test_agent_session.py
+++ b/multi-agent-shell/tests/test_agent_session.py
@@ -380,6 +380,25 @@ def test_live_existing_session_is_reused(tmp_path):
     assert out["status"] == "ok"
     calls = (h.fdir / "calls.log").read_text()
     assert "kill-session" not in calls, f"a live session must not be killed; calls={calls!r}"
+    # N3: a live ❯ session returns on the FIRST probe capture — the probe must not
+    # poll its full bound (READY_PROBE_S/POLL_S would be ~60 captures if it looped).
+    assert int((h.fdir / "capture.count").read_text()) < 10, "warm reuse must not poll the probe loop"
+
+
+def test_slow_live_existing_session_reused(tmp_path):
+    # N2: an EXISTING session briefly blank (mid-render) that shows ❯ within the
+    # probe bound must be REUSED, not killed (warm-but-rendering, the boundary the
+    # C1 hazard lives on). FAKE_COLD_CAPTURES blanks the first 2 captures, then ❯.
+    h = _make_harness(tmp_path)
+    h.env["FAKE_COLD_CAPTURES"] = "2"
+    e = dict(h.env)
+    (h.fdir / "has.code").write_text("0")          # session EXISTS
+    out = json.loads(subprocess.run(
+        [sys.executable, str(h.drv), "send", json.dumps(SEND_REQ)],
+        capture_output=True, text=True, env=e, timeout=30).stdout)
+    assert out["status"] == "ok"
+    assert "kill-session" not in (h.fdir / "calls.log").read_text(), \
+        "a slow-but-live REPL (renders ❯ within the probe) must be reused, not killed"
 
 
 def test_absent_session_still_creates(tmp_path):
@@ -470,6 +489,14 @@ def test_context_pct_parses():
     assert cp("Context left until auto-compact: 30%") == 70, "'left' wording must invert to % used"
     assert cp("no indicator here\n❯ ") is None
     assert cp("❯ \n⏵⏵ auto mode on\n") is None
+
+
+def test_context_pct_disambiguates_used_and_left():
+    # M1: a line carrying BOTH "used" and "left" must read the USED number (no
+    # inversion). M2: a leading token count must not derail the parse.
+    cp = _driver_module().context_pct
+    assert cp("Context: 45% used · 55% left until auto-compact") == 45
+    assert cp("context window 200000 tokens — 80% used") == 80
 
 
 def _run_with_ctx(harness, pct):

--- a/multi-agent-shell/tests/test_agent_session.py
+++ b/multi-agent-shell/tests/test_agent_session.py
@@ -15,6 +15,8 @@ proves the deprecated `STOA_*` aliases still drive identical behaviour.
 
 Modeled on the repo's existing pytest setup (`kali/tests/test_*.py`).
 """
+import importlib.machinery
+import importlib.util
 import json
 import os
 import socket
@@ -72,7 +74,12 @@ if cmd == "has-session":
 if cmd == "new-session":
     open(p("new.log"), "a").write(" ".join(a) + "\n"); sys.exit(0)
 if cmd == "load-buffer":
-    open(p("buffer.txt"), "w").write(sys.stdin.read()); sys.exit(0)
+    data = sys.stdin.read()
+    open(p("buffer.txt"), "w").write(data)
+    # Record the first line of every pasted buffer so tests can assert the
+    # ordering of control submits (/clear, /compact) relative to the message.
+    open(p("pastes.log"), "a").write((data.splitlines()[0] if data else "") + "\n")
+    sys.exit(0)
 if cmd == "paste-buffer":
     buf = open(p("buffer.txt")).read() if os.path.exists(p("buffer.txt")) else ""
     open(p("pending.txt"), "w").write(buf); sys.exit(0)
@@ -114,7 +121,11 @@ if cmd == "capture-pane":
         # FAKE_HISTORY_PROMPT adds a transcript line that ALSO contains ❯ above the
         # input box — the driver must read the LAST ❯ line (the box), not this one.
         history = "echoed ❯ old input\n" if os.environ.get("FAKE_HISTORY_PROMPT") == "1" else "some history\n"
-        sys.stdout.write(history + "❯ " + box + "\n⏵⏵ auto mode on\n")
+        # Optional context-usage indicator line (Fix E 60% compaction). The exact
+        # live string is a live-verify item (P2.T3.S2); the stub emits the parser's
+        # target form ("context: NN% used") so the unit path is exercisable.
+        ctx = ("context: " + os.environ["FAKE_CONTEXT_PCT"] + "% used\n") if os.environ.get("FAKE_CONTEXT_PCT") else ""
+        sys.stdout.write(history + "❯ " + box + "\n⏵⏵ auto mode on\n" + ctx)
     sys.exit(0)
 sys.exit(0)
 '''
@@ -142,6 +153,7 @@ def _make_harness(tmp_path, *, env_prefix="AGENT_SESSION_"):
     env["FAKE_DIR"] = str(fdir)
     env[env_prefix + "TURN_DIR"] = str(tmp_path / "turns")
     env[env_prefix + "OUT_DIR"] = str(tmp_path / "out")
+    env[env_prefix + "LAST_DIR"] = str(tmp_path / "last")
     env[env_prefix + "POLL_S"] = "0.05"
     env[env_prefix + "SETTLE_S"] = "0"
     env["FAKE_PAYLOAD"] = json.dumps(PAYLOAD)
@@ -226,18 +238,21 @@ def test_deprecated_stoa_aliases_still_drive(tmp_path):
     assert (tmp_path / "turns" / (SEND_REQ["session_id"] + ".turn")).exists()
 
 
-@pytest.mark.parametrize("agent,expected_launch", [
-    ("claude", "claude --permission-mode auto"),
-    ("codex", "codex --full-auto"),
-    ("antigravity", "agy --yolo"),
+@pytest.mark.parametrize("agent,expected_tokens", [
+    # claude embeds a per-session --session-id uuid (Fix E); codex/antigravity
+    # profiles are unchanged. Token-list assertion tolerates the injected uuid.
+    ("claude", ["claude", "--session-id", "--permission-mode auto"]),
+    ("codex", ["codex --full-auto"]),
+    ("antigravity", ["agy --yolo"]),
 ])
-def test_per_agent_launch_profile(harness, agent, expected_launch):
+def test_per_agent_launch_profile(harness, agent, expected_tokens):
     # ensure_session dispatches on the `agent` field via the launch-profile
     # table; the FAKE_TMUX records the new-session command verbatim.
     harness.run(dict(SEND_REQ, agent=agent), session_exists=False)
     newlog = (harness.fdir / "new.log").read_text()
-    assert expected_launch in newlog, \
-        f"agent {agent!r} must launch via `{expected_launch}`, got: {newlog!r}"
+    for tok in expected_tokens:
+        assert tok in newlog, \
+            f"agent {agent!r} launch missing {tok!r}, got: {newlog!r}"
 
 
 def test_unknown_agent_falls_back_to_claude(harness):
@@ -379,6 +394,112 @@ def test_absent_session_still_creates(tmp_path):
     assert out["status"] == "ok"
     assert SEND_REQ["session_id"] in (h.fdir / "new.log").read_text()
     assert "kill-session" not in (h.fdir / "calls.log").read_text()
+
+
+# --- Fix E: persistent --session-id sessions + idle /clear + 60% compaction ----
+
+def _driver_module():
+    # Import the baked driver as a module (no .py suffix → load by path) so unit
+    # tests can call its pure helpers (session_uuid, context_pct) directly. The
+    # __main__ guard prevents main() from running on import.
+    loader = importlib.machinery.SourceFileLoader("agent_session_drv", str(DRIVER))
+    spec = importlib.util.spec_from_loader("agent_session_drv", loader)
+    mod = importlib.util.module_from_spec(spec)
+    loader.exec_module(mod)   # DRIVER has no .py suffix → explicit SourceFileLoader
+    return mod
+
+
+def _paste_first_lines(harness):
+    pl = harness.fdir / "pastes.log"
+    return pl.read_text().splitlines() if pl.exists() else []
+
+
+def test_session_uuid_is_deterministic():
+    import uuid
+    mod = _driver_module()
+    a = mod.session_uuid("alert-agent-tg-2034763022")
+    b = mod.session_uuid("alert-agent-tg-2034763022")
+    c = mod.session_uuid("alert-agent-ops")
+    assert a == b, "same session_id must map to the same uuid (resume across restarts)"
+    assert uuid.UUID(a), "must be a valid UUID for claude --session-id"
+    assert a != c, "different session_ids must map to different uuids"
+
+
+def test_launch_uses_session_id_uuid(harness):
+    # claude launches with --session-id <uuid5(session_id)> so the conversation
+    # persists/resumes on the PVC across pod restarts.
+    mod = _driver_module()
+    harness.run(SEND_REQ, session_exists=False)
+    newlog = (harness.fdir / "new.log").read_text()
+    expected = mod.session_uuid(SEND_REQ["session_id"])
+    assert f"--session-id {expected}" in newlog, \
+        f"launch must pin the deterministic session uuid, got: {newlog!r}"
+    assert "--permission-mode auto" in newlog
+
+
+def test_idle_over_12h_clears_first(harness):
+    # A persisted conversation idle > 12h must be /clear'd (fresh conversation,
+    # SAME uuid) BEFORE the new message, and last_activity refreshed.
+    sid = SEND_REQ["session_id"]
+    last_dir = Path(harness.env["AGENT_SESSION_LAST_DIR"]); last_dir.mkdir(parents=True, exist_ok=True)
+    la = last_dir / (sid + ".last")
+    old = time.time() - (13 * 3600)
+    la.write_text(str(old))
+    out = json.loads(harness.run(SEND_REQ).stdout)   # has.code defaults to live (0)
+    assert out["status"] == "ok"
+    pastes = _paste_first_lines(harness)
+    assert "/clear" in pastes, f"idle>12h must submit /clear; pastes={pastes}"
+    assert pastes.index("/clear") < next(i for i, l in enumerate(pastes) if l.startswith("Investigate")), \
+        f"/clear must precede the message; pastes={pastes}"
+    assert float(la.read_text()) > old, "last_activity must be refreshed after the turn"
+
+
+def test_recent_activity_no_clear(harness):
+    # Recent activity (< 12h) must NOT clear — the conversation continues.
+    sid = SEND_REQ["session_id"]
+    last_dir = Path(harness.env["AGENT_SESSION_LAST_DIR"]); last_dir.mkdir(parents=True, exist_ok=True)
+    (last_dir / (sid + ".last")).write_text(str(time.time()))
+    out = json.loads(harness.run(SEND_REQ).stdout)
+    assert out["status"] == "ok"
+    assert "/clear" not in _paste_first_lines(harness), "recent activity must not /clear"
+
+
+def test_context_pct_parses():
+    cp = _driver_module().context_pct
+    assert cp("context: 70% used\n❯ ") == 70
+    assert cp("Context left until auto-compact: 30%") == 70, "'left' wording must invert to % used"
+    assert cp("no indicator here\n❯ ") is None
+    assert cp("❯ \n⏵⏵ auto mode on\n") is None
+
+
+def _run_with_ctx(harness, pct):
+    e = dict(harness.env)
+    if pct is not None:
+        e["FAKE_CONTEXT_PCT"] = str(pct)
+    (harness.fdir / "has.code").write_text("0")   # live session
+    return json.loads(subprocess.run(
+        [sys.executable, str(harness.drv), "send", json.dumps(SEND_REQ)],
+        capture_output=True, text=True, env=e, timeout=30).stdout)
+
+
+def test_compacts_when_context_over_threshold(harness):
+    # >= 60% context used after a successful turn → proactive /compact.
+    out = _run_with_ctx(harness, 70)
+    assert out["status"] == "ok"
+    assert "/compact" in _paste_first_lines(harness), "must /compact at 70% used"
+
+
+def test_no_compact_under_threshold(harness):
+    out = _run_with_ctx(harness, 40)
+    assert out["status"] == "ok"
+    assert "/compact" not in _paste_first_lines(harness), "must NOT /compact at 40% used"
+
+
+def test_no_compact_when_indicator_absent(harness):
+    # Unparseable/absent indicator → defer to claude auto-compact (no /compact, no crash).
+    out = _run_with_ctx(harness, None)
+    assert out["status"] == "ok"
+    assert "/compact" not in _paste_first_lines(harness)
 
 
 def test_s6_service_run_gated_on_serve_flag():


### PR DESCRIPTION
## Summary

Hardens the baked `agent-session` driver (in `multi-agent-shell`) and the
`agent-shell-base` tmux config so the agentic **alert-agent** reliably answers DMs
across pod restarts. This is the **gating** half of a two-repo change (the
`derio-net/frank` PR carries the Telegram-bridge menu/threading fixes + the
`AGENT_TMUX_RESTORE=off` env + the image-SHA bump).

- **Fix C — driver liveness check.** `ensure_session` no longer trusts a bare
  `has-session`: an existing session is probed for a live `❯` REPL (strict, short
  `READY_PROBE_S`); a dead bash shell (continuum-restored) or crashed claude is
  killed + recreated. This is the load-bearing fix for the live DM-into-bash
  failure (`syntax error near (` → 120s timeout → fallback).
- **Fix E — persistent resumable sessions.** Launch
  `claude --session-id <uuid5(session_id)> --permission-mode auto`, so each
  session resumes its PVC-persisted conversation across restarts. Idle > 12h →
  `/clear` first (fresh conversation, same id); proactive `/compact` at >= 60%
  context used (best-effort, falls back to claude auto-compact).
- **Fix B — gate continuum.** `agent-shell-base/etc/agent/tmux-resurrect.conf`
  gates `@continuum-restore` on `AGENT_TMUX_RESTORE` (default **on**); agent pods
  set it `off`, human shells keep restore.

**Spec:** `derio-net/frank:docs/superpowers/specs/2026-06-17--obs--alert-agent-session-reliability-design.md`
**Plan:** `docs/superpowers/plans/2026-06-17-agent-session-persistence/` (3 phases, TDD)

## Code review — findings and fixes

A code review of the C/E/B commits raised one Critical and several edge findings; all are fixed in `d2708dc`:

- **C1 (Critical):** the served endpoint is a `ThreadingHTTPServer` with no per-session lock, so two concurrent same-session POSTs let request B's liveness probe see a **mid-turn** REPL (no `❯` while streaming) and kill the in-flight session. Frank's bridge lock only protects alert-agent — **n8n-01 uses the same driver with no lock**. **Fix:** a driver-level per-session `flock` around the whole `send()` critical section, making the driver self-safe for any consumer.
- **I2:** `touch_last_activity` now fires on **success only**, so a stuck/timing-out session trips the idle `/clear` recovery instead of being marked perpetually active.
- **I3:** re-gate (`wait_ready`) after the idle `/clear` so a slow clear can't concatenate with the message in the input box.
- **M1/M2:** `context_pct` uses `finditer` + `used`/`left` disambiguation (a "used" line is never inverted; a leading token count no longer derails the parse).
- **N2/N3:** added tests for a slow-but-live existing REPL (reused, not killed) and a warm-path capture bound (probe returns on the first capture).
- **I1/N1:** clarifying comments. **M3** (`STOA_SESSION_PORT` alias naming) left as pre-existing/out-of-scope.

## Tests

TDD throughout (FAKE_TMUX stub, RED-verified against HEAD for each fix). Local full-suite is **33/35 green**; the 2 transient failures are the one socket-based integration test (`test_http_server_serves_session_send`) timing out under a momentary local machine-load spike (load avg > 80) — it passed in every clean run and is unrelated to these changes' logic. A clean CI run on this branch is the authoritative gate.

## Sequencing

Merge this first → CI builds a new `multi-agent-shell` tag → the frank PR sets
`AGENT_TMUX_RESTORE=off` on alert-agent + n8n-01 and bumps both image SHAs.

## Post-merge live-verify (operator)

Plan step P2.T3.S2 (deferred manual): confirm `claude --session-id <uuid>` resumes
on a 2nd launch (2.1.177) and capture the exact `/context` indicator string so the
`context_pct` parser can be tuned. Launcher provided at `/tmp/verify-e-live.sh`.
A-D do not depend on E, which degrades gracefully to fresh-session-per-launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
