### PR TITLE
fix(agent-shell-base): native-claude PATH on AGENT_HOME + bake memory-safe native install

### DIFF
--- a/agent-shell-base/Dockerfile
+++ b/agent-shell-base/Dockerfile
@@ -5,12 +5,20 @@ ARG AGENT_USER=agent
 ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 ARG AGENT_HOME=/home/agent
-# HOME tracks AGENT_HOME so supervised processes (sshd, supercronic, cont-init scripts)
-# do not silently fall back to the parent image's /home/claude.
+# HOME *and PATH* track AGENT_HOME so supervised processes (sshd, supercronic,
+# cont-init scripts, the agent-session driver) do not silently fall back to the
+# parent image's /home/claude. PATH matters specifically for the NON-login s6
+# agent-session driver: it launches `claude` via tmux with this baked PATH (not a
+# login shell, so the profile.d ~/.local/bin shim doesn't apply), and must resolve
+# the PV-installed NATIVE build at $AGENT_HOME/.local/bin — NOT the npm /usr/bin
+# shim, whose auto-updater can't write the root-owned npm prefix. (The base image
+# hardcodes /home/claude/.local/bin for its default user; re-set it here on
+# AGENT_HOME so every override — agent, or kali's claude — is correct.)
 # AGENT_GID is propagated alongside AGENT_UID so child images can reference
 # both at build time without re-declaring the ARG.
 ENV AGENT_USER=${AGENT_USER} AGENT_UID=${AGENT_UID} AGENT_GID=${AGENT_GID} \
-    AGENT_HOME=${AGENT_HOME} HOME=${AGENT_HOME}
+    AGENT_HOME=${AGENT_HOME} HOME=${AGENT_HOME} \
+    PATH=${AGENT_HOME}/.local/bin:/usr/local/bin:/usr/bin:/bin
 
 USER root
 

--- a/agent-shell-base/tests/test_agent_home_path.py
+++ b/agent-shell-base/tests/test_agent_home_path.py
@@ -1,0 +1,28 @@
+"""Guard: agent-shell-base must re-set PATH on AGENT_HOME, not leak the base
+image's hardcoded /home/claude/.local/bin.
+
+The non-login s6 agent-session driver launches `claude` via tmux with the baked
+ENV PATH (the profile.d ~/.local/bin shim applies only to LOGIN shells). If PATH
+points at /home/claude/.local/bin (the parent image's default user) instead of
+$AGENT_HOME/.local/bin, a non-kali shell (user `agent`, HOME /home/agent) resolves
+the npm /usr/bin/claude — whose auto-updater can't write the root-owned npm prefix
+("no write permission to npm prefix") — rather than the PV-installed native build
+that self-updates. Bug found live on alert-agent 2026-06-18.
+"""
+from pathlib import Path
+
+DOCKERFILE = Path(__file__).resolve().parents[1] / "Dockerfile"
+
+
+def test_path_env_is_parameterized_on_agent_home():
+    df = DOCKERFILE.read_text()
+    assert "PATH=${AGENT_HOME}/.local/bin" in df, \
+        "agent-shell-base must re-set PATH=${AGENT_HOME}/.local/bin (else base's /home/claude leaks)"
+
+
+def test_no_hardcoded_home_claude_in_a_path_line():
+    # This image overrides the user, so any PATH it sets must track AGENT_HOME —
+    # never a literal /home/claude (that's only correct in the base default).
+    for line in DOCKERFILE.read_text().splitlines():
+        if "PATH=" in line and not line.strip().startswith("#"):
+            assert "/home/claude" not in line, f"hardcoded /home/claude in PATH line: {line.strip()}"

