### PR TITLE
fix(hermes-ssh): add gh and rsync to the sidecar

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -941,6 +941,13 @@ jobs:
           docker exec hermes-ssh-smoke hermes --version \
             || { echo "✗ hermes CLI not runnable as UID 1000 in the sidecar"; docker logs hermes-ssh-smoke; docker rm -f hermes-ssh-smoke; exit 1; }
 
+          # Operator-side runtime prerequisites: `gh` for GitHub auth / PR work,
+          # and `rsync` for hermes-brain sync + snapshot flows.
+          docker exec hermes-ssh-smoke sh -c 'command -v gh >/dev/null' \
+            || { echo "✗ gh not present in the Hermes SSH sidecar"; docker logs hermes-ssh-smoke; docker rm -f hermes-ssh-smoke; exit 1; }
+          docker exec hermes-ssh-smoke sh -c 'command -v rsync >/dev/null' \
+            || { echo "✗ rsync not present in the Hermes SSH sidecar"; docker logs hermes-ssh-smoke; docker rm -f hermes-ssh-smoke; exit 1; }
+
           docker logs hermes-ssh-smoke
           docker rm -f hermes-ssh-smoke
 

--- a/hermes-agent-shell-ssh/Dockerfile
+++ b/hermes-agent-shell-ssh/Dockerfile
@@ -26,13 +26,18 @@ ARG AGENT_UID=1000
 ARG AGENT_GID=1000
 ARG AGENT_HOME=/opt/data/home
 
-# sshd + mosh + tmux only. C.UTF-8 (glibc built-in) covers mosh's UTF-8
-# requirement, so we skip the ~200MB locales-all the old base pulled in.
+# sshd + mosh + tmux for terminal access, plus the operator-side prerequisites
+# the Hermes shell workflows assume: `gh` for GitHub auth / PR work and `rsync`
+# for hermes-brain sync + snapshot scripts. C.UTF-8 (glibc built-in) covers
+# mosh's UTF-8 requirement, so we skip the ~200MB locales-all the old base
+# pulled in.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       openssh-server \
       mosh \
       tmux \
       passwd \
+      gh \
+      rsync \
     && rm -rf /var/lib/apt/lists/*
 
 # Create the login identity. The official image has no UID-1000 user; mirror


### PR DESCRIPTION
## Summary
- install `gh` and `rsync` in `hermes-agent-shell-ssh`
- document why those tools are required for operator workflows
- assert both tools in the Hermes SSH sidecar smoke test

## Why
The Hermes SSH sidecar is the operator-facing shell for the two-container Hermes pod. It needs `gh` for GitHub auth / PR work and `rsync` for hermes-brain sync + snapshot maintenance flows.

## Verification
- reviewed the live Frank deployment and confirmed the SSH sidecar is the custom Hermes image to extend
- verified the Dockerfile + smoke-test diff in the worktree
- attempted a local `docker build`, but this host has no reachable Docker daemon (`Cannot connect to the Docker daemon at unix:///var/run/docker.sock`)