### PR TITLE
ci(hermes-ssh-smoke): mount /opt/data/home like the live pod's home PVC

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -849,12 +849,18 @@ jobs:
           # Match the live pod securityContext (runAsUser 1000, cap-drop=ALL,
           # no-new-privileges): the non-root sshd must bind 2222 without ever
           # chowning /run at runtime (it pre-chowns /run/sshd at build time). The
-          # bind mount stands in for the shared /opt/data PVC (fsGroup:1000 in the
-          # pod); mount at /opt/data — not /opt/data/home — so both first-boot
-          # host-key writes AND the `hermes` CLI (which reads HERMES_HOME=/opt/data)
-          # work as UID 1000. chown to 1000 mirrors fsGroup.
-          mkdir -p /tmp/hermes-ssh-optdata
-          sudo chown 1000:1000 /tmp/hermes-ssh-optdata
+          # bind mounts stand in for the pod's PVCs (fsGroup:1000). The live pod
+          # mounts TWO volumes — the data PVC at /opt/data AND the tool-home PVC
+          # at /opt/data/home — so the smoke must too. The official base declares
+          # `VOLUME /opt/data` (HERMES_HOME=/opt/data), and a single 1000-owned
+          # bind at /opt/data alone leaves /opt/data/home NOT agent-writable, so
+          # the entrypoint's first-boot `mkdir ~/.ssh-host-keys` dies Permission
+          # denied (this smoke never ran until kali unblocked build-children, so
+          # the gap only surfaced now). Mounting /opt/data/home explicitly, 1000-
+          # owned like its PVC, is what makes the host-key + sshd.pid writes work
+          # as UID 1000.
+          mkdir -p /tmp/hermes-ssh-optdata /tmp/hermes-ssh-home
+          sudo chown 1000:1000 /tmp/hermes-ssh-optdata /tmp/hermes-ssh-home
 
           docker run -d --name hermes-ssh-smoke \
             --user 1000:1000 \
@@ -862,6 +868,7 @@ jobs:
             --security-opt=no-new-privileges \
             -p 12222:2222 \
             -v /tmp/hermes-ssh-optdata:/opt/data \
+            -v /tmp/hermes-ssh-home:/opt/data/home \
             "${HERMES_SSH_IMAGE}:${IMAGE_SHA}"
 
           # First boot generates host keys (incl. rsa-4096, a couple seconds) then


### PR DESCRIPTION
## Why it failed now
`smoke-test-hermes-agent-shell-ssh` **never actually ran** until #141 fixed kali — a broken `secure-agent-kali` leg was failing `build-children`, which skipped every `smoke-test-*`. Now that build-children is green, this smoke ran for the first time and failed:
```
mkdir: cannot create directory '/opt/data/home/.ssh-host-keys': Permission denied
✗ sshd never wrote its PidFile within 30s
```

## Root cause: the smoke harness, not the image
The official base declares **`VOLUME /opt/data`** (`HERMES_HOME=/opt/data`, confirmed from its image config). The smoke bind-mounted a 1000-owned dir at `/opt/data` **only**. But the live pod mounts **two** PVCs — the data PVC at `/opt/data` **and** the tool-home PVC at `/opt/data/home`, both under `fsGroup:1000` — so `/opt/data/home` is agent-writable there. With a single `/opt/data` bind, `/opt/data/home` isn't agent-writable, so the entrypoint's first-boot `mkdir ~/.ssh-host-keys` (uid 1000) dies.

The **image is correct** — the live pod works because it mounts `/opt/data/home` as its own PVC. The smoke just wasn't mirroring that topology.

## Fix
Mount `/opt/data/home` as its own 1000-owned bind in the smoke, matching the pod's home PVC. One-line-ish harness change; no image change.

## Validation
**Best-effort, unverified** (docker pruned locally). Please dispatch a branch build to confirm before merging:
```
gh workflow run "Build agent images" --repo derio-net/agent-images --ref fix/hermes-ssh-smoke-home-mount
```

Draft. Part of getting agent-images `main` fully green (needed before the dispatch-frank bump / Hermes cutover).