--- a/multi-agent-shell/rootfs/etc/cont-init.d/45-native-harnesses
+++ b/multi-agent-shell/rootfs/etc/cont-init.d/45-native-harnesses
@@ -1,0 +1,11 @@
+#!/command/with-contenv bash
+# 45-native-harnesses — install/refresh the PV-resident NATIVE harness builds on
+# every boot (memory-safe; idempotent — skips when already current; fail-open —
+# never blocks boot). Runs BEFORE services.d, so the native binary exists at
+# $HOME/.local/bin before the agent-session driver's first `claude` launch, and
+# PATH (set on AGENT_HOME in agent-shell-base) resolves it ahead of the npm shim.
+#
+# Currently installs: claude (the one harness with an OOM-prone native installer).
+# codex/opencode are npm (managed by 40-shell-inventory); agy is a build-time
+# binary. Extend the harness list here + add an installer in the helper.
+exec /usr/local/lib/multi-agent-shell/install-native-harness.sh claude

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/install-native-harness.sh
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/install-native-harness.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# install-native-harness.sh — install/refresh the NATIVE build of an agent harness
+# into the PV-resident $HOME/.local (self-updating, PATH-preferred over the npm
+# bootstrap shim). MEMORY-SAFE: plain curl of the published binary, NOT the
+# harness's own `install` subcommand, which buffers the whole download in-process
+# (~245MB ×17 ≈ 4GiB peak for claude) and group-OOMs a memory-limited pod.
+#
+# Idempotent (skips when the latest is already installed) and FAIL-OPEN (any
+# network/checksum failure leaves the existing build / npm bootstrap in place and
+# returns 0 — never blocks container boot). Runs as the agent user (cont-init,
+# non-root s6), so it writes $HOME/.local directly.
+#
+# Usage: install-native-harness.sh <harness> [<harness> …]   (default: claude)
+set -uo pipefail
+
+CURL_MAX_META="${NATIVE_HARNESS_CURL_META_TIMEOUT:-20}"
+CURL_MAX_DL="${NATIVE_HARNESS_CURL_DL_TIMEOUT:-300}"
+
+# --- claude: native build from the Anthropic releases CDN -----------------------
+install_claude() {
+    local DL="${CLAUDE_NATIVE_DL:-https://downloads.claude.ai/claude-code-releases}"
+    local version installed checksum vdir tmp
+    version=$(curl -fsSL --max-time "$CURL_MAX_META" "$DL/latest" 2>/dev/null) || {
+        echo "= native-claude: cannot reach $DL/latest — leaving the npm bootstrap in place"; return 0; }
+    [ -n "$version" ] || { echo "= native-claude: empty latest version — skip"; return 0; }
+    vdir="$HOME/.local/share/claude/versions"
+    installed=$(basename "$(readlink "$HOME/.local/bin/claude" 2>/dev/null || true)" 2>/dev/null || true)
+    if [ "$installed" = "$version" ] && [ -x "$vdir/$version" ]; then
+        echo "✓ native-claude: $version already installed (skip download)"; return 0
+    fi
+    echo "→ native-claude: installing $version (memory-safe curl)…"
+    checksum=$(curl -fsSL --max-time "$CURL_MAX_META" "$DL/$version/manifest.json" 2>/dev/null \
+                | jq -r '.platforms["linux-x64"].checksum' 2>/dev/null) || true
+    [ -n "${checksum:-}" ] && [ "$checksum" != "null" ] || {
+        echo "= native-claude: manifest/checksum unavailable — skip (bootstrap stands)"; return 0; }
+    mkdir -p "$vdir" "$HOME/.local/bin"
+    tmp="$vdir/$version.tmp.$$"
+    if ! curl -fsSL --max-time "$CURL_MAX_DL" -o "$tmp" "$DL/$version/linux-x64/claude"; then
+        echo "= native-claude: download failed — keeping previous build"; rm -f "$tmp"; return 0
+    fi
+    if ! echo "$checksum  $tmp" | sha256sum -c --status; then
+        echo "✘ native-claude: checksum mismatch — discarding download"; rm -f "$tmp"; return 0
+    fi
+    chmod +x "$tmp" && mv -f "$tmp" "$vdir/$version"
+    ln -sfn "$vdir/$version" "$HOME/.local/bin/claude"
+    echo "✓ native-claude: $version → $HOME/.local/bin/claude"
+}
+
+# Add further native harnesses here (e.g. install_opencode) as they gain a
+# published binary worth pinning on the PV. codex/opencode are npm (managed by the
+# inventory reconciler); agy is a build-time binary — neither needs this path.
+install_one() {
+    case "$1" in
+        claude) install_claude ;;
+        *) echo "= native-harness: no native installer defined for '$1' (npm/binary bootstrap stands)";;
+    esac
+}
+
+main() {
+    local had_any=0
+    for h in "${@:-claude}"; do had_any=1; install_one "$h"; done
+    [ "$had_any" = 1 ] || install_one claude
+    return 0   # fail-open overall: never fail container boot
+}
+
+main "$@"

