### PR TITLE
feat(harness): npm global prefix on the PV so self-updates work as the agent user

### DIFF
--- a/multi-agent-shell/README.md
+++ b/multi-agent-shell/README.md
@@ -26,10 +26,18 @@ lands on the PV. For the npm harnesses, updates flow via `<h> update` (CLI
 self-update) or the inventory `harnesses:` key on each reconcile; `agy` is the
 exception — it has no self-update and is refreshed by image rebuild (see note).
 
+The npm harnesses self-update by running `npm install -g` under the hood.
+`NPM_CONFIG_PREFIX` is pinned to `$HOME/.local` (login env,
+`rootfs/etc/profile.d/40-multi-agent-shell-paths.sh`) so those installs land on
+the **PV-resident, agent-owned** `~/.local` (PATH-preferred over the `/usr`
+bootstrap) instead of failing `EACCES` against the root-owned global prefix.
+The self-updated build then persists across restarts and image bumps — the
+`/usr` install is only the offline first-boot bootstrap.
+
 | Harness | Bootstrap | Auth command | Credential file (on PV) | Update command |
 |---|---|---|---|---|
 | `claude` | `npm i -g @anthropic-ai/claude-code` (inherited from `agent-base`) | `claude login` | `~/.claude/.credentials.json` | `claude update` |
-| `codex` | `npm i -g @openai/codex@${CODEX_VERSION}` | `codex login --device-auth` | `~/.config/codex/auth.json` | `codex update` (or inventory `harnesses: codex: <ver>`) |
+| `codex` | `npm i -g @openai/codex@${CODEX_VERSION}` | `codex login --device-auth` | `~/.codex/auth.json` (CODEX_HOME) | `codex update` → `~/.local` (or inventory `harnesses: codex: <ver>`) |
 | `agy` (antigravity) | `curl -fsSL …/install.sh \| bash -s -- --dir /usr/local/bin` (replaces gemini CLI) | `agy` (first run prompts the OAuth flow) | `~/.gemini/antigravity-cli/antigravity-oauth-token` | **image rebuild** (no self-update; not inventory-managed) |
 | `opencode` | `npm i -g opencode-ai@${OPENCODE_VERSION}` | `opencode auth login` | `~/.local/share/opencode/auth.json` | inventory `harnesses: opencode: <ver>` |
 

--- a/multi-agent-shell/rootfs/etc/profile.d/40-multi-agent-shell-paths.sh
+++ b/multi-agent-shell/rootfs/etc/profile.d/40-multi-agent-shell-paths.sh
@@ -22,3 +22,15 @@ case ":$PATH:" in
 esac
 
 export PATH
+
+# Point npm's global prefix at the PV-resident, agent-owned ~/.local so a
+# harness self-update (`npm install -g @openai/codex` / `opencode-ai`, the
+# mechanism the Dockerfile bootstrap documents) writes to the writable home
+# volume instead of the root-owned /usr default. Without it the update dies
+# `EACCES: permission denied, rename '/usr/lib/node_modules/@openai/codex'` and
+# the harness is stuck at the baked pin. ~/.local/bin is PATH-preferred above,
+# so the self-updated build shadows the /usr bootstrap; the update persists on
+# the PV across restarts and image bumps. Set only when unset so an operator's
+# explicit ~/.npmrc prefix still wins.
+: "${NPM_CONFIG_PREFIX:=$HOME/.local}"
+export NPM_CONFIG_PREFIX

--- a/multi-agent-shell/tests/test_paths.bats
+++ b/multi-agent-shell/tests/test_paths.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+# Tests the login-env drop-in that wires PATH + the npm global prefix for the
+# operator's interactive shell (rootfs/etc/profile.d/40-multi-agent-shell-paths.sh).
+
+setup() {
+  export TMP_HOME="$(mktemp -d)"
+  export HOME="$TMP_HOME"
+  PATHS="$(realpath rootfs/etc/profile.d/40-multi-agent-shell-paths.sh)"
+}
+
+teardown() { rm -rf "$TMP_HOME"; }
+
+@test "npm global prefix points at the PV-resident ~/.local" {
+  # A harness self-update (`npm install -g @openai/codex`) must land on the
+  # agent-writable home volume, not the root-owned /usr default (EACCES).
+  unset NPM_CONFIG_PREFIX
+  run bash -c "PATH=/usr/bin:/bin; . '$PATHS'; printf '%s' \"\$NPM_CONFIG_PREFIX\""
+  [ "$status" -eq 0 ]
+  [ "$output" = "$TMP_HOME/.local" ]
+}
+
+@test "an operator's explicit NPM_CONFIG_PREFIX is respected (not clobbered)" {
+  run bash -c "PATH=/usr/bin:/bin; export NPM_CONFIG_PREFIX=/custom/prefix; . '$PATHS'; printf '%s' \"\$NPM_CONFIG_PREFIX\""
+  [ "$status" -eq 0 ]
+  [ "$output" = "/custom/prefix" ]
+}
+
+@test "~/.local/bin is PATH-preferred (self-updated build shadows the /usr bootstrap)" {
+  run bash -c "PATH=/usr/bin:/bin; . '$PATHS'; printf '%s' \"\$PATH\""
+  [ "$status" -eq 0 ]
+  # ~/.local/bin must appear before /usr/bin
+  [[ "$output" == "$TMP_HOME/.local/bin:"* ]]
+}


### PR DESCRIPTION
## Problem
An npm harness self-update (codex/opencode run `npm install -g` under the hood) fails for the non-root agent user:

```
npm error code EACCES
npm error  rename '/usr/lib/node_modules/@openai/codex' -> '/usr/lib/node_modules/@openai/.codex-XXXX'
Error: `npm install -g @openai/codex` failed with status 243
```

The Dockerfile bootstrap already **documents** that codex/opencode self-update into `$HOME/.local/bin` — but nothing pointed npm's global prefix there, so the update targeted the root-owned `/usr` default and died. The harness is then stuck at the baked pin.

## The proper mechanism (formulated)
Harness binaries are **self-updating CLIs**; per the multi-harness-shells standard, self-updated CLIs live on the **home PV**. Point npm's global prefix at the PV-resident, agent-owned `~/.local`:

- `NPM_CONFIG_PREFIX=$HOME/.local` in the login env (`40-multi-agent-shell-paths.sh`), **set-if-unset** so an operator's explicit `~/.npmrc` still wins.
- `~/.local/bin` is already PATH-preferred, so the self-updated build **shadows** the `/usr` bootstrap.
- The update **persists on the PV** across restarts and image bumps; `/usr` becomes an offline first-boot seed.
- **No PV migration** — it's login env, so existing and new volumes are covered.

Images change slowly; harnesses update often — this lets the fast-moving part live on the volume. (A future medium-term step could split into per-harness ephemeral images auto-rebuilt on release.)

## Also
Corrects the README harness table: codex creds are `~/.codex/auth.json` (CODEX_HOME), not `~/.config/codex`; documents the npm-prefix update path.

## Tests
`tests/test_paths.bats`: prefix resolves to `~/.local`, operator override respected, `~/.local/bin` PATH-preferred. Validated by sourcing the drop-in (unset → `~/.local`; `/custom/prefix` override honored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)