### PR TITLE
fix(agent-session): OOM-safe --resume + MOTD auth path (re-land orphaned #130 commits)

### DIFF
--- a/multi-agent-shell/README.md
+++ b/multi-agent-shell/README.md
@@ -28,7 +28,7 @@ exception — it has no self-update and is refreshed by image rebuild (see note)
 
 | Harness | Bootstrap | Auth command | Credential file (on PV) | Update command |
 |---|---|---|---|---|
-| `claude` | `npm i -g @anthropic-ai/claude-code` (inherited from `agent-base`) | `claude login` | `~/.claude/credentials.json` | `claude update` |
+| `claude` | `npm i -g @anthropic-ai/claude-code` (inherited from `agent-base`) | `claude login` | `~/.claude/.credentials.json` | `claude update` |
 | `codex` | `npm i -g @openai/codex@${CODEX_VERSION}` | `codex login` | `~/.config/codex/auth.json` | `codex update` (or inventory `harnesses: codex: <ver>`) |
 | `agy` (antigravity) | `curl -fsSL …/install.sh \| bash -s -- --dir /usr/local/bin` (replaces gemini CLI) | `agy` (first run prompts the OAuth flow) | `~/.gemini/antigravity-cli/antigravity-oauth-token` | **image rebuild** (no self-update; not inventory-managed) |
 | `opencode` | `npm i -g opencode-ai@${OPENCODE_VERSION}` | `opencode auth login` | `~/.local/share/opencode/auth.json` | inventory `harnesses: opencode: <ver>` |

--- a/multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh
+++ b/multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh
@@ -31,7 +31,7 @@ check() {
 # and the OAuth token lands at ~/.gemini/antigravity-cli/antigravity-oauth-token
 # (confirmed 2026-06-15 by completing a real login in this image — a plain file,
 # not an OS-keyring entry, so this presence check works on a headless pod).
-check claude   .claude/credentials.json
+check claude   .claude/.credentials.json
 check codex    .config/codex/auth.json
 check agy      .gemini/antigravity-cli/antigravity-oauth-token   agy
 check opencode .local/share/opencode/auth.json                   "opencode auth login"

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
@@ -13,6 +13,7 @@ aliases (one migration cycle) when the new var is unset. Stdlib-only so it runs
 on the image's python3 with no extra deps.
 """
 import fcntl
+import glob
 import json
 import os
 import re
@@ -89,13 +90,27 @@ def session_uuid(session_id):
     return str(uuid.uuid5(SESSION_UUID_NAMESPACE, session_id))
 
 
+def _session_jsonl_exists(session_uuid_str):
+    # The session transcript persists on the PVC at
+    # ~/.claude/projects/<cwd-encoded>/<uuid>.jsonl. claude keys the project dir on
+    # the launch cwd (which we don't control here), so glob across project dirs —
+    # the uuid is unique, so it resolves to at most one file.
+    return bool(glob.glob(os.path.join(HOME, ".claude", "projects", "*", session_uuid_str + ".jsonl")))
+
+
 def launch_command(agent, session_id=None):
-    # claude gets a per-session --session-id (Fix E) so the conversation persists
-    # on the PVC and resumes across pod restarts. Other (best-effort) profiles are
-    # unchanged. Unknown agent → fall back to the verified static claude profile
-    # rather than launching nothing (which would leave send() to time out).
+    # claude (Fix E): an EXISTING transcript is reopened with --resume, which
+    # recovers the session after a graceful exit AND a hard kill/OOM — the latter
+    # leaves `--session-id` rejecting it as "Session ID already in use" (verified
+    # live; a graceful SIGTERM releases it, an OOM SIGKILL does NOT). A brand-NEW
+    # session uses --session-id to create it; --resume is only ever used when the
+    # jsonl exists, so the headless `--resume`-on-missing picker can never hang us.
+    # Other (best-effort) profiles unchanged; unknown agent → static claude profile.
     if agent == "claude" and session_id is not None:
-        return f"claude --session-id {session_uuid(session_id)} --permission-mode auto"
+        u = session_uuid(session_id)
+        if _session_jsonl_exists(u):
+            return f"claude --resume {u} --permission-mode auto"
+        return f"claude --session-id {u} --permission-mode auto"
     return LAUNCH_PROFILES.get(agent, LAUNCH_PROFILES[DEFAULT_AGENT])
 
 

--- a/multi-agent-shell/tests/test_agent_session.py
+++ b/multi-agent-shell/tests/test_agent_session.py
@@ -445,8 +445,8 @@ def test_session_uuid_is_deterministic():
 
 
 def test_launch_uses_session_id_uuid(harness):
-    # claude launches with --session-id <uuid5(session_id)> so the conversation
-    # persists/resumes on the PVC across pod restarts.
+    # A BRAND-NEW session (no transcript on disk) launches with --session-id
+    # <uuid5(session_id)> to create it; never --resume (that would picker-hang).
     mod = _driver_module()
     harness.run(SEND_REQ, session_exists=False)
     newlog = (harness.fdir / "new.log").read_text()
@@ -454,6 +454,21 @@ def test_launch_uses_session_id_uuid(harness):
     assert f"--session-id {expected}" in newlog, \
         f"launch must pin the deterministic session uuid, got: {newlog!r}"
     assert "--permission-mode auto" in newlog
+    assert "--resume" not in newlog, "a brand-new session must create with --session-id"
+
+
+def test_existing_transcript_resumes_oom_safe(harness):
+    # Fix E (OOM-safe): when the session transcript already exists (any prior boot),
+    # claude launches with --resume — which recovers the session after a graceful
+    # exit AND a hard kill/OOM, where --session-id would error "already in use".
+    u = _driver_module().session_uuid(SEND_REQ["session_id"])
+    proj = harness.home / ".claude" / "projects" / "-home-agent"
+    proj.mkdir(parents=True)
+    (proj / (u + ".jsonl")).write_text('{"type":"summary"}\n')   # a prior boot's transcript
+    harness.run(SEND_REQ, session_exists=False)
+    newlog = (harness.fdir / "new.log").read_text()
+    assert f"--resume {u}" in newlog, f"an existing transcript must launch with --resume; got {newlog!r}"
+    assert "--session-id" not in newlog, "must NOT --session-id an existing session (it may be 'in use')"
 
 
 def test_idle_over_12h_clears_first(harness):


### PR DESCRIPTION
## Summary

Re-lands two fixes that were **orphaned by the squash-merge of #130**: they were
pushed to #130's branch *after* it was squash-merged, so they never reached `main`
(verified: `main` has the C1 flock but neither the OOM `--resume` logic nor the
MOTD dot-path). Both are cherry-picked cleanly onto current `main`.

- **OOM/SIGKILL resume crash-loop (critical).** Live-verify on the pod found
  `claude --session-id <uuid>` REFUSES a session left "in use" by a **hard** kill:
  a graceful SIGTERM (normal restart) releases it, but an **OOM SIGKILL does not**
  → a post-OOM restart would error "Session ID already in use", claude exits, Fix C
  recreates with the same id, and it exits again → crash loop (E's whole point —
  surviving restarts — broken). Fix: `launch_command` reopens an existing
  transcript with `claude --resume <uuid>` (verified live to recover the
  hard-killed session that `--session-id` rejects); a brand-new session still uses
  `--session-id` (so `--resume` never runs on a missing id and can't picker-hang).
  Transcript presence is globbed across `~/.claude/projects/*/<uuid>.jsonl`.
- **Stale login MOTD.** The auth-status check looked for `~/.claude/credentials.json`
  but claude Code stores its token at `~/.claude/.credentials.json` (leading dot),
  so it always printed "✗ claude not logged in" despite valid auth. Corrected the
  path in the MOTD script + README.

## Tests

Full suite **35/35 green** locally on this main-based branch (the OOM-safe resume
test is RED-verified against the pre-fix `launch_command`). FAKE_TMUX stub; the
OOM test pre-creates a transcript and asserts `--resume` vs `--session-id`.

## Why this happened / follow-up

#130 was reviewed mid-session; the OOM + MOTD fixes came out of the *live-verify*
that ran after the review and were pushed to the same branch — which had already
been squash-merged. After this merges, the `multi-agent-shell` tag bump (auto-PR
via #570) brings both fixes to alert-agent + n8n-01.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
