### PR TITLE
fix(motd): codex auth lives at ~/.codex, not ~/.config/codex

### DIFF
--- a/multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh
+++ b/multi-agent-shell/rootfs/etc/profile.d/50-multi-agent-shell-motd.sh
@@ -35,6 +35,8 @@ check claude   .claude/.credentials.json
 # codex: plain `codex login` starts a browser-based LOCAL login server
 # (localhost:1455) that is useless on a headless pod/container — the device flow
 # is the correct headless path (codex prints this hint itself on failure).
-check codex    .config/codex/auth.json   "codex login --device-auth"
+# Creds live at CODEX_HOME (default ~/.codex/auth.json), NOT ~/.config/codex —
+# the old path silently reported an authenticated codex as "not logged in".
+check codex    .codex/auth.json          "codex login --device-auth"
 check agy      .gemini/antigravity-cli/antigravity-oauth-token   agy
 check opencode .local/share/opencode/auth.json                   "opencode auth login"

--- a/multi-agent-shell/tests/test_motd.bats
+++ b/multi-agent-shell/tests/test_motd.bats
@@ -43,6 +43,16 @@ teardown() { rm -rf "$TMP_HOME"; }
   [[ "$output" == *"✗ codex"* ]]
 }
 
+@test "codex creds present at ~/.codex/auth.json: shows ✓ for codex" {
+  # Regression guard: codex writes CODEX_HOME (~/.codex), not ~/.config/codex.
+  # The old path made an authenticated codex read as "not logged in".
+  mkdir -p "$TMP_HOME/.codex"
+  echo '{}' > "$TMP_HOME/.codex/auth.json"
+  run bash "$MOTD"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"✓ codex"* ]]
+}
+
 @test "agy creds present: shows ✓ for agy" {
   mkdir -p "$TMP_HOME/.gemini/antigravity-cli"
   echo 'token' > "$TMP_HOME/.gemini/antigravity-cli/antigravity-oauth-token"


### PR DESCRIPTION
## Bug
The MOTD auth-status detector reported an **authenticated codex** as `✗ codex not logged in`.

## Cause
It presence-checked `~/.config/codex/auth.json`, but the codex CLI writes **CODEX_HOME** (default `~/.codex/auth.json`). The check never matched.

## Fix
- `check codex .codex/auth.json` (device-auth hint preserved).
- New bats regression guard: codex creds present at `~/.codex/auth.json` → `✓ codex` (fails on the old path, passes on the new).

## Verified
`HOME` with `~/.codex/auth.json` → `✓ codex`; the old `~/.config/codex` path no longer matches.

Consumers that mirror this detector (node-local auth probes) should match the same path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)