### PR TITLE
fix(agent-session): start the harness session in HOME, not the s6 scandir

### DIFF
--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
@@ -206,7 +206,15 @@ def ensure_session(session_id, agent=DEFAULT_AGENT):
 
 def _create_session(session_id, agent):
     pretrust()
-    tmux("new-session", "-d", "-s", session_id, launch_command(agent, session_id))
+    # Start the session in HOME (-c). Without it the session inherits the tmux
+    # server's cwd, which under s6 is the service scandir
+    # (/run/s6/legacy-services/agent-session-server) — NOT a real workspace. The
+    # harness then resolves the per-turn output-file path against that scandir and
+    # the completion JSON never lands at OUT_DIR (HOME/.agent-session/out), so the
+    # driver's poll never sees it and EVERY turn times out (turn=0, started=True).
+    # It also mismatches pretrust()'s trusted project (HOME). Verified: launching
+    # with -c HOME lands the completion file; without it, it never appears.
+    tmux("new-session", "-d", "-c", HOME, "-s", session_id, launch_command(agent, session_id))
     # Cold-start gate: a just-launched REPL is not yet accepting input (the pane
     # is empty for several seconds). Block until it is, so the first submit's
     # Enter is not dropped. CAVEAT: under the threaded server a SECOND send for

--- a/multi-agent-shell/tests/test_agent_session.py
+++ b/multi-agent-shell/tests/test_agent_session.py
@@ -253,9 +253,12 @@ def test_deprecated_stoa_aliases_still_drive(tmp_path):
 @pytest.mark.parametrize("agent,expected_tokens", [
     # claude embeds a per-session --session-id uuid (Fix E); codex/antigravity
     # profiles are unchanged. Token-list assertion tolerates the injected uuid.
-    ("claude", ["claude", "--session-id", "--permission-mode auto"]),
-    ("codex", ["codex --full-auto"]),
-    ("antigravity", ["agy --yolo"]),
+    # `-c` guards the session-cwd fix: the session must start in HOME, not the
+    # inherited s6 service scandir, or the harness writes its completion file
+    # where the driver never polls and every turn times out (turn=0).
+    ("claude", ["-c", "claude", "--session-id", "--permission-mode auto"]),
+    ("codex", ["-c", "codex --full-auto"]),
+    ("antigravity", ["-c", "agy --yolo"]),
 ])
 def test_per_agent_launch_profile(harness, agent, expected_tokens):
     # ensure_session dispatches on the `agent` field via the launch-profile


### PR DESCRIPTION
## Bug
Every `agent-session` turn timed out (`status:timeout, turn:0, started:true`) even though the harness ran fine — it received the message, did the work, and its Write tool reported writing the completion JSON. But the file **never appeared** at the driver's poll path (`HOME/.agent-session/out/<session>.<nonce>.json`) — nor anywhere on the filesystem — so the completion signal never fired and the run failed. A caller that retries a pre-start rejection then re-dispatches, spawning session after session.

## Root cause
`_create_session` ran `tmux new-session` **without `-c`**, so the session inherited the tmux server's cwd. Under s6 (this image's `agent-session-server` longrun) that cwd is the **service scandir** `/run/s6/legacy-services/agent-session-server`, not a real workspace. The harness resolved its per-turn output-file path against that scandir, so the JSON landed somewhere the driver never polls; it also mismatched `pretrust()`'s trusted project (`HOME`).

## Fix
`tmux new-session -d -c HOME …` — start the session in `HOME`.

## Verified live
Launching a claude session **with** `-c HOME` + the same completion instruction → the JSON lands at `HOME/.agent-session/out/…` (`{"status": "DONE"}`) and the turn returns `ok`. **Without** it, the file never appears and the turn times out. The scandir cwd was confirmed via `/proc/<pid>/cwd`.

Test guards that `new-session` carries `-c` for every launch profile (claude/codex/antigravity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)