### PR TITLE
fix(kali): put /usr/sbin on PATH so t64 maintainer scripts can configure (corrects #138)

### DIFF
--- a/kali/Dockerfile
+++ b/kali/Dockerfile
@@ -52,26 +52,26 @@ RUN sed -i "s|/home/agent|${AGENT_HOME}|g" /opt/sshd_config \
 # and aborts dist-upgrade; --force-overwrite is the canonical resolution — it
 # only permits file overwrites, never dependency breakage.
 #
-# t64 config-order hardening (2026-07): even with --force-overwrite, dist-upgrade
-# can exit 100 on a dependency *configuration* ordering failure during the t64
-# transition. For example libtss2-sys1t64 / libtss2-esys-3.0.2-0t64 leave
-# `systemd` unpacked-but-unconfigured (Errors were encountered while processing:
-# systemd), and --force-overwrite only permits file overwrites, never config/dep
-# ordering. So the sequence below lets the first dist-upgrade fail, then
-# converges: `dpkg --configure -a` configures every unpacked package (ordering
-# now resolvable), `apt-get install -f` repairs broken deps, and a second
-# dist-upgrade re-runs and STILL fails the build if the tree is genuinely broken
-# rather than merely mis-ordered.
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# REAL cause of the 2026-07 dist-upgrade failure (misdiagnosed as config-ordering
+# in #138 — that convergence hardening did NOT fix it): the base lineage
+# (base/Dockerfile, agent-shell-base/Dockerfile) sets a PATH WITHOUT /usr/sbin or
+# /sbin. The t64 library renames make dpkg run the maintainer scripts of
+# tpm-udev / libtss2* / systemd, which invoke `ldconfig` and `start-stop-daemon`
+# (both in /usr/sbin). dpkg can't find them ("dpkg: error: 2 expected programs
+# not found in PATH", "Package tpm-udev is not configured yet"), so every
+# configure fails and dist-upgrade cascades to exit 100. No amount of
+# --force-overwrite or `dpkg --configure -a` fixes a missing PATH. Prepend the
+# sbin dirs for this RUN so the maintainer scripts resolve. (The proper root fix
+# is to add sbin to the base images' ENV PATH — larger blast radius since it
+# changes every descendant's runtime PATH, so it's a separate follow-up.)
+RUN export PATH="/usr/local/sbin:/usr/sbin:/sbin:$PATH" \
+    && apt-get update && apt-get install -y --no-install-recommends \
       lsb-release wget gnupg \
     && wget -qO - https://archive.kali.org/archive-key.asc \
       | gpg --dearmor -o /usr/share/keyrings/kali-archive-keyring.gpg \
     && echo "deb [signed-by=/usr/share/keyrings/kali-archive-keyring.gpg] https://kali.download/kali kali-rolling main non-free contrib" \
       > /etc/apt/sources.list.d/kali.list \
     && apt-get update \
-    && { apt-get dist-upgrade -y -o Dpkg::Options::="--force-overwrite" || true; } \
-    && dpkg --configure -a --force-confdef --force-confold \
-    && apt-get install -f -y -o Dpkg::Options::="--force-overwrite" \
     && apt-get dist-upgrade -y -o Dpkg::Options::="--force-overwrite" \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## #138 didn't fix it — real root cause found
#138 merged but the `secure-agent-kali` build on main **still fails**. My earlier "config-order hardening" was a misdiagnosis. dpkg spells out the actual cause:
```
dpkg: warning: 'ldconfig' not found in PATH or not executable
dpkg: warning: 'start-stop-daemon' not found in PATH or not executable
dpkg: error: 2 expected programs not found in PATH or not executable
Note: root's PATH should usually contain /usr/local/sbin, /usr/sbin and /sbin
```
The base lineage sets a **sbin-less PATH**:
- `base/Dockerfile`: `PATH=/home/claude/.local/bin:/usr/local/bin:/usr/bin:/bin`
- `agent-shell-base/Dockerfile`: `PATH=${AGENT_HOME}/.local/bin:/usr/local/bin:/usr/bin:/bin`

The t64 library renames make dpkg run the maintainer scripts of `tpm-udev` / `libtss2*` / `systemd`, which call `ldconfig` and `start-stop-daemon` (both in `/usr/sbin`). dpkg can't find them → every configure fails → `tpm-udev is not configured yet` → dist-upgrade cascades to exit 100. `--force-overwrite` and `dpkg --configure -a` cannot fix a *missing PATH*, which is why #138's hardening was inert.

## Fix
- Prepend `/usr/local/sbin:/usr/sbin:/sbin` to PATH for the apt RUN so the maintainer scripts resolve.
- Revert the #138 convergence hardening back to the plain `dist-upgrade --force-overwrite` (the #122 file-overwrite fix stays; it's still valid for that class).

## Follow-up (not in this PR)
The **proper** root fix is to add sbin to the base images' `ENV PATH` — but that changes the runtime PATH of *every* descendant agent-shell image (all of them inherit it), so it's a larger-blast-radius change worth its own PR + review. This PR is the targeted kali-only fix.

## Validation
**Best-effort, unverified** (cluster/CI down; docker pruned). Next `build-children` run on main validates. Supersedes #138's approach — #138 is already merged, so this corrects it forward.

Draft — do not merge during the maintenance window.