### PR TITLE
fix(kali): reset /run to root during dist-upgrade so systemd 261 can configure

### DIFF
--- a/kali/Dockerfile
+++ b/kali/Dockerfile
@@ -64,6 +64,14 @@ RUN sed -i "s|/home/agent|${AGENT_HOME}|g" /opt/sshd_config \
 # sbin dirs for this RUN so the maintainer scripts resolve. (The proper root fix
 # is to add sbin to the base images' ENV PATH — larger blast radius since it
 # changes every descendant's runtime PATH, so it's a separate follow-up.)
+#
+# AND /run ownership (2026-07): agent-shell-base chowns /run to the agent uid
+# (1000) so s6-overlay can write its supervisor sockets there at runtime. But
+# systemd 261's tmpfiles refuses an "unsafe path transition" when creating
+# root-owned /run/systemd under a non-root /run, so `systemd` fails to configure
+# during dist-upgrade — and tpm-udev (depends on systemd) → libtss2* (depend on
+# tpm-udev) cascade to exit 100. Reset /run to root just for the upgrade so
+# systemd configures, then restore agent ownership (1000:1000) for the s6 runtime.
 RUN export PATH="/usr/local/sbin:/usr/sbin:/sbin:$PATH" \
     && apt-get update && apt-get install -y --no-install-recommends \
       lsb-release wget gnupg \
@@ -72,7 +80,9 @@ RUN export PATH="/usr/local/sbin:/usr/sbin:/sbin:$PATH" \
     && echo "deb [signed-by=/usr/share/keyrings/kali-archive-keyring.gpg] https://kali.download/kali kali-rolling main non-free contrib" \
       > /etc/apt/sources.list.d/kali.list \
     && apt-get update \
+    && chown root:root /run \
     && apt-get dist-upgrade -y -o Dpkg::Options::="--force-overwrite" \
+    && chown -R 1000:1000 /run \
     && rm -rf /var/lib/apt/lists/*
 
 # ── Kali tooling + logrotate (openssh-server/tmux/mosh inherited from agent-shell-base) ──


### PR DESCRIPTION
## The actual root cause (finally visible after #140)
#140's PATH fix cleared the `ldconfig`/`start-stop-daemon` errors, and the next CI log shows what was underneath:
```
Setting up systemd (261.1-2) ...
Detected unsafe path transition /run (owned by claude) → /run/systemd (owned by root) during canonicalization of run/systemd.
dpkg: error processing package systemd (--configure): ...
tpm-udev depends on systemd | ... ; Package systemd is not configured yet
→ libtss2-sys1t64 / libtss2-esys / libtss2-tcti-* depend on tpm-udev → exit 100
```

`agent-shell-base/Dockerfile:80` does `chown -R ${AGENT_UID}:${AGENT_GID} /run` so s6-overlay can write supervisor sockets at runtime. **systemd 261's `systemd-tmpfiles` now refuses** to create root-owned `/run/systemd` under a non-root `/run` (a new hardening check), so `systemd` fails to configure — and `tpm-udev` (needs systemd) → all the `libtss2*` (need tpm-udev) cascade to exit 100.

## Fix
The kali RUN is `USER root` (Dockerfile:13), so:
- `chown root:root /run` immediately before `dist-upgrade` → systemd's tmpfiles accepts the transition and configures cleanly, unblocking tpm-udev + libtss2*.
- `chown -R 1000:1000 /run` immediately after → restores the agent ownership s6-overlay needs at runtime.

Non-recursive chown to root is enough for the tmpfiles check (only the `/run` → `/run/systemd` transition matters); the restore is recursive to re-own anything systemd created plus the pre-existing `/run/s6`, `/run/sshd` dirs.

## Progression
- #138: config-order hardening — misdiagnosis, inert (merged).
- #140: PATH fix (`/usr/sbin` for ldconfig/start-stop-daemon) — necessary, revealed this (merged).
- This PR: the `/run` ownership issue that was the real head of the cascade. Evidence says this is the last layer, but I still **can't build at prep time** (cluster/CI down, docker pruned) — the next `build-children` run on main is the real confirmation.

Draft — do not merge during the maintenance window.