### PR TITLE
feat(hermes-agent-shell-ssh): thin SSH/Mosh sidecar for the two-container hermes-agent-shell pod (willikins#285)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -179,6 +179,16 @@ jobs:
             context: hermes-agent-shell
             build_args: |
               BASE_SHA=${{ needs.build-shell-base.outputs.sha }}
+          # Thin SSH/Mosh sidecar for the two-container hermes-agent-shell pod
+          # (willikins#285). Unlike its single-container sibling above, this image
+          # builds FROM the official docker.io/nousresearch/hermes-agent tag
+          # (HERMES_TAG arg, defaulted in the Dockerfile) — NOT the agent-shell-base
+          # chain — so it carries no BASE_SHA, same as ruflo-server. It still runs
+          # in build-children (which needs the base chain) for matrix uniformity;
+          # the unused base deps just mean it waits a little, harmless.
+          - name: hermes-agent-shell-ssh
+            context: hermes-agent-shell-ssh
+            build_args: ""
           - name: infra-shell
             context: infra-shell
             build_args: |
@@ -809,6 +819,102 @@ jobs:
           docker logs has-smoke
           docker rm -f has-smoke
 
+  smoke-test-hermes-agent-shell-ssh:
+    needs: build-children
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      HERMES_SSH_IMAGE: ghcr.io/derio-net/hermes-agent-shell-ssh
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Smoke test — sshd sidecar binds 2222 under K8s-equivalent securityContext
+        env:
+          IMAGE_SHA: ${{ github.sha }}
+        run: |
+          # This sidecar does NOT run s6-overlay (unlike the shell-base images) —
+          # it runs sshd in the foreground as PID 1 via a custom entrypoint
+          # (hermes-ssh-sidecar-entrypoint.sh). So the readiness signal is
+          # "sshd wrote its PidFile / bound 2222", not "s6-svstat sshd up".
+          #
+          # Match the live pod securityContext (runAsUser 1000, cap-drop=ALL,
+          # no-new-privileges): the non-root sshd must bind 2222 without ever
+          # chowning /run at runtime (it pre-chowns /run/sshd at build time). The
+          # bind mount stands in for the shared /opt/data PVC (fsGroup:1000 in the
+          # pod); mount at /opt/data — not /opt/data/home — so both first-boot
+          # host-key writes AND the `hermes` CLI (which reads HERMES_HOME=/opt/data)
+          # work as UID 1000. chown to 1000 mirrors fsGroup.
+          mkdir -p /tmp/hermes-ssh-optdata
+          sudo chown 1000:1000 /tmp/hermes-ssh-optdata
+
+          docker run -d --name hermes-ssh-smoke \
+            --user 1000:1000 \
+            --cap-drop=ALL \
+            --security-opt=no-new-privileges \
+            -p 12222:2222 \
+            -v /tmp/hermes-ssh-optdata:/opt/data \
+            "${HERMES_SSH_IMAGE}:${IMAGE_SHA}"
+
+          # First boot generates host keys (incl. rsa-4096, a couple seconds) then
+          # execs sshd, which writes its PidFile onto the shared PVC. 30s budget
+          # mirrors the sibling shells.
+          ready=0
+          for i in $(seq 1 30); do
+            if docker exec hermes-ssh-smoke test -f /opt/data/home/.ssh/sshd.pid 2>/dev/null; then
+              echo "✓ sshd wrote its PidFile after ${i}s"
+              ready=1
+              break
+            fi
+            sleep 1
+          done
+          if [ "$ready" -ne 1 ]; then
+            echo "✗ sshd never wrote its PidFile within 30s"
+            docker logs hermes-ssh-smoke
+            docker rm -f hermes-ssh-smoke
+            exit 1
+          fi
+
+          # Host keys must land on the shared PVC (persist across restarts, same
+          # mechanism agent-shell-base's 10-ssh-host-keys uses).
+          docker exec hermes-ssh-smoke test -f /opt/data/home/.ssh-host-keys/ssh_host_ed25519_key \
+            || { echo "✗ ed25519 host key not generated on the PVC"; docker logs hermes-ssh-smoke; docker rm -f hermes-ssh-smoke; exit 1; }
+
+          # The port must actually accept TCP and speak the SSH protocol — proves
+          # the non-root sshd bound 2222 under cap-drop=ALL (the sshd_config
+          # comment's claim), not merely that some process is up.
+          bound=0
+          for i in $(seq 1 15); do
+            if banner=$(timeout 3 bash -c 'exec 3<>/dev/tcp/127.0.0.1/12222; head -c 20 <&3' 2>/dev/null); then
+              echo "banner: ${banner}"
+              if echo "$banner" | grep -q '^SSH-2.0'; then
+                echo "✓ sshd is speaking SSH on 2222"
+                bound=1
+                break
+              fi
+            fi
+            sleep 1
+          done
+          if [ "$bound" -ne 1 ]; then
+            echo "✗ sshd never answered with an SSH banner on 2222"
+            docker logs hermes-ssh-smoke
+            docker rm -f hermes-ssh-smoke
+            exit 1
+          fi
+
+          # The whole point of building FROM the official Hermes tag: the `hermes`
+          # CLI invoked over SSH is byte-for-byte the gateway's runtime and shares
+          # /opt/data. Assert it runs cleanly as UID 1000 in the sidecar.
+          docker exec hermes-ssh-smoke hermes --version \
+            || { echo "✗ hermes CLI not runnable as UID 1000 in the sidecar"; docker logs hermes-ssh-smoke; docker rm -f hermes-ssh-smoke; exit 1; }
+
+          docker logs hermes-ssh-smoke
+          docker rm -f hermes-ssh-smoke
+
   smoke-test-infra-shell:
     needs: build-children
     runs-on: ubuntu-latest
@@ -916,6 +1022,7 @@ jobs:
       - smoke-test-ruflo-server
       - smoke-test-multi-agent-shell
       - smoke-test-hermes-agent-shell
+      - smoke-test-hermes-agent-shell-ssh
       - smoke-test-infra-shell
     runs-on: ubuntu-latest
     # Only notify frank when the MAIN image tag actually moved: a push to main

--- a/hermes-agent-shell-ssh/Dockerfile
+++ b/hermes-agent-shell-ssh/Dockerfile
@@ -1,0 +1,72 @@
+# hermes-agent-shell-ssh — thin SSH/Mosh sidecar for the two-container
+# hermes-agent-shell pod (willikins#285). Built FROM the SAME official Hermes
+# tag the main container runs, so the `hermes` CLI invoked over SSH is byte-for-
+# byte the gateway's runtime and talks to the shared /opt/data state directly.
+#
+# It does NOT run the gateway or the dashboard — that is the main container's
+# job. This image only adds terminal access (sshd + mosh + tmux) and a login
+# identity, then runs sshd in the foreground.
+#
+# WHY not FROM agent-shell-base like the old single-container image: the whole
+# point of the migration is that the main service container is the unmodified
+# official image. The sidecar shares its /opt/data layout, HERMES_HOME, PATH and
+# CLI — building FROM the same tag guarantees that; agent-shell-base would
+# reintroduce a divergent /home/agent world.
+ARG HERMES_TAG=v2026.7.7.2
+FROM docker.io/nousresearch/hermes-agent:${HERMES_TAG}
+
+# The official image is Debian trixie and runs as root with HERMES_HOME=/opt/data
+# (confirmed from its image config, 2026-07-09). We add a non-root login user
+# matching the pod securityContext (runAsUser/Group 1000) whose HOME is the
+# shared tool-home PVC at /opt/data/home.
+USER root
+
+ARG AGENT_USER=agent
+ARG AGENT_UID=1000
+ARG AGENT_GID=1000
+ARG AGENT_HOME=/opt/data/home
+
+# sshd + mosh + tmux only. C.UTF-8 (glibc built-in) covers mosh's UTF-8
+# requirement, so we skip the ~200MB locales-all the old base pulled in.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      openssh-server \
+      mosh \
+      tmux \
+      passwd \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create the login identity. The official image has no UID-1000 user; mirror
+# agent-shell-base's idempotent handling in case a future base ships one.
+RUN if ! id -u "${AGENT_USER}" >/dev/null 2>&1; then \
+        if getent passwd "${AGENT_UID}" >/dev/null; then \
+            /usr/sbin/userdel -r "$(getent passwd ${AGENT_UID} | cut -d: -f1)" 2>/dev/null || true; \
+        fi; \
+        if getent group "${AGENT_GID}" >/dev/null; then \
+            /usr/sbin/groupdel "$(getent group ${AGENT_GID} | cut -d: -f1)" 2>/dev/null || true; \
+        fi; \
+        /usr/sbin/groupadd --gid ${AGENT_GID} ${AGENT_USER}; \
+        /usr/sbin/useradd --uid ${AGENT_UID} --gid ${AGENT_GID} \
+            --home-dir ${AGENT_HOME} --shell /bin/bash ${AGENT_USER}; \
+    fi
+
+# sshd privsep dir owned by the agent UID: a non-root sshd under
+# cap-drop=ALL + allowPrivilegeEscalation=false cannot chown /run at runtime
+# (same constraint agent-shell-base pre-chowns for). The pod runs everything as
+# UID 1000, so login-user == daemon-user and sshd needs no privilege drop.
+RUN mkdir -p /run/sshd && chown ${AGENT_UID}:${AGENT_GID} /run/sshd
+
+ENV AGENT_USER=${AGENT_USER} AGENT_UID=${AGENT_UID} AGENT_GID=${AGENT_GID} \
+    AGENT_HOME=${AGENT_HOME} HOME=${AGENT_HOME} \
+    LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+COPY rootfs/ /
+RUN sed -i "s|__AGENT_HOME__|${AGENT_HOME}|g" /opt/sshd_config \
+ && chmod 0644 /opt/sshd_config \
+ && chmod +x /usr/local/bin/hermes-ssh-sidecar-entrypoint.sh
+
+USER ${AGENT_USER}
+WORKDIR ${AGENT_HOME}
+EXPOSE 2222
+# Override the official ENTRYPOINT (/init + main-wrapper.sh, which would start
+# the gateway). This sidecar runs sshd only.
+ENTRYPOINT ["/usr/local/bin/hermes-ssh-sidecar-entrypoint.sh"]

--- a/hermes-agent-shell-ssh/rootfs/opt/sshd_config
+++ b/hermes-agent-shell-ssh/rootfs/opt/sshd_config
@@ -1,0 +1,15 @@
+Port 2222
+HostKey __AGENT_HOME__/.ssh-host-keys/ssh_host_ed25519_key
+HostKey __AGENT_HOME__/.ssh-host-keys/ssh_host_rsa_key
+AuthorizedKeysFile __AGENT_HOME__/.ssh/authorized_keys
+PubkeyAuthentication yes
+PasswordAuthentication no
+UsePAM no
+StrictModes no
+PidFile __AGENT_HOME__/.ssh/sshd.pid
+# NB: `UsePrivilegeSeparation no` (used by the bookworm-based agent-shell-base)
+# is a REMOVED keyword in the OpenSSH shipped on Debian trixie — including it
+# would make sshd refuse to start. Modern OpenSSH runs privsep unconditionally;
+# a non-root sshd where the login user == the daemon user (both UID 1000 here)
+# does not need to drop privileges, so no directive is required. The CI smoke
+# test asserts sshd actually binds 2222 as UID 1000 with cap-drop=ALL.

--- a/hermes-agent-shell-ssh/rootfs/usr/local/bin/hermes-ssh-sidecar-entrypoint.sh
+++ b/hermes-agent-shell-ssh/rootfs/usr/local/bin/hermes-ssh-sidecar-entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Entry point for the hermes-agent-shell SSH sidecar. Idempotent first-boot prep
+# (host keys + authorized_keys onto the shared PVC), then exec sshd in the
+# foreground so it is PID 1 and the kubelet's TCP probes on 2222 see it directly.
+#
+# Runs as the agent UID (pod securityContext runAsUser 1000). HOME/AGENT_HOME is
+# the shared tool-home PVC at /opt/data/home; host keys persist there across
+# restarts (same mechanism as agent-shell-base's 10-ssh-host-keys).
+set -euo pipefail
+
+: "${AGENT_HOME:=/opt/data/home}"
+
+KEYDIR="${AGENT_HOME}/.ssh-host-keys"
+mkdir -p "$KEYDIR"
+chmod 700 "$KEYDIR"
+if [ ! -f "$KEYDIR/ssh_host_ed25519_key" ]; then
+    echo "[entrypoint] generating SSH host keys (first boot)"
+    ssh-keygen -t ed25519 -f "$KEYDIR/ssh_host_ed25519_key" -N ""
+    ssh-keygen -t rsa -b 4096 -f "$KEYDIR/ssh_host_rsa_key" -N ""
+fi
+chmod 600 "$KEYDIR"/ssh_host_*_key
+
+# Authorized keys from the SOPS-managed Secret (mounted read-only at /etc/ssh-keys
+# in the sidecar only). Copied onto the PVC so sshd reads a 0600 file it owns.
+mkdir -p "${AGENT_HOME}/.ssh"
+chmod 700 "${AGENT_HOME}/.ssh"
+if [ -f /etc/ssh-keys/authorized_keys ]; then
+    install -m 600 /etc/ssh-keys/authorized_keys "${AGENT_HOME}/.ssh/authorized_keys"
+fi
+
+exec /usr/sbin/sshd -D -e -f /opt/sshd_config


### PR DESCRIPTION
New image dir `hermes-agent-shell-ssh/`, sibling to `hermes-agent-shell/`. Built
FROM the official `nousresearch/hermes-agent` tag (unmodified elsewhere) plus
sshd/mosh/tmux and a non-root login identity (UID/GID 1000) whose HOME is the
shared `/opt/data/home` PVC in frank's two-container Deployment. Does not run
the gateway/dashboard — overrides the official ENTRYPOINT to run sshd in the
foreground only.

Companion frank PR (manifests, not synced): derio-net/frank#616

## Known gaps — flagged, not resolved here
- **Not yet wired into `.github/workflows/build.yaml`'s build matrix.** No image
  is published under this name/tag yet. frank's `deployment.yaml` currently pins
  a placeholder SHA (`0000...0000`) for
  `ghcr.io/derio-net/hermes-agent-shell-ssh` pending this.
- **No smoke-test job added.** Sibling sidecar images (`paperclip-shell`,
  `ruflo-shell`) have one in `build.yaml`; this dir does not yet.

Both are next steps before this image can actually be built/published and
before frank#616's placeholder SHA can be resolved to a real one.


---

## Part 1b update (igor, 2026-07-09) — both gaps closed

- **Wired into the `build-children` matrix** (no `BASE_SHA` — this image builds
  `FROM` the official `docker.io/nousresearch/hermes-agent` tag, not the
  `agent-shell-base` chain, same as `ruflo-server`).
- **Smoke test added** (`smoke-test-hermes-agent-shell-ssh`). This sidecar runs
  sshd in the foreground as PID 1 (no s6-overlay), so it asserts a different
  shape than the sibling shells: under the K8s-equivalent securityContext
  (`runAsUser 1000`, `cap-drop=ALL`, `no-new-privileges`) it verifies sshd wrote
  its PidFile, host keys landed on the shared `/opt/data` PVC, port 2222 answers
  with an `SSH-2.0` banner, and `hermes --version` runs as UID 1000 (the whole
  point of building `FROM` the official tag). Validated locally against the built
  image; also gated into `dispatch-frank`.
- **Image IS published** to ghcr from this branch:
  `ghcr.io/derio-net/hermes-agent-shell-ssh:6991631d7e556ed69b156514691418a85304a039`
  (digest `sha256:24f5a9ffc16c8e158e73c9dfabd0e9e32aa687f0c36b73edfa76145c6a95f3d3`),
  built by run 28999391005's `build-children (hermes-agent-shell-ssh)` leg.
  frank#616 now pins this SHA.

### CI caveat (pre-existing, unrelated to this PR)
The overall workflow run is red because the **`secure-agent-kali` build leg is
currently broken by a Kali-rolling upstream package regression**
(`update-alternatives: error: alternative path
/usr/share/man/man7/bash-builtins.7.gz doesn't exist`) — this branch touches **0**
`kali/` files and the same failure reproduces on `main` today (last green main
build was 2026-06-18). Because every `smoke-test-*` job `needs: build-children`,
a single red matrix leg **skips all sibling smoke tests**, including this new one
— they didn't fail, they never ran. The `hermes-agent-shell-ssh` build leg itself
is green and published. Decoupling the smoke tests from the full `build-children`
job (so one broken sibling doesn't skip the rest) is a separate repo-wide workflow
change, out of scope here.
