### PR TITLE
fix(motd): codex login hint is the headless device flow

### DIFF
--- a/multi-agent-shell/README.md
+++ b/multi-agent-shell/README.md
@@ -29,7 +29,7 @@ exception — it has no self-update and is refreshed by image rebuild (see note)
 | Harness | Bootstrap | Auth command | Credential file (on PV) | Update command |
 |---|---|---|---|---|
 | `claude` | `npm i -g @anthropic-ai/claude-code` (inherited from `agent-base`) | `claude login` | `~/.claude/.credentials.json` | `claude update` |
-| `codex` | `npm i -g @openai/codex@${CODEX_VERSION}` | `codex login` | `~/.config/codex/auth.json` | `codex update` (or inventory `harnesses: codex: <ver>`) |
+| `codex` | `npm i -g @openai/codex@${CODEX_VERSION}` | `codex login --device-auth` | `~/.config/codex/auth.json` | `codex update` (or inventory `harnesses: codex: <ver>`) |
 | `agy` (antigravity) | `curl -fsSL …/install.sh \| bash -s -- --dir /usr/local/bin` (replaces gemini CLI) | `agy` (first run prompts the OAuth flow) | `~/.gemini/antigravity-cli/antigravity-oauth-token` | **image rebuild** (no self-update; not inventory-managed) |
 | `opencode` | `npm i -g opencode-ai@${OPENCODE_VERSION}` | `opencode auth login` | `~/.local/share/opencode/auth.json` | inventory `harnesses: opencode: <ver>` |
 

--- a/multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh
+++ b/multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh
@@ -32,6 +32,9 @@ check() {
 # (confirmed 2026-06-15 by completing a real login in this image — a plain file,
 # not an OS-keyring entry, so this presence check works on a headless pod).
 check claude   .claude/.credentials.json
-check codex    .config/codex/auth.json
+# codex: plain `codex login` starts a browser-based LOCAL login server
+# (localhost:1455) that is useless on a headless pod/container — the device flow
+# is the correct headless path (codex prints this hint itself on failure).
+check codex    .config/codex/auth.json   "codex login --device-auth"
 check agy      .gemini/antigravity-cli/antigravity-oauth-token   agy
 check opencode .local/share/opencode/auth.json                   "opencode auth login"

--- a/multi-agent-shell/tests/test_motd.bats
+++ b/multi-agent-shell/tests/test_motd.bats
@@ -27,6 +27,13 @@ teardown() { rm -rf "$TMP_HOME"; }
   [[ "$output" != *"run: agy login"* ]]
 }
 
+@test "codex hint is the headless device flow, not the browser login server" {
+  run bash "$MOTD"
+  [ "$status" -eq 0 ]
+  # plain 'codex login' spins a localhost login server useless on a headless pod.
+  [[ "$output" == *"run: codex login --device-auth"* ]]
+}
+
 @test "claude creds present: shows ✓ for claude only" {
   mkdir -p "$TMP_HOME/.claude"
   echo '{}' > "$TMP_HOME/.claude/credentials.json"


### PR DESCRIPTION
The multi-agent-shell auth-status MOTD told an unauthenticated operator to run `codex login` — which starts a browser-based **local** login server (`localhost:1455`) that can't work on a headless pod/container. codex itself prints "On a remote or headless machine? Use `codex login --device-auth` instead." on failure.

Point the MOTD hint (and the README login-command column) at `codex login --device-auth`. Adds a `test_motd.bats` case asserting the device-flow hint (mirrors the existing agy-hint test). The `agy`/`opencode`/`claude` hints are unchanged.