### PR TITLE
feat(hermes-agent-shell-hindsight): Hindsight memory sidecar image (willikins#285)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -179,6 +179,10 @@ jobs:
             context: hermes-agent-shell
             build_args: |
               BASE_SHA=${{ needs.build-shell-base.outputs.sha }}
+          - name: hermes-agent-shell-hindsight
+            context: hermes-agent-shell-hindsight
+            build_args: |
+              BASE_SHA=${{ needs.build-multi-agent-shell.outputs.sha }}
           - name: infra-shell
             context: infra-shell
             build_args: |
@@ -809,6 +813,84 @@ jobs:
           docker logs has-smoke
           docker rm -f has-smoke
 
+  smoke-test-hermes-agent-shell-hindsight:
+    needs: build-children
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      HINDSIGHT_IMAGE: ghcr.io/derio-net/hermes-agent-shell-hindsight
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Smoke test — PG + hindsight-api boot on an empty PVC, offline, under K8s securityContext
+        env:
+          IMAGE_SHA: ${{ github.sha }}
+        run: |
+          # Match the live sidecar securityContext (runAsUser:1000, cap-drop=ALL,
+          # no-new-privileges). The PVC is emulated by a host dir chowned to 1000
+          # (the fsGroup:1000 equivalent) mounted at /opt/hindsight, so the
+          # cont-init initdb can write PGDATA as the agent UID on an empty volume.
+          #
+          # --network none proves the embedding model loads OFFLINE from the baked
+          # HF cache (no huggingface.co fetch) and that PG/api need only loopback.
+          # Retain is unset here, so the run script defaults LLM_PROVIDER=none —
+          # no LLM client, no egress.
+          mkdir -p /tmp/hindsight-data
+          sudo chown 1000:1000 /tmp/hindsight-data
+          docker run -d --name hindsight-smoke \
+            --user 1000:1000 \
+            --cap-drop=ALL \
+            --security-opt=no-new-privileges \
+            --network none \
+            -v /tmp/hindsight-data:/opt/hindsight \
+            "${HINDSIGHT_IMAGE}:${IMAGE_SHA}"
+
+          # First boot does initdb + torch import + Alembic migrations + model
+          # load, so budget generously.
+          ok=0
+          for i in $(seq 1 180); do
+            code=$(docker exec hindsight-smoke \
+              curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8888/health 2>/dev/null || echo 000)
+            if [ "$code" = 200 ]; then ok=1; echo "✓ /health 200 after ${i}s"; break; fi
+            sleep 1
+          done
+          if [ "$ok" != 1 ]; then
+            echo "✗ hindsight-api /health never returned 200 within 180s"
+            docker logs hindsight-smoke
+            docker rm -f hindsight-smoke
+            exit 1
+          fi
+
+          # DB connected → Alembic migrations ran on the freshly-initdb'd empty
+          # PVC (proves pgvector + schema creation work end-to-end).
+          docker exec hindsight-smoke \
+            curl -s http://127.0.0.1:8888/health | grep -q '"database":"connected"' \
+            || { echo "✗ /health did not report database connected"; docker logs hindsight-smoke; docker rm -f hindsight-smoke; exit 1; }
+
+          # initdb initialized the empty volume (idempotent path).
+          docker exec hindsight-smoke test -s /opt/hindsight/pgdata/PG_VERSION \
+            || { echo "✗ initdb did not initialize /opt/hindsight/pgdata"; docker rm -f hindsight-smoke; exit 1; }
+
+          # Postgres accepts loopback connections on :5433.
+          docker exec hindsight-smoke \
+            /opt/micromamba/envs/hindsight-pg/bin/pg_isready -h 127.0.0.1 -p 5433 \
+            || { echo "✗ postgres not ready on 127.0.0.1:5433"; docker rm -f hindsight-smoke; exit 1; }
+
+          # pgvector extension present (hindsight-api's CREATE EXTENSION vector succeeded).
+          docker exec hindsight-smoke \
+            /opt/micromamba/envs/hindsight-pg/bin/psql -h 127.0.0.1 -p 5433 -U hindsight -d postgres \
+            -tAc "select extname from pg_extension where extname='vector'" | grep -q vector \
+            || { echo "✗ pgvector extension not installed"; docker logs hindsight-smoke; docker rm -f hindsight-smoke; exit 1; }
+
+          echo "✓ hindsight sidecar: PG 18 + pgvector up, api healthy, model loaded offline"
+          docker logs hindsight-smoke | tail -40
+          docker rm -f hindsight-smoke
+
   smoke-test-infra-shell:
     needs: build-children
     runs-on: ubuntu-latest
@@ -916,6 +998,7 @@ jobs:
       - smoke-test-ruflo-server
       - smoke-test-multi-agent-shell
       - smoke-test-hermes-agent-shell
+      - smoke-test-hermes-agent-shell-hindsight
       - smoke-test-infra-shell
     runs-on: ubuntu-latest
     # Only notify frank when the MAIN image tag actually moved: a push to main

--- a/hermes-agent-shell-hindsight/Dockerfile
+++ b/hermes-agent-shell-hindsight/Dockerfile
@@ -65,10 +65,36 @@ RUN chown -R ${AGENT_UID}:${AGENT_GID} /opt/micromamba /opt/hindsight-models
 
 COPY --chown=root:root rootfs/ /
 
-# Disable the inherited sshd longrun: the base bakes an sshd on :2222, which
-# would collide with the main pod's ssh-sidecar in the shared netns. The
-# gated-off agent-session-server longrun stays (harmless: execs sleep infinity).
-RUN rm -rf /etc/services.d/sshd
+# Strip ALL inherited agent-shell scaffolding — this is a headless Hindsight
+# backend, not an interactive shell. The base's cont-init.d/services.d assume a
+# writable MOUNTED $HOME (ssh host/authorized keys, a uv venv for cron
+# heartbeats, native-harness/claude installs, shell inventory, supercronic) and
+# hard-fail here: $HOME is an unmounted image dir (only /opt/hindsight is a PVC).
+# Keep ONLY our own 30-hindsight-initdb cont-init and the postgres/hindsight-api
+# longruns. (sshd would also collide with the main ssh-sidecar on :2222 in the
+# shared pod netns; the claude CLI *binary* stays on PATH for claude-code retain
+# — only the runtime init scripts go.)
+RUN rm -rf \
+      /etc/services.d/sshd \
+      /etc/services.d/supercronic \
+      /etc/services.d/agent-session-server \
+      /etc/cont-init.d/00-run-agent-init \
+      /etc/cont-init.d/10-ssh-host-keys \
+      /etc/cont-init.d/20-venv \
+      /etc/cont-init.d/30-authorized-keys \
+      /etc/cont-init.d/40-skel \
+      /etc/cont-init.d/40-shell-inventory \
+      /etc/cont-init.d/45-native-harnesses \
+      /etc/cont-init.d/46-agent-instructions
+
+# $HOME must be writable by UID 1000: our initdb + service run scripts call
+# `micromamba run`, which acquires a proc-lock under the XDG cache. $HOME is an
+# unmounted image dir here, so redirect the cache to a writable in-image path
+# (the CrashLoop was `micromamba run` failing to lock $HOME/.cache/mamba/proc)
+# and chown $HOME as belt-and-suspenders.
+ENV XDG_CACHE_HOME=/opt/hindsight-cache
+RUN install -d -o ${AGENT_UID} -g ${AGENT_GID} -m 0755 /opt/hindsight-cache \
+ && chown -R ${AGENT_UID}:${AGENT_GID} /home/agent
 
 # Stable hindsight-api settings (pydantic-settings env). LLM/retain provider
 # vars are set by the frank manifest (claude-code), NOT baked here, so the

--- a/hermes-agent-shell-hindsight/Dockerfile
+++ b/hermes-agent-shell-hindsight/Dockerfile
@@ -1,0 +1,95 @@
+ARG BASE_SHA=latest
+FROM ghcr.io/derio-net/multi-agent-shell:${BASE_SHA}
+
+# Inherit AGENT_USER=agent, AGENT_HOME=/home/agent, AGENT_UID=1000 (ENV from
+# agent-shell-base). AGENT_GID is an ARG upstream so it does not propagate —
+# re-declare it for the install -o/-g substitutions below.
+ARG AGENT_GID=1000
+
+USER root
+
+# ---------------------------------------------------------------------------
+# Hindsight backend stack — the permanent, image-baked form of the stack that
+# was hand-run on the migrate pod (derio-net/willikins#285). Ground-truth
+# recipe extracted verbatim from the live env: PostgreSQL 18.4 + pgvector 0.8.3
+# (conda-forge) and hindsight-api-slim[local-ml] 0.8.4 (public PyPI → torch-CPU
+# + sentence-transformers). Baked into the IMAGE at /opt/micromamba, so a pod
+# restart never loses the stack; only DATA lives on the PVC.
+#
+# We build FROM multi-agent-shell (not a bare micromamba base) deliberately: it
+# supplies s6-overlay, the UID-1000 `agent` user, and the baked `claude` CLI +
+# claude-agent-sdk that the `claude-code` Hindsight retain provider drives.
+# ---------------------------------------------------------------------------
+ENV MAMBA_ROOT_PREFIX=/opt/micromamba
+ENV HINDSIGHT_ENV=hindsight-pg
+ENV HF_HOME=/opt/hindsight-models
+ARG MICROMAMBA_VERSION=2.8.1
+ARG HINDSIGHT_API_VERSION=0.8.4
+ARG TORCH_VERSION=2.13.0
+# Pin the embedding-model revision so the baked snapshot is byte-reproducible.
+ARG BGE_REVISION=5c38ec7c405ec4b44b94cc5a9bb96e735b38267a
+
+# micromamba binary (static; extracts bin/micromamba).
+RUN curl -Ls "https://micro.mamba.pm/api/micromamba/linux-64/${MICROMAMBA_VERSION}" \
+      | tar -xj -C /usr/local bin/micromamba \
+ && micromamba --version
+
+# conda-forge env: python + postgresql + pgvector extension. The env matches
+# the live `hindsight-pg` env; pgvector 0.8.3 provides vector.so/vector.control
+# so hindsight-api's Alembic `CREATE EXTENSION vector` succeeds on first boot.
+RUN micromamba create -y -n "${HINDSIGHT_ENV}" -c conda-forge \
+      "python=3.11" pip "postgresql=18.4" "pgvector=0.8.3" \
+ && micromamba clean -qya
+
+# torch first, pinned to the +cpu index so the ML stack stays CPU-only (no
+# multi-GB CUDA wheels) — matches the live torch==2.13.0+cpu.
+RUN micromamba run -n "${HINDSIGHT_ENV}" pip install --no-cache-dir \
+      --index-url https://download.pytorch.org/whl/cpu "torch==${TORCH_VERSION}"
+
+# hindsight-api-slim with the local-ml extra (sentence-transformers, onnxruntime,
+# etc.). torch is already satisfied above; the cpu extra-index keeps any
+# transitive torch resolution CPU-only.
+RUN micromamba run -n "${HINDSIGHT_ENV}" pip install --no-cache-dir \
+      --extra-index-url https://download.pytorch.org/whl/cpu \
+      "hindsight-api-slim[local-ml]==${HINDSIGHT_API_VERSION}" \
+ && micromamba run -n "${HINDSIGHT_ENV}" hindsight-api --help >/dev/null
+
+# Pre-bake the embedding model into the IMAGE HF cache (HF_HOME) so the API
+# loads it offline, on CPU, with no network at runtime.
+RUN micromamba run -n "${HINDSIGHT_ENV}" python -c \
+      "from huggingface_hub import snapshot_download; snapshot_download('BAAI/bge-small-en-v1.5', revision='${BGE_REVISION}')"
+
+# The baked stack must be readable/executable by UID 1000 (the runtime user);
+# the env is immutable at runtime, all mutable state is on the PVC.
+RUN chown -R ${AGENT_UID}:${AGENT_GID} /opt/micromamba /opt/hindsight-models
+
+COPY --chown=root:root rootfs/ /
+
+# Disable the inherited sshd longrun: the base bakes an sshd on :2222, which
+# would collide with the main pod's ssh-sidecar in the shared netns. The
+# gated-off agent-session-server longrun stays (harmless: execs sleep infinity).
+RUN rm -rf /etc/services.d/sshd
+
+# Stable hindsight-api settings (pydantic-settings env). LLM/retain provider
+# vars are set by the frank manifest (claude-code), NOT baked here, so the
+# image is provider-agnostic.
+ENV HINDSIGHT_API_DATABASE_URL=postgresql://hindsight:hindsight@127.0.0.1:5433/postgres \
+    HINDSIGHT_API_EMBEDDINGS_PROVIDER=local \
+    HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL=BAAI/bge-small-en-v1.5 \
+    HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=true \
+    HINDSIGHT_API_RERANKER_PROVIDER=rrf \
+    HINDSIGHT_PGDATA=/opt/hindsight/pgdata
+
+# Pre-create the PVC mount point (UID 1000 owned so initdb can write once
+# fsGroup makes the mounted volume group-writable) and make the s6 scripts
+# executable — under K8s the agent UID cannot chmod root-owned files at runtime.
+RUN install -d -o ${AGENT_UID} -g ${AGENT_GID} -m 0755 /opt/hindsight \
+ && chmod +x \
+      /etc/cont-init.d/30-hindsight-initdb \
+      /etc/services.d/postgres/run \
+      /etc/services.d/hindsight-api/run
+
+USER ${AGENT_USER}
+WORKDIR ${AGENT_HOME}
+EXPOSE 8888
+# ENTRYPOINT inherited from agent-shell-base: /init (s6-overlay)

--- a/hermes-agent-shell-hindsight/Dockerfile
+++ b/hermes-agent-shell-hindsight/Dockerfile
@@ -54,10 +54,14 @@ RUN micromamba run -n "${HINDSIGHT_ENV}" pip install --no-cache-dir \
       "hindsight-api-slim[local-ml]==${HINDSIGHT_API_VERSION}" \
  && micromamba run -n "${HINDSIGHT_ENV}" hindsight-api --help >/dev/null
 
-# Pre-bake the embedding model into the IMAGE HF cache (HF_HOME) so the API
-# loads it offline, on CPU, with no network at runtime.
+# Pre-bake the embedding model into a fixed LOCAL dir (not the hub cache) so the
+# API loads it offline, on CPU, BY PATH — bypassing hub refs/revision resolution.
+# A revision-pinned snapshot_download populates snapshots/<hash>/ but writes no
+# refs/main, so loading by repo-id offline (SentenceTransformer's default `main`
+# revision) fails "not in cached files". local_dir + a path-valued model env
+# sidesteps that entirely while keeping the revision pin.
 RUN micromamba run -n "${HINDSIGHT_ENV}" python -c \
-      "from huggingface_hub import snapshot_download; snapshot_download('BAAI/bge-small-en-v1.5', revision='${BGE_REVISION}')"
+      "from huggingface_hub import snapshot_download; snapshot_download('BAAI/bge-small-en-v1.5', revision='${BGE_REVISION}', local_dir='/opt/hindsight-models/bge-small-en-v1.5')"
 
 # The baked stack must be readable/executable by UID 1000 (the runtime user);
 # the env is immutable at runtime, all mutable state is on the PVC.
@@ -99,12 +103,17 @@ RUN install -d -o ${AGENT_UID} -g ${AGENT_GID} -m 0755 /opt/hindsight-cache \
 # Stable hindsight-api settings (pydantic-settings env). LLM/retain provider
 # vars are set by the frank manifest (claude-code), NOT baked here, so the
 # image is provider-agnostic.
+# The embedding model is a PATH (the baked local_dir), not a repo-id, so it
+# loads offline without hub resolution. HF_HUB_OFFLINE/TRANSFORMERS_OFFLINE make
+# the sidecar strictly self-contained (no accidental huggingface.co fetch).
 ENV HINDSIGHT_API_DATABASE_URL=postgresql://hindsight:hindsight@127.0.0.1:5433/postgres \
     HINDSIGHT_API_EMBEDDINGS_PROVIDER=local \
-    HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL=BAAI/bge-small-en-v1.5 \
+    HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL=/opt/hindsight-models/bge-small-en-v1.5 \
     HINDSIGHT_API_EMBEDDINGS_LOCAL_FORCE_CPU=true \
     HINDSIGHT_API_RERANKER_PROVIDER=rrf \
-    HINDSIGHT_PGDATA=/opt/hindsight/pgdata
+    HINDSIGHT_PGDATA=/opt/hindsight/pgdata \
+    HF_HUB_OFFLINE=1 \
+    TRANSFORMERS_OFFLINE=1
 
 # Pre-create the PVC mount point (UID 1000 owned so initdb can write once
 # fsGroup makes the mounted volume group-writable) and make the s6 scripts

--- a/hermes-agent-shell-hindsight/README.md
+++ b/hermes-agent-shell-hindsight/README.md
@@ -1,0 +1,57 @@
+# hermes-agent-shell-hindsight
+
+The **Hindsight memory sidecar** for the `hermes-agent-shell` pod on Frank
+(`derio-net/willikins#285`). It runs the Hindsight backend — PostgreSQL 18.4 +
+`hindsight-api-slim` — as a dedicated, k8s-supervised container alongside the
+bare official `nousresearch/hermes-agent` main container. Hermes reaches it in
+`local_external` mode over the shared pod loopback (`127.0.0.1:8888`), exactly
+as it did when the backend was hand-run inside the old custom image — but now
+supervised by s6, isolated on its own PVC, and running strict non-root.
+
+## Why a sidecar
+
+The official Hermes image ships only the Hindsight *client*; it has no embedded
+backend (no `hindsight_embed`, no Postgres, no torch). The permanent design puts
+the backend in this separate image so the main container stays the unmodified
+official image, k8s supervises the backend (no in-pod watchdog), Postgres gets a
+clean non-root `securityContext` (impossible in the root-bound main container),
+and the memory volume — isolated on its own PVC — auto-joins Longhorn's existing
+backup group. See the design spec in willikins:
+`docs/superpowers/specs/2026-07-09-hermes-official-migration-design.md`.
+
+## Stack (ground-truth recipe, willikins#285)
+
+Built `FROM ghcr.io/derio-net/multi-agent-shell` — inherits s6-overlay, the
+UID-1000 `agent` user, and the baked `claude`/`codex` CLIs used by the
+`claude-code` retain provider. On top:
+
+- **micromamba env `hindsight-pg`** (baked into the image, not the PVC):
+  `postgresql=18.4` + `hindsight-api-slim[local-ml]==0.8.4` (public PyPI) →
+  torch-CPU + sentence-transformers.
+- **`BAAI/bge-small-en-v1.5`** pre-baked into the image HF cache (offline, CPU).
+- **s6 longruns**: `postgres` (loopback `:5433`) and `hindsight-api` (`:8888`),
+  `hindsight-api` gated on `pg_isready`.
+- **sshd disabled** — the base bakes an sshd on `:2222`, which would collide
+  with the main pod's ssh-sidecar in the shared netns.
+
+## Data vs. image
+
+- **Image** carries the *stack* (binaries, Python env, embedding model).
+- **PVC** (`hermes-agent-shell-hindsight`, mounted at `/opt/hindsight`) carries
+  only *data*: `PGDATA=/opt/hindsight/pgdata`. A fresh volume is `initdb`'d by
+  `cont-init.d/30-hindsight-initdb` (locale `C.UTF-8`, role `hindsight`, db
+  `postgres`); production data is `pg_restore`d on top during migration.
+
+## Retain
+
+Recall works with no LLM. Retain (writing new memories) uses
+`HINDSIGHT_API_LLM_PROVIDER=claude-code` (set by the frank manifest, Sonnet),
+reusing the pre-migration provider. Left wired-dark until the model var is
+confirmed; recall is unaffected.
+
+## Smoke test
+
+CI (`.github/workflows/build.yaml`) boots the image under the live K8s-equivalent
+`securityContext` and asserts: s6 brings both services up, Postgres accepts
+connections, `hindsight-api` `/health` returns `healthy`, and the embedding
+model loads offline.

--- a/hermes-agent-shell-hindsight/rootfs/etc/cont-init.d/30-hindsight-initdb
+++ b/hermes-agent-shell-hindsight/rootfs/etc/cont-init.d/30-hindsight-initdb
@@ -1,0 +1,27 @@
+#!/command/with-contenv bash
+# Initialize an empty Hindsight PVC on first boot, before s6 starts the
+# postgres longrun. IDEMPOTENT: if PGDATA is already initialized (PG_VERSION
+# present) it no-ops — production memory arrives via `pg_restore` on top of a
+# fresh initdb during migration, and pod restarts must never re-init.
+#
+# Ground-truth recipe (willikins#285): superuser role `hindsight`, default db
+# `postgres`, UTF8 / C.UTF-8, trust auth on loopback (the live pg_hba). Runs as
+# UID 1000; the frank pod sets fsGroup:1000 so the mounted PVC is writable.
+set -eu
+
+export MAMBA_ROOT_PREFIX=/opt/micromamba
+PGDATA=${HINDSIGHT_PGDATA:-/opt/hindsight/pgdata}
+
+if [ -s "$PGDATA/PG_VERSION" ]; then
+  echo "[hindsight-initdb] $PGDATA already initialized (PG $(cat "$PGDATA/PG_VERSION")) — skipping"
+  exit 0
+fi
+
+mkdir -p "$PGDATA"
+micromamba run -n hindsight-pg initdb \
+  -D "$PGDATA" \
+  -U hindsight \
+  --encoding=UTF8 --locale=C.UTF-8 \
+  --auth-local=trust --auth-host=trust
+
+echo "[hindsight-initdb] initialized empty PGDATA at $PGDATA (role hindsight, db postgres, C.UTF-8)"

--- a/hermes-agent-shell-hindsight/rootfs/etc/cont-init.d/30-hindsight-initdb
+++ b/hermes-agent-shell-hindsight/rootfs/etc/cont-init.d/30-hindsight-initdb
@@ -13,15 +13,21 @@ export MAMBA_ROOT_PREFIX=/opt/micromamba
 PGDATA=${HINDSIGHT_PGDATA:-/opt/hindsight/pgdata}
 
 if [ -s "$PGDATA/PG_VERSION" ]; then
-  echo "[hindsight-initdb] $PGDATA already initialized (PG $(cat "$PGDATA/PG_VERSION")) — skipping"
-  exit 0
+  echo "[hindsight-initdb] $PGDATA already initialized (PG $(cat "$PGDATA/PG_VERSION")) — skipping initdb"
+else
+  mkdir -p "$PGDATA"
+  micromamba run -n hindsight-pg initdb \
+    -D "$PGDATA" \
+    -U hindsight \
+    --encoding=UTF8 --locale=C.UTF-8 \
+    --auth-local=trust --auth-host=trust
+  echo "[hindsight-initdb] initialized empty PGDATA at $PGDATA (role hindsight, db postgres, C.UTF-8)"
 fi
 
-mkdir -p "$PGDATA"
-micromamba run -n hindsight-pg initdb \
-  -D "$PGDATA" \
-  -U hindsight \
-  --encoding=UTF8 --locale=C.UTF-8 \
-  --auth-local=trust --auth-host=trust
-
-echo "[hindsight-initdb] initialized empty PGDATA at $PGDATA (role hindsight, db postgres, C.UTF-8)"
+# `fsGroup:1000` makes k8s recursively re-apply group perms to the PVC on EVERY
+# (re)mount (default policy Always), loosening PGDATA to g+rwx on restart —
+# PostgreSQL refuses any data dir wider than 0750 and CrashLoops. Force 0700
+# every boot (uid 1000 owns PGDATA, so this always succeeds, and it self-heals a
+# dir already loosened by a prior boot).
+chmod 700 "$PGDATA"
+echo "[hindsight-initdb] PGDATA perms normalized to 0700"

--- a/hermes-agent-shell-hindsight/rootfs/etc/services.d/hindsight-api/run
+++ b/hermes-agent-shell-hindsight/rootfs/etc/services.d/hindsight-api/run
@@ -1,0 +1,28 @@
+#!/command/with-contenv bash
+# hindsight-api (hindsight-api-slim 0.8.4) — the local_external backend Hermes
+# talks to over the pod loopback at 127.0.0.1:8888.
+#
+# Launch command + stable settings are the ground-truth recipe from the live
+# migrate pod (willikins#285). The HINDSIGHT_API_* settings are pydantic-
+# settings env (no config file). The DATABASE_URL / EMBEDDINGS / RERANKER
+# values are fixed for this image and baked as ENV in the Dockerfile; the
+# LLM_* retain vars come from the frank manifest (claude-code provider, or
+# `none` for recall-only) and are inherited here via with-contenv.
+#
+# Direct exec, no s6-setuidgid — same reason as the postgres run script.
+#
+# hindsight-api needs Postgres accepting connections before it binds, so we
+# gate on pg_isready. s6 supervises restarts; no while/sleep restart loop.
+export MAMBA_ROOT_PREFIX=/opt/micromamba
+export HF_HOME=${HF_HOME:-/opt/hindsight-models}
+: "${HINDSIGHT_API_LLM_PROVIDER:=none}"
+export HINDSIGHT_API_LLM_PROVIDER
+
+# Wait for the loopback Postgres to accept connections.
+until /opt/micromamba/envs/hindsight-pg/bin/pg_isready -h 127.0.0.1 -p 5433 -q; do
+  echo "[hindsight-api] waiting for postgres on 127.0.0.1:5433 ..."
+  sleep 1
+done
+
+exec micromamba run -n hindsight-pg \
+  hindsight-api --host 127.0.0.1 --port 8888 --log-level info

--- a/hermes-agent-shell-hindsight/rootfs/etc/services.d/postgres/run
+++ b/hermes-agent-shell-hindsight/rootfs/etc/services.d/postgres/run
@@ -1,0 +1,22 @@
+#!/command/with-contenv bash
+# PostgreSQL 18.4 for the Hindsight sidecar — loopback-only on :5433.
+#
+# Launch command is the ground-truth recipe extracted from the live migrate
+# pod (willikins#285): `postgres -D <PGDATA> -p 5433 -k /tmp -c
+# listen_addresses=127.0.0.1`. PG serves ONLY the pod's loopback (shared
+# netns); no container port is declared in the frank manifest.
+#
+# Direct exec, NO s6-setuidgid: under the live K8s securityContext
+# (runAsNonRoot, runAsUser:1000, cap-drop=ALL, no-new-privileges) s6-overlay
+# already runs as UID 1000 and s6-setuidgid's setgroups() needs CAP_SETGID,
+# which is dropped — mirrors the base image's sshd / agent-session-server
+# run scripts. PostgreSQL refuses to run as root but is happy as UID 1000
+# against a 1000-owned PGDATA (that's why the sidecar can be strict non-root
+# where the root-bound main container cannot).
+#
+# initdb of an empty PVC happens earlier in cont-init.d/30-hindsight-initdb,
+# so PGDATA is always initialized by the time s6 starts this longrun.
+export MAMBA_ROOT_PREFIX=/opt/micromamba
+PGDATA=${HINDSIGHT_PGDATA:-/opt/hindsight/pgdata}
+exec micromamba run -n hindsight-pg \
+  postgres -D "$PGDATA" -p 5433 -k /tmp -c listen_addresses=127.0.0.1


### PR DESCRIPTION
The permanent **Hindsight memory sidecar** image for the `hermes-agent-shell` pod migration (`derio-net/willikins#285`). Validated end-to-end on-cluster.

## What it is
`FROM multi-agent-shell` (s6, uid-1000 user, baked `claude` CLI + claude-agent-sdk for `claude-code` retain) + a micromamba env (the ground-truth recipe extracted from the live env): `postgresql=18.4` + `pgvector=0.8.3` (conda-forge) + `hindsight-api-slim[local-ml]==0.8.4` (public PyPI, torch-CPU) + a pre-baked `BAAI/bge-small-en-v1.5`. s6 longruns: postgres (loopback :5433) + hindsight-api (:8888). Idempotent `initdb` cont-init; hindsight-api auto-migrates (Alembic, 21 tables, `CREATE EXTENSION vector`) on first boot. Stack baked in the image; only PGDATA on the PVC (`/opt/hindsight`). Strict non-root.

## Validated (2026-07-11)
Live on the temporary migrate deployment: sidecar boots healthy, **369 memory_units restored and surviving pod restarts** on the sidecar PVC, dashboard reachable. Three image bugs were found and fixed during the shakeout (all in this branch):
1. CrashLoop — inherited multi-agent-shell shell-init assumed a writable mounted `$HOME` → stripped all inherited cont-init.d/services.d; writable mamba cache.
2. Offline model wouldn't load (revision-pinned bake had no `refs/main`) → bake to `local_dir`, load by path.
3. Restart CrashLoop (fsGroup loosens PGDATA to g+rwx) → `chmod 700 $PGDATA` every boot (self-heals).

Two further issues were **manifest-side** (frank#616), not image: the restore harness (old data dir also fsGroup-loosened) and the k8s probes (must be `exec` against loopback, not `httpGet` on the pod IP — hindsight-api binds `127.0.0.1` only).

## Status — do not merge standalone
Draft, cutover-gated. Merging this to main publishes the image on a permanent tag AND triggers the dispatch-frank bump — so it's **cutover step 1** (see willikins#285 / frank#616). CI is red only due to the pre-existing unrelated `secure-agent-kali` build break (skips sibling smokes on the shared matrix); the `hermes-agent-shell-hindsight` build leg itself is green and the image is validated live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)