### PR TITLE
feat(multi-agent-shell): fan canonical AGENTS.md out to per-harness instruction files

### DIFF
--- a/multi-agent-shell/rootfs/etc/cont-init.d/46-agent-instructions
+++ b/multi-agent-shell/rootfs/etc/cont-init.d/46-agent-instructions
@@ -1,0 +1,8 @@
+#!/command/with-contenv bash
+# 46-agent-instructions — fan a canonical $HOME/AGENTS.md out to the per-harness
+# project-instruction filenames (CLAUDE.md, .github/copilot-instructions.md, …) so
+# every harness the driver may launch (claude / codex / opencode / antigravity / pi
+# / copilot) loads the same agent instructions. AGENTS.md-native harnesses need no
+# symlink; only claude (CLAUDE.md) and Copilot get one. Idempotent + fail-open;
+# never clobbers a real mounted file. Extend via AGENT_INSTRUCTION_LINKS.
+exec /usr/local/lib/multi-agent-shell/link-agent-instructions.sh

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/link-agent-instructions.sh
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/link-agent-instructions.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# link-agent-instructions.sh — fan a canonical $HOME/AGENTS.md out to the per-harness
+# project-instruction filenames, so whichever agent harness the driver launches loads
+# the SAME instructions (tools, persona, boundaries).
+#
+# AGENTS.md (the agents.md cross-tool standard) is read NATIVELY by codex, opencode,
+# antigravity and pi — they need no symlink. The exceptions get one → AGENTS.md:
+#   * claude  reads CLAUDE.md ONLY (never AGENTS.md natively)
+#   * Copilot reads .github/copilot-instructions.md
+# Extend via AGENT_INSTRUCTION_LINKS (space-separated `target=symlink-value`, value
+# relative to the target's own dir) — e.g. add a harness that wants its own file.
+#
+# Idempotent + fail-open; NEVER clobbers a real (non-symlink) file a deployment
+# mounted at one of these paths.
+set -uo pipefail
+
+src="$HOME/AGENTS.md"
+if [ ! -e "$src" ]; then
+    echo "= agent-instructions: no $src — nothing to fan out"
+    exit 0
+fi
+
+LINKS="${AGENT_INSTRUCTION_LINKS:-CLAUDE.md=AGENTS.md .github/copilot-instructions.md=../AGENTS.md}"
+for pair in $LINKS; do
+    rel="${pair%%=*}"; val="${pair#*=}"
+    tgt="$HOME/$rel"
+    if [ -e "$tgt" ] && [ ! -L "$tgt" ]; then
+        echo "= agent-instructions: $rel is a real file (mounted?) — leaving it"
+        continue
+    fi
+    mkdir -p "$(dirname "$tgt")" 2>/dev/null || true
+    if ln -sfn "$val" "$tgt" 2>/dev/null; then
+        echo "✓ agent-instructions: $rel → $val"
+    else
+        echo "= agent-instructions: could not link $rel (skipping)"
+    fi
+done
+exit 0