--- a/multi-agent-shell/tests/test_native_harness.py
+++ b/multi-agent-shell/tests/test_native_harness.py
@@ -1,0 +1,99 @@
+"""Tests for the baked native-harness installer (cont-init.d/45-native-harnesses
++ install-native-harness.sh).
+
+The image bakes the memory-safe native claude install: plain `curl` of the
+published binary into the PV-resident $HOME/.local (NOT `claude install`, which
+buffers ~4GiB and OOM-kills a memory-limited pod). It must be idempotent (skip the
+~232MB download when already current) and fail-open (never block container boot).
+Functional tests drive the helper with PATH-injected fake curl/jq/sha256sum.
+"""
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+MAS = Path(__file__).resolve().parents[1]
+HELPER = MAS / "rootfs/usr/local/lib/multi-agent-shell/install-native-harness.sh"
+CONT_INIT = MAS / "rootfs/etc/cont-init.d/45-native-harnesses"
+
+FAKE_CURL = r'''#!/usr/bin/env bash
+echo "curl $*" >> "$FAKE_LOG"
+url="${@: -1}"                       # the URL is the last argument
+out=""; prev=""; for a in "$@"; do [ "$prev" = "-o" ] && out="$a"; prev="$a"; done
+[ "${FAKE_CURL_FAIL:-0}" = 1 ] && exit 22
+case "$url" in
+  */latest)        printf '%s' "${FAKE_VERSION:-9.9.9}" ;;
+  */manifest.json) printf '%s' '{"platforms":{"linux-x64":{"checksum":"abc123"}}}' ;;
+  */linux-x64/claude) printf 'FAKEBINARY' > "$out" ;;
+esac
+exit 0
+'''
+FAKE_JQ = "#!/usr/bin/env bash\ncat >/dev/null\nprintf '%s' abc123\n"            # echo the checksum
+FAKE_SHA = "#!/usr/bin/env bash\ncat >/dev/null\nexit 0\n"                       # sha256sum -c --status → match
+
+
+def _harness(tmp_path, *, version="9.9.9", curl_fail=False):
+    bindir = tmp_path / "bin"; bindir.mkdir()
+    for name, body in (("curl", FAKE_CURL), ("jq", FAKE_JQ), ("sha256sum", FAKE_SHA)):
+        f = bindir / name; f.write_text(body); f.chmod(f.stat().st_mode | stat.S_IEXEC)
+    home = tmp_path / "home"; home.mkdir()
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["HOME"] = str(home)
+    env["FAKE_LOG"] = str(tmp_path / "curl.log")
+    env["FAKE_VERSION"] = version
+    if curl_fail:
+        env["FAKE_CURL_FAIL"] = "1"
+    return env, home
+
+def _run(env):
+    return subprocess.run(["bash", str(HELPER), "claude"], capture_output=True, text=True, env=env, timeout=30)
+
+def _curl_log(tmp_path):
+    p = tmp_path / "curl.log"
+    return p.read_text() if p.exists() else ""
+
+
+# --- structure ----------------------------------------------------------------
+
+def test_cont_init_execs_the_helper():
+    text = CONT_INIT.read_text()
+    assert text.startswith("#!/command/with-contenv bash"), "must use the s6 with-contenv shebang"
+    assert "install-native-harness.sh" in text and "claude" in text
+    assert os.access(CONT_INIT, os.X_OK), "cont-init script must be executable"
+
+def test_helper_is_memory_safe_not_install_subcommand():
+    text = HELPER.read_text()
+    assert "downloads.claude.ai" in text and "curl" in text, "must curl the published binary"
+    # MUST NOT shell out to `claude install` (the OOM path).
+    assert "claude install" not in text, "must NOT use `claude install` (buffers ~4GiB → OOM)"
+    assert "sha256sum" in text, "must checksum-verify the download"
+
+
+# --- functional ---------------------------------------------------------------
+
+def test_installs_native_binary_and_symlink(tmp_path):
+    env, home = _harness(tmp_path)
+    r = _run(env)
+    assert r.returncode == 0, r.stderr
+    link = home / ".local/bin/claude"
+    assert link.is_symlink(), f"must symlink ~/.local/bin/claude; out={r.stdout}"
+    assert link.resolve().name == "9.9.9"
+    assert (home / ".local/share/claude/versions/9.9.9").exists()
+    assert "/linux-x64/claude" in _curl_log(tmp_path), "first install must download the binary"
+
+def test_idempotent_skips_when_current(tmp_path):
+    env, home = _harness(tmp_path)
+    assert _run(env).returncode == 0           # first install
+    (tmp_path / "curl.log").write_text("")     # reset the call log
+    r = _run(env)                              # second run, same version
+    assert r.returncode == 0
+    assert "already installed" in r.stdout
+    assert "/linux-x64/claude" not in _curl_log(tmp_path), "must NOT re-download when current"
+
+def test_fail_open_on_network_error(tmp_path):
+    env, home = _harness(tmp_path, curl_fail=True)
+    r = _run(env)
+    assert r.returncode == 0, "must fail-open (never block boot) when the CDN is unreachable"
+    assert not (home / ".local/bin/claude").exists(), "no symlink written on failure"


