### PR TITLE
test(hermes-agent-shell): assert rsync and gh runtime prerequisites

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -775,6 +775,14 @@ jobs:
           # so a green `--version` also proves the relocatable copy works.
           docker exec has-smoke hermes --version
 
+          # Runtime prerequisites used by hermes-brain maintenance and general
+          # operator workflows must remain present in the shell image. In
+          # particular, rsync backs the hermes-brain sync/snapshot scripts and
+          # gh provides the documented git-credential helper path used across
+          # derio-net repos.
+          docker exec has-smoke sh -c 'command -v rsync >/dev/null'
+          docker exec has-smoke sh -c 'command -v gh >/dev/null'
+
           # frank#496 — PVC-resident venv: the live venv must be on the PVC,
           # uid-1000-owned and WRITABLE (the whole point: the in-pod operator
           # can patch Hermes in place). The image seed at /opt is just a

--- a/hermes-agent-shell/README.md
+++ b/hermes-agent-shell/README.md
@@ -150,7 +150,9 @@ the standard's smoke contract: sshd up under K8s-equivalent
 securityContext, `hermes --version` runs cleanly as UID 1000, and
 `hermes-agent-shell-reconcile` produces a clean exit and a non-empty MOTD
 against an empty inventory. The BYOK MOTD drop-in is asserted present and
-runnable.
+runnable. The smoke path also asserts `rsync` and `gh` remain on PATH,
+because hermes-brain maintenance and the documented git credential-helper
+flow depend on them.
 
 Local bats coverage:
 


### PR DESCRIPTION
## Summary
- extend the hermes-agent-shell smoke test to assert `rsync` and `gh` are present on PATH
- document why those binaries matter for hermes-brain maintenance and the documented git credential-helper flow

## Why
The live Hermes-brain investigation on 2026-07-13 found maintenance depends on `rsync`, and the documented GitHub credential-helper path depends on `gh`. These are easy to regress silently in image churn unless CI checks them explicitly.

## Test Plan
- smoke-test-hermes-agent-shell in CI
- git diff --check locally
