### PR TITLE
feat(agent-session): versioned authenticated /v1 contract + home-ownership fix

### DIFF
--- a/.devcontainer/dev/devcontainer-lock.json
+++ b/.devcontainer/dev/devcontainer-lock.json
@@ -1,0 +1,19 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    },
+    "ghcr.io/jsburckhardt/devcontainer-features/uv:1": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/jsburckhardt/devcontainer-features/uv@sha256:542a0bc2203205b3c696de650ba862f280b20af3543493cc232edd9ac35791f7",
+      "integrity": "sha256:542a0bc2203205b3c696de650ba862f280b20af3543493cc232edd9ac35791f7"
+    }
+  }
+}

--- a/multi-agent-shell/Dockerfile
+++ b/multi-agent-shell/Dockerfile
@@ -79,6 +79,14 @@ RUN install -d -o ${AGENT_UID} -g ${AGENT_GID} -m 0755 \
  && ln -sf /usr/local/lib/multi-agent-shell/agent-session \
            /usr/local/bin/agent-session
 
+# Own the whole home tree as the agent UID (CNC node fix). install-base-runtimes.sh
+# and other root-stage steps above create dirs under ${AGENT_HOME} (~/.cache,
+# ~/.config, ~/.local, ~/.npm) owned by root. When a CNC node mounts a NAMED or PV
+# volume at ${AGENT_HOME}, first-use copy-up PRESERVES that root ownership, and s6
+# cont-init (running as the agent UID) then fails to mkdir under them — the node
+# exits before it boots. Chowning here makes copy-up inherit agent ownership.
+RUN chown -R ${AGENT_UID}:${AGENT_GID} ${AGENT_HOME}
+
 USER ${AGENT_USER}
 WORKDIR ${AGENT_HOME}
 EXPOSE 2222

--- a/multi-agent-shell/README.md
+++ b/multi-agent-shell/README.md
@@ -224,22 +224,49 @@ there is no postStart hook or restart loop to wire up. `agent-session send
 ### API
 
 ```
