### PR TITLE
fix(agent-shells): harden hermes state-dir permissions on PVC remount

### DIFF
--- a/hermes-agent-shell/Dockerfile
+++ b/hermes-agent-shell/Dockerfile
@@ -86,6 +86,7 @@ RUN install -d -o ${AGENT_UID} -g ${AGENT_GID} -m 0755 \
       /var/lib/hermes-agent-shell \
  && chmod +x \
       /etc/cont-init.d/35-hermes-venv-seed \
+      /etc/cont-init.d/36-hermes-strict-state-perms \
       /etc/cont-init.d/40-shell-inventory \
       /etc/profile.d/40-hermes-agent-shell-paths.sh \
       /etc/profile.d/45-hermes-agent-shell-reconcile-motd.sh \

--- a/hermes-agent-shell/README.md
+++ b/hermes-agent-shell/README.md
@@ -108,6 +108,27 @@ ConfigMap on Frank). Removed semantics mirror multi-agent-shell.
    declare per-harness MCP servers, or clone skills. The next pod restart
    (or `hermes-agent-shell-reconcile` interactively) applies them.
 
+## Strict-state permission guard
+
+Some Kubernetes PVC mount paths get broad fsGroup-driven mode rewrites on pod
+start/remount. For PostgreSQL-style state this is fatal: a previously healthy
+`PGDATA` can come back group-writable/setgid and fail only on the next start.
+
+To guard sensitive state dirs, the image ships
+`cont-init.d/36-hermes-strict-state-perms`. It reads the optional env var
+`HERMES_AGENT_SHELL_STRICT_PATHS`, a semicolon-separated list of:
+
+```text
+/abs/path
+/abs/path:700
+/abs/path:700:600
+```
+
+Defaults are `700` for directories and `600` for files. Missing paths are
+ignored (fail-open), so the hook is safe to leave configured before the state
+exists. Frank's `hermes-agent-shell` pod can use this to re-tighten
+`/home/agent/.local/pgsql/hindsight-data` on every boot.
+
 ## Layered install model
 
 Same three-layer model as `multi-agent-shell` and `paperclip-shell`:
@@ -158,6 +179,7 @@ Local bats coverage:
 cd hermes-agent-shell
 bats tests/test_motd.bats              # BYOK MOTD + OPENAI_BASE_URL hint
 bats tests/test_install_inventory.bats # harnesses/mcp-servers/skills handlers
