### PR TITLE
ci: decouple the frank auto-bump from the flaky kali build leg

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -148,6 +148,16 @@ jobs:
   build-children:
     needs: [build-base, build-shell-base, build-multi-agent-shell]
     runs-on: ubuntu-latest
+    # secure-agent-kali is the one child that periodically breaks on Kali-rolling
+    # transitions (t64, GCC churn) — a flake unrelated to every other image. Make
+    # ONLY its matrix leg soft (fail-fast:false above already keeps a kali failure
+    # from cancelling the sibling builds) so a broken kali build no longer fails
+    # build-children and starves the downstream smokes + the frank auto-bump. The
+    # kali SMOKE stays hard (a real regression still reds the run), and
+    # dispatch-frank no longer needs it (see its needs: below); frank's bump
+    # handler pins per-image by GHCR tag existence, so it skips any image not
+    # actually published at the SHA.
+    continue-on-error: ${{ matrix.image.name == 'secure-agent-kali' }}
     strategy:
       # One child's external flake (e.g. ruflo-server's build-time
       # router.huggingface.co fetch returning 429, #115) must not cancel the
@@ -1098,7 +1108,13 @@ jobs:
       - test-multi-agent-shell
       - build-children
       - smoke-test-vk-local
-      - smoke-test-secure-agent-kali
+      # NOT smoke-test-secure-agent-kali (deliberately dropped): kali is the
+      # known-flaky Kali-rolling leg (t64 / GCC churn). Gating the frank bump on
+      # it means one kali break starves EVERY image's delivery to frank. The kali
+      # build leg is soft (build-children.continue-on-error) and its smoke stays a
+      # hard signal, but the bump no longer waits on it. Safe because frank's
+      # agent-images-bump handler pins per-image by GHCR tag existence, so it
+      # skips kali at a SHA where kali did not publish (no ImagePullBackOff).
       - smoke-test-paperclip-shell
       - smoke-test-ruflo-shell
       - smoke-test-ruflo-server


### PR DESCRIPTION
## Problem
The `dispatch-frank` auto-bump stalls whenever `secure-agent-kali` breaks (Kali-rolling t64 / GCC churn):
`secure-agent-kali` build fails → `build-children` fails → all `smoke-test-*` skip → `dispatch-frank` (needs every smoke) skips → **no bump PR**. One flaky image starves every other image's delivery to frank.

## Changes
- **`build-children`**: `continue-on-error` on **only** the `secure-agent-kali` matrix leg (`fail-fast: false` already keeps it from cancelling siblings). A broken kali build no longer fails the job or starves the downstream smokes / the bump. Every other image still builds and publishes at the SHA.
- **`dispatch-frank`**: drop `smoke-test-secure-agent-kali` from `needs`. The kali smoke **stays a hard signal** (a real regression still reds the run), but the bump no longer waits on it.

## Why this is handler-aware (important)
frank's `agent-images-bump` handler currently **blindly pins every image** to the incoming `$AI_SHA` (sed across `apps/`, plus a Verify-coverage step that *fails* unless all pins equal `$AI_SHA`). So a bump firing while kali is unbuilt would point `secure-agent-pod` at a non-existent `secure-agent-kali:<sha>` → **ImagePullBackOff**.

The companion frank PR makes the handler **pin per-image by GHCR tag existence** (skip + warn any image whose `:<sha>` tag isn't published), which makes this decoupling safe. **That frank PR should merge before or with this one.**

Design alternative considered: passing the built-image set through `client_payload` and consuming it in the handler. Rejected in favour of the handler querying GHCR directly — it's self-contained in frank and robust to *any* image missing for *any* reason, not just kali.

## Validation
**Best-effort, unverified at prep time** (CI/cluster down for maintenance; docker pruned). YAML + structure validated locally (`continue-on-error` expression parses, kali smoke removed from `needs`). CI validates on the next build. No related open issue found.

Draft — do not merge during the maintenance window. Pairs with the kali build fix (#138) and the frank handler PR.