### PR DESCRIPTION
Two cohesive image fixes so the agent runs the **native** claude build (self-updating, PV-resident) instead of the npm bootstrap shim — found live on alert-agent.

## 1. PATH fix (`agent-shell-base/Dockerfile`)
`base/Dockerfile` bakes `ENV PATH=/home/claude/.local/bin:…` (its default user). agent-shell-base overrode `HOME`/`AGENT_HOME` to `/home/agent` **but left `PATH`** pointing at `/home/claude/.local/bin`. So the **non-login** s6 agent-session driver (which launches `claude` via tmux with the baked PATH — the profile.d `~/.local/bin` shim is login-shell-only) resolved the npm `/usr/bin/claude` instead of the PV-installed native build at `/home/agent/.local/bin`. Symptom: the driver's claude kept printing `Auto-update failed: no write permission to npm prefix` and never self-updated. Fix re-sets `PATH=${AGENT_HOME}/.local/bin:…` on the same ENV (correct for `agent` and kali's `claude`).

## 2. Bake the memory-safe native install (`multi-agent-shell`)
A fresh pod needed a **manual** `claude install`, which **OOM-kills** on a memory-limited pod (`exit 137` — it buffers ~245 MB ×17 ≈ 4 GiB). New `cont-init.d/45-native-harnesses` → `install-native-harness.sh` installs the native build via **plain curl** of the published binary into `$HOME/.local` (constant memory), **idempotent** (skips the ~232 MB download when already current — normal boots are free), **fail-open** (network/checksum failure leaves the npm bootstrap; never blocks boot), checksum-verified. Runs before `services.d`, so native claude exists before the driver's first launch.

Framework takes a harness list; **claude** is wired (the only harness with an OOM-prone native installer). codex/opencode are npm (managed by `40-shell-inventory`); agy is a build-time binary.

## Tests
- `agent-shell-base/tests/test_agent_home_path.py` — PATH parameterized on AGENT_HOME, no hardcoded `/home/claude` (RED-verified).
- `multi-agent-shell/tests/test_native_harness.py` — structure + functional (install / idempotent-skip / fail-open) via fake curl/jq/sha256sum. 5 pass.

## Pairs with
frank #575 (agent container 3Gi→8Gi, so the native auto-updater's spike fits). After this merges + bumps, fresh alert-agent/n8n pods come up on the native binary automatically, and the npm-prefix auto-update error is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)