+bats tests/test_strict_state_perms.bats
 ```
 
 ## Telegram alerting

--- a/hermes-agent-shell/rootfs/etc/cont-init.d/36-hermes-strict-state-perms
+++ b/hermes-agent-shell/rootfs/etc/cont-init.d/36-hermes-strict-state-perms
@@ -1,0 +1,58 @@
+#!/command/with-contenv bash
+# 36-hermes-strict-state-perms — Re-apply strict modes to sensitive state dirs
+# on every container boot.
+#
+# Why this exists:
+# - Some Kubernetes PVC mount paths are subject to fsGroup-driven permission
+#   reconciliation on pod start/remount.
+# - That broad rewrite can leave directories group-writable/setgid (e.g. 2775)
+#   and files 664 across $HOME on the PVC.
+# - PostgreSQL rejects those modes inside PGDATA, so a previously healthy
+#   cluster can fail on the next restart even though no operator touched it.
+#
+# Contract:
+# - HERMES_AGENT_SHELL_STRICT_PATHS is a semicolon-separated list of specs:
+#     /abs/path
+#     /abs/path:700
+#     /abs/path:700:600
+# - Defaults are dir mode 700 and file mode 600.
+# - Missing paths are ignored (fail-open). This hook never blocks sshd.
+set -u
+
+specs="${HERMES_AGENT_SHELL_STRICT_PATHS:-}"
+if [ -z "$specs" ]; then
+    exit 0
+fi
+
+old_ifs="$IFS"
+IFS=';'
+for spec in $specs; do
+    IFS="$old_ifs"
+    [ -z "$spec" ] && continue
+
+    path="${spec%%:*}"
+    rest="${spec#*:}"
+    dir_mode="700"
+    file_mode="600"
+
+    if [ "$rest" != "$spec" ]; then
+        if [[ "$rest" == *:* ]]; then
+            dir_mode="${rest%%:*}"
+            file_mode="${rest#*:}"
+        else
+            dir_mode="$rest"
+        fi
+    fi
+
+    if [ ! -e "$path" ]; then
+        echo "36-hermes-strict-state-perms: skip missing path $path"
+        continue
+    fi
+
+    echo "36-hermes-strict-state-perms: enforcing dir=$dir_mode file=$file_mode on $path"
+    find "$path" -type d -exec chmod "$dir_mode" {} +
+    find "$path" -type f -exec chmod "$file_mode" {} +
+done
+IFS="$old_ifs"
+
+exit 0

--- a/hermes-agent-shell/tests/test_strict_state_perms.bats
+++ b/hermes-agent-shell/tests/test_strict_state_perms.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+setup() {
+  HOOK="$(realpath hermes-agent-shell/rootfs/etc/cont-init.d/36-hermes-strict-state-perms)"
+  STATE_ROOT="$BATS_TEST_TMPDIR/state"
+  export STATE_ROOT
+}
+
+run_hook() { run bash "$HOOK"; }
+
+@test "no env configured is a clean no-op" {
+  unset HERMES_AGENT_SHELL_STRICT_PATHS
+  run_hook
+  [ "$status" -eq 0 ]
+}
+
+@test "missing path is skipped fail-open" {
+  export HERMES_AGENT_SHELL_STRICT_PATHS="$STATE_ROOT/missing:700:600"
+  run_hook
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"skip missing path"* ]]
+}
+
+@test "enforces default strict modes recursively" {
+  mkdir -p "$STATE_ROOT/pg/base"
+  printf '16\n' > "$STATE_ROOT/pg/PG_VERSION"
+  printf 'config\n' > "$STATE_ROOT/pg/postgresql.conf"
+  chmod 2775 "$STATE_ROOT/pg" "$STATE_ROOT/pg/base"
+  chmod 664 "$STATE_ROOT/pg/PG_VERSION" "$STATE_ROOT/pg/postgresql.conf"
+
+  export HERMES_AGENT_SHELL_STRICT_PATHS="$STATE_ROOT/pg"
+  run_hook
+  [ "$status" -eq 0 ]
+  [ "$(stat -c '%a' "$STATE_ROOT/pg")" = "700" ]
+  [ "$(stat -c '%a' "$STATE_ROOT/pg/base")" = "700" ]
+  [ "$(stat -c '%a' "$STATE_ROOT/pg/PG_VERSION")" = "600" ]
+  [ "$(stat -c '%a' "$STATE_ROOT/pg/postgresql.conf")" = "600" ]
+}
+
+@test "supports custom dir and file modes" {
+  mkdir -p "$STATE_ROOT/custom/sub"
+  printf 'x\n' > "$STATE_ROOT/custom/file.txt"
+  chmod 775 "$STATE_ROOT/custom" "$STATE_ROOT/custom/sub"
+  chmod 664 "$STATE_ROOT/custom/file.txt"
+
+  export HERMES_AGENT_SHELL_STRICT_PATHS="$STATE_ROOT/custom:750:640"
+  run_hook
+  [ "$status" -eq 0 ]
+  [ "$(stat -c '%a' "$STATE_ROOT/custom")" = "750" ]
+  [ "$(stat -c '%a' "$STATE_ROOT/custom/sub")" = "750" ]
+  [ "$(stat -c '%a' "$STATE_ROOT/custom/file.txt")" = "640" ]
+}


### PR DESCRIPTION
## Summary
- add a cont-init hook that reapplies strict modes to configured state paths on every boot
- document the new HERMES_AGENT_SHELL_STRICT_PATHS env contract in the hermes-agent-shell README
- add bats coverage for default and custom mode enforcement

## Why
Kubernetes fsGroup reconciliation on PVC remount can broaden modes across the home tree (2775 dirs / 664 files). That is fatal for embedded PostgreSQL-style state such as Hermes Hindsight PGDATA.

## Validation
- git diff --check
- bash -n hermes-agent-shell/rootfs/etc/cont-init.d/35-hermes-venv-seed
- bash -n hermes-agent-shell/rootfs/etc/cont-init.d/36-hermes-strict-state-perms
- bats not installed in the current shell pod, so the new bats file was added but not executed here