-POST /session/send   {session_id, agent, message, timeout_s?}
-                  -> {session_id, agent, status, turn, payload}
-GET  /healthz        -> 200 {"status":"ok"}
+POST /v1/session/send   Authorization: Bearer <runner-token>   (when a token is configured)
+                        Idempotency-Key: <wake-stable-key>      (optional; de-dups a retry)
+                        {session_id, agent, message, timeout_s?, capability?}
+                     -> {session_id, agent, status, turn, payload, started, error_code}
+POST /session/send      (legacy alias of /v1/session/send — kept one migration cycle)
+GET  /healthz           -> 200 {"status":"ok"}   (unauthenticated; leaks no metadata)
 ```
 
-Bound on `127.0.0.1:${AGENT_SESSION_PORT:-8765}` (pod-local; same netns as the
-consumer — never the wildcard address). `status` is `ok` or `timeout` (the
-per-turn file never appeared); on timeout `payload` is `null`, so a consumer
-can fall back to a deterministic render.
+`status` is `ok`, `timeout`, or `failed`. **`started`** is the retry
+discriminator: `false` *only* when the turn was rejected before any harness
+session began (bad auth, malformed `session_id`, bad JSON) — safe to retry;
+`true` once the message was submitted (a later timeout/disconnect is **not**
+retryable). **`error_code`** is a stable machine value
+(`not_started`/`timeout`/…) or `null` on success. A repeated **`Idempotency-Key`**
+returns the first turn's cached result instead of firing a duplicate turn.
+
+**Auth & bind (CNC /v1 upgrade).** The bind defaults to `127.0.0.1` — the legacy
+pod-local posture — so existing loopback consumers are unchanged. A consumer that
+needs cross-container/pod reach (e.g. cncd on a runner network) sets
+`AGENT_SESSION_BIND` explicitly **and** supplies a runner token
+(`AGENT_SESSION_RUNNER_TOKEN[_FILE]`); the server **refuses to bind a non-loopback
+address without a token** (fail-closed). When a token is set, every
+`/v1/session/send` (and legacy) POST needs a constant-time-checked
+`Authorization: Bearer`, else `401` before any session is created.
+
+**Run capability.** An optional `capability` in the body (a run-scoped CNC token)
+is written to a **mode-0600 file** in the turn cwd; the turn message tells the
+harness the file *path* (never the token) so its credential helper can call the
+CNC API as the agent. The file is deleted when the turn ends and the token is
+never echoed into the message or transcript.
 
 ### Environment
 
 | Var | Default | Purpose |
 |-----|---------|---------|
 | `AGENT_SESSION_SERVE` | `0` | `1` starts the baked serve longrun |
-| `AGENT_SESSION_PORT` | `8765` | loopback port the HTTP server binds |
+| `AGENT_SESSION_PORT` | `8765` | port the HTTP server binds |
+| `AGENT_SESSION_BIND` | `127.0.0.1` | bind address; a non-loopback value requires a runner token |
+| `AGENT_SESSION_RUNNER_TOKEN` | — | bearer token the server checks (constant-time); empty ⇒ no auth (loopback only) |
+| `AGENT_SESSION_RUNNER_TOKEN_FILE` | — | read the runner token from a mounted secret file instead |
+| `AGENT_SESSION_CRED_DIR` | `~/.agent-session/cred` | where the per-turn 0600 capability file is brokered |
+| `AGENT_SESSION_IDEM_DIR` | `~/.agent-session/idem` | idempotency-key result cache |
+| `AGENT_SESSION_IDEM_TTL_S` | `86400` | idempotency cache TTL (s) |
 | `AGENT_SESSION_TURN_DIR` | `~/.agent-session` | per-session turn counters |
 | `AGENT_SESSION_OUT_DIR` | `~/.agent-session/out` | per-turn output files |
 | `AGENT_SESSION_POLL_S` | `2` | output-file poll interval (s) |
@@ -259,12 +286,17 @@ cycle** so a consumer mid-migration never breaks.
 |---------|----------------|--------|
 | `claude` (default) | `claude --permission-mode auto` | wired + verified |
 | `codex` | `codex --full-auto` | config-selectable — **auto-approve invocation not yet verified live (follow-up)** |
-| `antigravity` | `agy --yolo` | config-selectable — **auto-approve invocation not yet verified live (follow-up)** |
+| `agy` | `agy --yolo` | config-selectable — **not yet verified live (follow-up)** |
+| `opencode` | `opencode` | config-selectable — **not yet verified live (follow-up)** |
+| `antigravity` | `agy --yolo` | deprecated alias of `agy` (one migration cycle; gemini-cli retired) |
 
-An unrecognized `agent` falls back to the verified `claude` profile. The auto-
-approve flag lets the session write its per-turn output file without a prompt
-(short of a full permissions bypass). Correcting a `codex`/`antigravity` flag
-is a one-line edit to the `LAUNCH_PROFILES` table in the driver.
+These match the CNC harness enum `claude-code|codex|opencode|agy` (spec a §5),
+mapped to launch-profile names by the caller (`claude-code`→`claude`). An
+unrecognized `agent` falls back to the verified `claude` profile — the node is
+lenient; cncd's adapter is the component that rejects an unknown harness value.
+The auto-approve flag lets the session write its per-turn output file without a
+prompt (short of a full permissions bypass). Correcting a flag is a one-line
+edit to the `LAUNCH_PROFILES` table in the driver.
 
 ## Plan / spec
 

--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
@@ -14,6 +14,7 @@ on the image's python3 with no extra deps.
 """
 import fcntl
 import glob
+import hmac
 import json
 import os
 import re
@@ -27,11 +28,30 @@ import uuid
 def _env(new, old, default):
     # Read the genericized AGENT_SESSION_* var, falling back to the deprecated
     # STOA_* alias if unset, then the default. Keeps a consumer mid-migration
-    # working for one cycle without setting the new name.
+    # working for one cycle without setting the new name. `old=None` skips the
+    # alias lookup (for vars that never had a STOA_* name).
     val = os.environ.get(new)
-    if val is None:
+    if val is None and old is not None:
         val = os.environ.get(old)
     return val if val is not None else default
+
+
+def _runner_token():
+    # The per-runner service credential that authenticates cncd -> node on the
+    # /v1 contract. Read from AGENT_SESSION_RUNNER_TOKEN, else the file named by
+    # AGENT_SESSION_RUNNER_TOKEN_FILE (a mounted secret). Empty/unset => no auth
+    # (dev/loopback only — serve() refuses a non-loopback bind without it).
+    tok = os.environ.get("AGENT_SESSION_RUNNER_TOKEN")
+    if tok:
+        return tok.strip()
+    path = os.environ.get("AGENT_SESSION_RUNNER_TOKEN_FILE")
+    if path:
+        try:
+            with open(path) as fh:
+                return fh.read().strip()
+        except OSError:
+            return ""
+    return ""
 
 
 HOME = os.path.expanduser("~")
@@ -49,6 +69,26 @@ READY_TIMEOUT_S = float(_env("AGENT_SESSION_READY_TIMEOUT_S", "STOA_READY_TIMEOU
 # or crashed claude never shows ❯, so the probe gives up fast and recreates.
 READY_PROBE_S = float(_env("AGENT_SESSION_READY_PROBE_S", "STOA_READY_PROBE_S", "3"))
 PORT = int(_env("AGENT_SESSION_PORT", "STOA_SESSION_PORT", "8765"))
+# Bind address (CNC /v1 upgrade). Default STAYS 127.0.0.1 — existing consumers
+# (n8n, alert-agent) rely on the loopback-only posture, so the shared image's
+# default is never loosened. A consumer that needs cross-container/pod reach
+# (cncd on the runner network) OPTS IN by setting AGENT_SESSION_BIND explicitly,
+# and serve() REFUSES any non-loopback bind unless a runner token is also
+# configured (fail-closed — the endpoint can never be exposed unauthenticated).
+BIND = _env("AGENT_SESSION_BIND", None, "127.0.0.1")
+# Per-turn CNC run capability (spec b Scope 2 broker) written mode-0600 here; the
+# launch profile's credential helper reads it, and it is deleted at turn end. The
+# token is NEVER placed in the turn message (only the file path is).
+CRED_DIR = _env("AGENT_SESSION_CRED_DIR", None, os.path.join(HOME, ".agent-session", "cred"))
+# Idempotency store (spec b Scope 5 / AF-7): a wake-stable Idempotency-Key maps to
+# its completed response so a cncd retry after restart returns the first result
+# instead of firing a duplicate turn. Best-effort on-disk cache, TTL-swept.
+IDEM_DIR = _env("AGENT_SESSION_IDEM_DIR", None, os.path.join(HOME, ".agent-session", "idem"))
+IDEM_TTL_S = float(_env("AGENT_SESSION_IDEM_TTL_S", None, str(24 * 3600)))
+# session_id is used in tmux target names and filesystem paths — constrain it so a
+# caller can't traverse paths or inject tmux target syntax (colon/dot are tmux
+# session:window.pane separators; the node login shell uses the `node-` convention).
+_SAFE_SESSION_RE = re.compile(r"^[A-Za-z0-9_-]{1,128}$")
 # Fix E — persistent resumable conversations. last_activity timestamps live on
 # the PVC beside the turn counter; an idle gap > IDLE_RESET_S triggers a /clear
 # (fresh conversation, SAME --session-id) before the next message. COMPACT_PCT is
@@ -79,6 +119,10 @@ READY_MARKER = "❯"
 LAUNCH_PROFILES = {
     "claude": "claude --permission-mode auto",
     "codex": "codex --full-auto",
+    "agy": "agy --yolo",
+    "opencode": "opencode",
+    # deprecated alias for one migration cycle (gemini-cli retired 2026-06-18; the
+    # CNC harness enum is claude-code|codex|opencode|agy — spec a §5).
     "antigravity": "agy --yolo",
 }
 DEFAULT_AGENT = "claude"
@@ -313,9 +357,85 @@ def context_pct(pane):
     return None
 
 
-def response(session_id, agent, status, turn, payload):
+def response(session_id, agent, status, turn, payload, started, error_code=None):
+    # `started` is the AF-7 retry discriminator: False ONLY when the turn was
+    # rejected before any harness process/session began (safe to retry); True once
+    # the message was submitted (including a subsequent timeout/disconnect — NOT
+    # retryable). `error_code` is a stable machine value (not_started, timeout,
+    # harness_failed, canceled, unavailable) or None on success.
     return {"session_id": session_id, "agent": agent, "status": status,
-            "turn": turn, "payload": payload}
+            "turn": turn, "payload": payload, "started": started,
+            "error_code": error_code}
+
+
+def _write_capability(session_id, nonce, capability):
+    # Broker the per-turn CNC run token to a mode-0600 file the launch profile's
+    # credential helper reads (never the turn message). Returns the path.
+    os.makedirs(CRED_DIR, exist_ok=True)
+    path = os.path.join(CRED_DIR, "{}.{}.cred".format(session_id, nonce))
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as fh:
+        fh.write(capability)
+    return path
+
+
+def _idem_path(key):
+    safe = re.sub(r"[^A-Za-z0-9_.-]", "_", key)[:200]
+    return os.path.join(IDEM_DIR, safe + ".json")
+
+
+def _idem_get(key):
+    # Return the cached completed response for a wake-stable key, or None. Sweeps
+    # its own entry if past TTL so a reused key eventually re-runs.
+    path = _idem_path(key)
+    try:
+        st = os.stat(path)
+    except OSError:
+        return None
+    if time.time() - st.st_mtime > IDEM_TTL_S:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+        return None
+    try:
+        with open(path) as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _idem_put(key, resp):
+    os.makedirs(IDEM_DIR, exist_ok=True)
+    path = _idem_path(key)
+    tmp = path + ".tmp"
+    try:
+        with open(tmp, "w") as fh:
+            json.dump(resp, fh)
+        os.replace(tmp, path)
+    except OSError:
+        pass
+
+
+def send_idempotent(req, idempotency_key):
+    # Dedup a wake-stable key: a completed result is returned as-is; a concurrent
+    # duplicate serializes on the key lock then sees the cached result. Without a
+    # key, plain send() (existing behavior).
+    if not idempotency_key:
+        return send(req)
+    os.makedirs(IDEM_DIR, exist_ok=True)
+    lockpath = _idem_path(idempotency_key) + ".lock"
+    with open(lockpath, "w") as lk:
+        fcntl.flock(lk, fcntl.LOCK_EX)
+        cached = _idem_get(idempotency_key)
+        if cached is not None:
+            return cached
+        resp = send(req)
+        # Cache only STARTED turns — an un-started rejection (auth/validation) is
+        # safe to retry, so it must not be pinned to the key.
+        if resp.get("started"):
+            _idem_put(idempotency_key, resp)
+        return resp
 
 
 def send(req):
@@ -325,7 +445,13 @@ def send(req):
     # ensure_session's liveness probe against a MID-TURN REPL (no ❯ while it streams)
     # and kill the in-flight session. flock (not threading.Lock) covers BOTH
     # consumers; a different session_id locks a different file → no contention.
-    session_id = req["session_id"]
+    session_id = req.get("session_id", "")
+    agent = req.get("agent", "claude")
+    # Validate session_id BEFORE it is used to build any tmux target or filesystem
+    # path (it is interpolated into the lock path just below). A malformed value is
+    # refused pre-start (started=False → retryable), never mangled or traversed.
+    if not _SAFE_SESSION_RE.match(session_id or ""):
+        return response(session_id, agent, "failed", 0, None, False, "not_started")
     os.makedirs(TURN_DIR, exist_ok=True)
     lockpath = os.path.join(TURN_DIR, session_id + ".send.lock")
     with open(lockpath, "w") as lk:
@@ -338,6 +464,10 @@ def _send_locked(req):
     agent = req.get("agent", "claude")
     message = req["message"]
     timeout_s = float(req.get("timeout_s", 300))
+    capability = req.get("capability")
+    # session_id is validated in send() before any path is built. The agent-enum
+    # check is cncd's adapter's job (spec b Scope 1); the node keeps
+    # launch_command's lenient fallback so existing image consumers are unaffected.
 
     ensure_session(session_id, agent)
 
@@ -362,50 +492,87 @@ def _send_locked(req):
     except OSError:
         pass
 
+    # Broker the run capability to a mode-0600 file and tell the harness the PATH
+    # (never the token itself — spec b Scope 2). Deleted in the finally below.
+    cred_path = None
+    cred_note = ""
+    if capability:
+        cred_path = _write_capability(session_id, nonce, capability)
+        cred_note = (
+            "\n[agent-session] Your CNC API token is in the file "
+            + cred_path
+            + " (mode 0600). Read it via your credential helper to call the CNC API "
+            + "as yourself; never echo the token itself into output or this transcript."
+        )
+
     driven = (
         message
+        + cred_note
         + "\n\n[agent-session] When done, write ONLY the JSON result to the file "
         + outfile
         + " — raw JSON, overwrite it, nothing else in that file."
     )
-    submit(session_id, driven)
+    # Past this point a harness turn has begun: started=True (not retryable).
+    try:
+        submit(session_id, driven)
 
-    # The file appearing + parsing IS the completion signal (robust to TUI
-    # rendering / soft-wrapping). Tolerate a partial write by retrying.
-    deadline = time.monotonic() + timeout_s
-    while time.monotonic() < deadline:
-        if os.path.exists(outfile):
+        # The file appearing + parsing IS the completion signal (robust to TUI
+        # rendering / soft-wrapping). Tolerate a partial write by retrying.
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            if os.path.exists(outfile):
+                try:
+                    with open(outfile) as fh:
+                        payload = json.load(fh)
+                except (OSError, json.JSONDecodeError):
+                    time.sleep(POLL_S)
+                    continue
+                try:
+                    os.remove(outfile)
+                except OSError:
+                    pass
+                turn = bump_turn(session_id)
+                # Touch on SUCCESS only (I2): a stuck/timing-out session is NOT marked
+                # active, so after IDLE_RESET_S it trips the idle /clear recovery above —
+                # "last conversation" = the last real exchange, per the operator's intent.
+                touch_last_activity(session_id)
+                # Proactive compaction (Fix E, best-effort): if the context indicator reads
+                # >= COMPACT_PCT used, /compact to bound growth; None/unparseable → defer to
+                # claude's near-limit auto-compact. Safe: payload already read+removed and
+                # turn bumped, so /compact can't corrupt THIS turn; the per-session flock
+                # serializes the NEXT turn so its ensure_session won't probe mid-compaction (N1).
+                pct = context_pct(_pane(session_id))
+                if pct is not None and pct >= COMPACT_PCT:
+                    submit(session_id, "/compact")
+                return response(session_id, agent, "ok", turn, payload, True)
+            time.sleep(POLL_S)
+
+        # Timed out with the turn already in flight — started=True → NOT retried.
+        return response(session_id, agent, "timeout", read_turn(session_id), None,
+                        True, "timeout")
+    finally:
+        if cred_path:
             try:
-                with open(outfile) as fh:
-                    payload = json.load(fh)
-            except (OSError, json.JSONDecodeError):
-                time.sleep(POLL_S)
-                continue
-            try:
-                os.remove(outfile)
+                os.remove(cred_path)
             except OSError:
                 pass
-            turn = bump_turn(session_id)
-            # Touch on SUCCESS only (I2): a stuck/timing-out session is NOT marked
-            # active, so after IDLE_RESET_S it trips the idle /clear recovery above —
-            # "last conversation" = the last real exchange, per the operator's intent.
-            touch_last_activity(session_id)
-            # Proactive compaction (Fix E, best-effort): if the context indicator reads
-            # >= COMPACT_PCT used, /compact to bound growth; None/unparseable → defer to
-            # claude's near-limit auto-compact. Safe: payload already read+removed and
-            # turn bumped, so /compact can't corrupt THIS turn; the per-session flock
-            # serializes the NEXT turn so its ensure_session won't probe mid-compaction (N1).
-            pct = context_pct(_pane(session_id))
-            if pct is not None and pct >= COMPACT_PCT:
-                submit(session_id, "/compact")
-            return response(session_id, agent, "ok", turn, payload)
-        time.sleep(POLL_S)
-
-    return response(session_id, agent, "timeout", read_turn(session_id), None)
 
 
 def serve():
     from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    runner_token = _runner_token()
+    is_loopback = BIND in ("127.0.0.1", "::1", "localhost")
+    # Fail-closed: never expose the code-execution endpoint on a routable address
+    # without a runner token. Loopback keeps the legacy netns-sharing posture.
+    if not is_loopback and not runner_token:
+        print("agent-session serve: refusing to bind non-loopback address "
+              "{!r} without AGENT_SESSION_RUNNER_TOKEN[_FILE]".format(BIND),
+              file=sys.stderr)
+        raise SystemExit(1)
+
+    # Accept both the versioned CNC path and the legacy path (one migration cycle).
+    send_paths = ("/v1/session/send", "/session/send")
 
     class Handler(BaseHTTPRequestHandler):
         def _json(self, code, obj):
@@ -416,37 +583,56 @@ def serve():
             self.end_headers()
             self.wfile.write(body)
 
+        def _authorized(self):
+            # Constant-time bearer check. No configured token => auth disabled
+            # (only reachable on loopback per the bind guard above).
+            if not runner_token:
+                return True
+            got = self.headers.get("Authorization", "")
+            if not got.startswith("Bearer "):
+                return False
+            return hmac.compare_digest(got[7:], runner_token)
+
         def do_GET(self):
+            # /healthz is unauthenticated but leaks no runner/harness metadata.
             if self.path == "/healthz":
                 self._json(200, {"status": "ok"})
             else:
                 self._json(404, {"status": "error", "error": "not found"})
 
         def do_POST(self):
-            if self.path != "/session/send":
+            if self.path not in send_paths:
                 self._json(404, {"status": "error", "error": "not found"})
+                return
+            if not self._authorized():
+                # 401 BEFORE any session is created (started=false semantics).
+                self._json(401, {"status": "error", "error": "unauthorized",
+                                 "started": False, "error_code": "not_started"})
                 return
             n = int(self.headers.get("Content-Length", "0") or 0)
             try:
                 req = json.loads(self.rfile.read(n) or b"{}")
             except json.JSONDecodeError:
-                self._json(400, {"status": "error", "error": "bad json"})
+                self._json(400, {"status": "error", "error": "bad json",
+                                 "started": False, "error_code": "not_started"})
                 return
-            self._json(200, send(req))
+            idem = self.headers.get("Idempotency-Key", "")
+            self._json(200, send_idempotent(req, idem))
 
         def log_message(self, *a):  # quiet
             pass
 
-    # Pod-local only: the consumer shares the pod netns — bind loopback, never
-    # the wildcard address. Threaded so a long send() never head-of-line-blocks
-    # /healthz or a concurrent request.
+    # Threaded so a long send() never head-of-line-blocks /healthz or a
+    # concurrent request. Bind is configurable (default loopback); a routable
+    # bind is gated on a runner token by the fail-closed guard above.
     try:
-        server = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
+        server = ThreadingHTTPServer((BIND, PORT), Handler)
     except OSError as exc:
         # Surface bind failures (handler logs are silenced, not stderr). Under
         # the baked s6 longrun this stderr lands in the agent-session-server
         # service / container logs (`docker logs` / `kubectl logs`).
-        print(f"agent-session serve: bind 127.0.0.1:{PORT} failed: {exc}", file=sys.stderr)
+        print("agent-session serve: bind {}:{} failed: {}".format(BIND, PORT, exc),
+              file=sys.stderr)
         raise
     server.daemon_threads = True
     server.serve_forever()

--- a/multi-agent-shell/tests/test_agent_session.py
+++ b/multi-agent-shell/tests/test_agent_session.py
@@ -25,6 +25,7 @@ import subprocess
 import sys
 import time
 import types
+import urllib.error
 import urllib.request
 from pathlib import Path
 
@@ -43,7 +44,7 @@ SEND_REQ = {
     "message": "Investigate the surge and write a structured finding.",
     "timeout_s": 300,
 }
-RECV_KEYS = {"session_id", "agent", "status", "turn", "payload"}
+RECV_KEYS = {"session_id", "agent", "status", "turn", "payload", "started", "error_code"}
 PAYLOAD = {"finding": "traffic surge", "severity": "info", "sources": []}
 
 # Fake tmux: load-buffer stages the message, paste-buffer holds it, send-keys
@@ -96,6 +97,17 @@ if cmd == "send-keys":
         else:
             open(p("box.txt"), "w").write("")   # submitted → input box clears
             msg = open(p("pending.txt")).read() if os.path.exists(p("pending.txt")) else ""
+            # Witness a brokered capability file (content + octal mode) BEFORE the
+            # driver deletes it, so the broker test can assert 0600 + exact content.
+            cm = re.search(r"token is in the file (\S+)", msg)
+            if cm:
+                try:
+                    cpath = cm.group(1)
+                    st = os.stat(cpath)
+                    open(p("cred_mode.txt"), "w").write(oct(st.st_mode & 0o777))
+                    open(p("cred_witness.txt"), "w").write(open(cpath).read())
+                except OSError:
+                    pass
             m = re.search(r"to the file (\S+)", msg)
             if m:
                 outfile = m.group(1)
@@ -591,3 +603,143 @@ def test_http_server_serves_session_send(harness):
         assert out["status"] == "ok" and out["payload"] == PAYLOAD
     finally:
         proc.terminate(); proc.wait(timeout=5)
+
+
+# ── CNC /v1 contract upgrade (spec b Scope 8) ────────────────────────────────
+
+def _start_server(harness, port, extra_env=None):
+    (harness.fdir / "has.code").write_text("0")
+    env = dict(harness.env); env["AGENT_SESSION_PORT"] = str(port)
+    if extra_env:
+        env.update(extra_env)
+    proc = subprocess.Popen([sys.executable, str(harness.drv), "serve"],
+                            env=env, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    return proc
+
+
+def _wait_healthz(base, proc=None):
+    for _ in range(50):
+        if proc is not None and proc.poll() is not None:
+            return False
+        try:
+            with urllib.request.urlopen(base + "/healthz", timeout=1) as r:
+                if r.status == 200:
+                    return True
+        except Exception:
+            time.sleep(0.1)
+    return False
+
+
+def _post(base, path, req, headers=None):
+    h = {"Content-Type": "application/json"}
+    if headers:
+        h.update(headers)
+    r = urllib.request.Request(base + path, data=json.dumps(req).encode(),
+                               headers=h, method="POST")
+    try:
+        with urllib.request.urlopen(r, timeout=10) as resp:
+            return resp.status, json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        return e.code, json.loads(e.read() or b"{}")
+
+
+def test_started_and_error_code_on_success(harness):
+    out = json.loads(harness.run(SEND_REQ).stdout)
+    assert out["status"] == "ok"
+    assert out["started"] is True, "a completed turn must report started=True"
+    assert out["error_code"] is None
+
+
+def test_bad_session_id_rejected_before_start(harness):
+    bad = dict(SEND_REQ, session_id="../../etc/evil")
+    out = json.loads(harness.run(bad).stdout)
+    assert out["status"] == "failed"
+    assert out["started"] is False, "a malformed session_id must be rejected pre-start (retryable)"
+    assert out["error_code"] == "not_started"
+
+
+def test_v1_path_is_served(harness):
+    port = _free_port()
+    proc = _start_server(harness, port)
+    try:
+        base = f"http://127.0.0.1:{port}"
+        assert _wait_healthz(base, proc), "server did not become ready"
+        code, out = _post(base, "/v1/session/send", SEND_REQ)
+        assert code == 200 and out["status"] == "ok" and out["started"] is True
+    finally:
+        proc.terminate(); proc.wait(timeout=5)
+
+
+def test_v1_requires_bearer_when_token_configured(harness):
+    port = _free_port()
+    token = "runner-secret-abc123"
+    proc = _start_server(harness, port, {"AGENT_SESSION_RUNNER_TOKEN": token})
+    try:
+        base = f"http://127.0.0.1:{port}"
+        assert _wait_healthz(base, proc), "server did not become ready"
+        # No credential → 401, no session created.
+        code, out = _post(base, "/v1/session/send", SEND_REQ)
+        assert code == 401 and out["started"] is False
+        # Wrong token → 401.
+        code, _ = _post(base, "/v1/session/send", SEND_REQ,
+                        {"Authorization": "Bearer wrong"})
+        assert code == 401
+        # Correct token → 200.
+        code, out = _post(base, "/v1/session/send", SEND_REQ,
+                          {"Authorization": "Bearer " + token})
+        assert code == 200 and out["status"] == "ok"
+    finally:
+        proc.terminate(); proc.wait(timeout=5)
+
+
+def test_idempotency_key_dedups_the_turn(harness):
+    port = _free_port()
+    proc = _start_server(harness, port)
+    try:
+        base = f"http://127.0.0.1:{port}"
+        assert _wait_healthz(base, proc), "server did not become ready"
+        hdr = {"Idempotency-Key": "wake-42"}
+        code1, out1 = _post(base, "/v1/session/send", SEND_REQ, hdr)
+        code2, out2 = _post(base, "/v1/session/send", SEND_REQ, hdr)
+        assert code1 == 200 and code2 == 200
+        # The second call returns the FIRST result (same turn) instead of firing a
+        # duplicate turn — the AF-7 wake-stable-key guarantee.
+        assert out2 == out1, "a repeated idempotency key must return the cached result"
+        pastes = (harness.fdir / "pastes.log").read_text().splitlines()
+        assert len(pastes) == 1, f"the message must be submitted exactly once, got {pastes}"
+    finally:
+        proc.terminate(); proc.wait(timeout=5)
+
+
+def test_capability_brokered_to_0600_file_then_removed(harness):
+    cred_dir = harness.home / "creddir"
+    token = "CNC-RUN-TOKEN-do-not-leak"
+    env = dict(harness.env); env["AGENT_SESSION_CRED_DIR"] = str(cred_dir)
+    req = dict(SEND_REQ, capability=token)
+    (harness.fdir / "has.code").write_text("0")
+    out = json.loads(subprocess.run(
+        [sys.executable, str(harness.drv), "send", json.dumps(req)],
+        capture_output=True, text=True, env=env, timeout=30).stdout)
+    assert out["status"] == "ok"
+    # The token was written to a mode-0600 file (witnessed before deletion)…
+    assert (harness.fdir / "cred_witness.txt").read_text() == token
+    assert (harness.fdir / "cred_mode.txt").read_text() == "0o600"
+    # …the turn message referenced the PATH, never the token itself…
+    pasted = (harness.fdir / "buffer.txt").read_text()
+    assert token not in pasted, "the capability token must never appear in the turn message"
+    assert "token is in the file" in pasted
+    # …and the cred file is deleted when the turn ends.
+    assert not list(cred_dir.glob("*.cred")), "the brokered cred file must be removed after the turn"
+
+
+def test_serve_refuses_nonloopback_bind_without_token(harness):
+    port = _free_port()
+    proc = _start_server(harness, port, {"AGENT_SESSION_BIND": "0.0.0.0"})
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.terminate(); proc.wait(timeout=5)
+        raise AssertionError("serve must exit (fail-closed), not bind 0.0.0.0 without a token")
+    assert proc.returncode != 0, "non-loopback bind without a runner token must fail-closed"
+    err = proc.stderr.read().decode()
+    assert "refusing to bind" in err


### PR DESCRIPTION

Advance the agent-session server to a versioned, authenticated contract so a networked consumer (not just a same-netns/loopback one) can drive turns safely, and fix a home-volume boot bug. Both improve this repo's own standard.

agent-session driver:
- POST /v1/session/send (legacy /session/send kept one migration cycle)
- constant-time Bearer runner-token auth (AGENT_SESSION_RUNNER_TOKEN[_FILE]); 401 before any session is created
- Idempotency-Key de-dup: a stable key returns the first turn's cached result instead of firing a duplicate turn (safe retry-after-timeout)
- started + error_code response fields (the retry discriminator)
- configurable bind (default STAYS 127.0.0.1; a non-loopback bind is fail-closed — refused without a runner token, so the code-execution endpoint can never be exposed unauthenticated)
- optional capability body field brokered to a mode-0600 cwd file; the turn message references the path (never the value); deleted at turn end
- session_id validated before building any tmux target / fs path
- agy + opencode launch profiles (antigravity kept as a deprecated alias)

Dockerfile: chown -R agent $AGENT_HOME so a named/PV home volume's copy-up inherits agent ownership — otherwise root-owned ~/.cache etc. survive copy-up and s6 cont-init (running as the agent UID) fails to mkdir under them, so the container exits before booting.

Tests: 7 new; full suite 54 passed. README documents /v1, auth, bind, capability.