--- a/multi-agent-shell/tests/test_agent_instructions_fanout.py
+++ b/multi-agent-shell/tests/test_agent_instructions_fanout.py
@@ -1,0 +1,76 @@
+"""Tests for the baked agent-instructions fan-out (cont-init.d/46-agent-instructions
++ link-agent-instructions.sh).
+
+A deployment provides ONE canonical $HOME/AGENTS.md; the image symlinks the
+per-harness filenames to it so whichever harness the driver launches loads the same
+instructions. AGENTS.md-native harnesses (codex/opencode/antigravity/pi) need no
+symlink; claude (CLAUDE.md) and Copilot (.github/copilot-instructions.md) do.
+Idempotent, fail-open, never clobbers a real mounted file.
+"""
+import os
+import subprocess
+from pathlib import Path
+
+MAS = Path(__file__).resolve().parents[1]
+HELPER = MAS / "rootfs/usr/local/lib/multi-agent-shell/link-agent-instructions.sh"
+CONT_INIT = MAS / "rootfs/etc/cont-init.d/46-agent-instructions"
+
+
+def _run(home, env_extra=None):
+    env = dict(os.environ); env["HOME"] = str(home)
+    if env_extra:
+        env.update(env_extra)
+    return subprocess.run(["bash", str(HELPER)], capture_output=True, text=True, env=env, timeout=20)
+
+
+# --- structure ----------------------------------------------------------------
+
+def test_cont_init_execs_helper():
+    text = CONT_INIT.read_text()
+    assert text.startswith("#!/command/with-contenv bash")
+    assert "link-agent-instructions.sh" in text
+    assert os.access(CONT_INIT, os.X_OK), "cont-init must be executable"
+
+def test_helper_drops_gemini_and_targets_claude_copilot():
+    text = HELPER.read_text()
+    assert "CLAUDE.md" in text and "copilot-instructions.md" in text
+    assert "GEMINI.md" not in text, "antigravity reads AGENTS.md; no GEMINI.md symlink"
+
+
+# --- functional ---------------------------------------------------------------
+
+def test_fans_out_to_claude_and_copilot(tmp_path):
+    home = tmp_path; (home / "AGENTS.md").write_text("# instructions\n")
+    r = _run(home); assert r.returncode == 0, r.stderr
+    claude = home / "CLAUDE.md"
+    copilot = home / ".github/copilot-instructions.md"
+    assert claude.is_symlink() and os.readlink(claude) == "AGENTS.md"
+    assert copilot.is_symlink() and os.readlink(copilot) == "../AGENTS.md"
+    # both resolve to the canonical content
+    assert claude.read_text() == "# instructions\n"
+    assert copilot.read_text() == "# instructions\n"
+
+def test_no_source_is_noop(tmp_path):
+    r = _run(tmp_path); assert r.returncode == 0
+    assert not (tmp_path / "CLAUDE.md").exists(), "no AGENTS.md → no symlinks"
+    assert "nothing to fan out" in r.stdout
+
+def test_never_clobbers_a_real_mounted_file(tmp_path):
+    home = tmp_path; (home / "AGENTS.md").write_text("canonical\n")
+    (home / "CLAUDE.md").write_text("a directly-mounted CLAUDE.md\n")   # real file, not a symlink
+    r = _run(home); assert r.returncode == 0
+    assert not (home / "CLAUDE.md").is_symlink(), "must not clobber a mounted CLAUDE.md"
+    assert (home / "CLAUDE.md").read_text() == "a directly-mounted CLAUDE.md\n"
+    assert (home / ".github/copilot-instructions.md").is_symlink()     # the others still linked
+
+def test_idempotent(tmp_path):
+    home = tmp_path; (home / "AGENTS.md").write_text("x\n")
+    assert _run(home).returncode == 0
+    r = _run(home); assert r.returncode == 0                            # second run, no error
+    assert (home / "CLAUDE.md").is_symlink()
+
+def test_link_list_is_configurable(tmp_path):
+    home = tmp_path; (home / "AGENTS.md").write_text("x\n")
+    r = _run(home, {"AGENT_INSTRUCTION_LINKS": "PI.md=AGENTS.md"})
+    assert r.returncode == 0
+    assert (home / "PI.md").is_symlink() and os.readlink(home / "PI.md") == "AGENTS.md"


### PR DESCRIPTION
Makes the multi-agent-shell image **harness-agnostic** for agent instructions, so it works for *all* harnesses, not only claude.

A deployment provides ONE canonical `$HOME/AGENTS.md`; `cont-init.d/46-agent-instructions` → `link-agent-instructions.sh` symlinks the per-harness project-instruction filenames to it, so whichever harness the driver launches loads the same agent instructions (tools, persona, HTTP-only/no-kubectl boundary).

**Per-harness mapping** (confirmed via docs):
- `AGENTS.md` (the agents.md standard) — read **natively** by **codex, opencode, antigravity, pi** → no symlink.
- `CLAUDE.md` → `AGENTS.md` — **claude reads CLAUDE.md ONLY** (never AGENTS.md natively).
- `.github/copilot-instructions.md` → `AGENTS.md` — **Copilot**.
- **No `GEMINI.md`** — antigravity reads AGENTS.md (gemini is deprecated).

Idempotent + fail-open; **never clobbers a real mounted file** (a deployment that directly mounts `CLAUDE.md` is left alone — so it composes with the alert-agent change that mounts both AGENTS.md + CLAUDE.md). The symlink set is overridable via `AGENT_INSTRUCTION_LINKS` (space-separated `target=symlink-value`) if a harness wants its own file.

## Tests
`multi-agent-shell/tests/test_agent_instructions_fanout.py` — structure + functional: fan-out to claude/copilot, no-source no-op, **never clobber a mounted file**, idempotent, configurable list. 7 pass.

## Pairs with
frank #576 (alert-agent mounts instructions as both `AGENTS.md` + `CLAUDE.md`). With this image, any future agent provides just `AGENTS.md` and every harness picks it up.

## Open question (pi)
`pi`'s project-instruction filename isn't documented in the superpowers `pi-tools.md`, and pi isn't in the image's harness bootstrap yet. I've assumed pi reads `AGENTS.md` (the standard) → covered by the canonical. If pi uses a specific file, it's a one-line add to the default `LINKS` (or set `AGENT_INSTRUCTION_LINKS`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)