### PR TITLE
fix(agent-session): pass PWD=HOME so the harness chdir()s home (follow-up to #149)

### DIFF
--- a/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
+++ b/multi-agent-shell/rootfs/usr/local/lib/multi-agent-shell/agent-session
@@ -206,15 +206,24 @@ def ensure_session(session_id, agent=DEFAULT_AGENT):
 
 def _create_session(session_id, agent):
     pretrust()
-    # Start the session in HOME (-c). Without it the session inherits the tmux
-    # server's cwd, which under s6 is the service scandir
-    # (/run/s6/legacy-services/agent-session-server) — NOT a real workspace. The
-    # harness then resolves the per-turn output-file path against that scandir and
-    # the completion JSON never lands at OUT_DIR (HOME/.agent-session/out), so the
-    # driver's poll never sees it and EVERY turn times out (turn=0, started=True).
-    # It also mismatches pretrust()'s trusted project (HOME). Verified: launching
-    # with -c HOME lands the completion file; without it, it never appears.
-    tmux("new-session", "-d", "-c", HOME, "-s", session_id, launch_command(agent, session_id))
+    # Start the session in HOME, with a matching PWD in its environment.
+    #
+    #   -c HOME sets the pane's working directory, but the harness reads $PWD and
+    #   chdir()s to it — and $PWD is inherited from THIS process, the s6
+    #   agent-session-server longrun, whose PWD is the service scandir
+    #   (/run/s6/legacy-services/agent-session-server), NOT a workspace. So with
+    #   only -c the pane cwd is HOME yet claude's own cwd is the scandir; it then
+    #   resolves the per-turn output-file path there and the completion JSON never
+    #   lands at OUT_DIR (HOME/.agent-session/out). The driver's poll never sees
+    #   it and EVERY turn times out (turn=0, started=True). It also mismatches
+    #   pretrust()'s trusted project (HOME).
+    #
+    #   -e PWD=HOME overrides the inherited scandir PWD for the session, so the
+    #   harness chdir()s to HOME. Verified live (default socket, polluted PWD):
+    #   -c HOME + -e PWD=HOME → claude cwd = HOME and the completion file lands;
+    #   -c HOME alone → claude cwd = the scandir and the file never appears.
+    tmux("new-session", "-d", "-c", HOME, "-e", "PWD=" + HOME,
+         "-s", session_id, launch_command(agent, session_id))
     # Cold-start gate: a just-launched REPL is not yet accepting input (the pane
     # is empty for several seconds). Block until it is, so the first submit's
     # Enter is not dropped. CAVEAT: under the threaded server a SECOND send for

--- a/multi-agent-shell/tests/test_agent_session.py
+++ b/multi-agent-shell/tests/test_agent_session.py
@@ -253,12 +253,13 @@ def test_deprecated_stoa_aliases_still_drive(tmp_path):
 @pytest.mark.parametrize("agent,expected_tokens", [
     # claude embeds a per-session --session-id uuid (Fix E); codex/antigravity
     # profiles are unchanged. Token-list assertion tolerates the injected uuid.
-    # `-c` guards the session-cwd fix: the session must start in HOME, not the
-    # inherited s6 service scandir, or the harness writes its completion file
-    # where the driver never polls and every turn times out (turn=0).
-    ("claude", ["-c", "claude", "--session-id", "--permission-mode auto"]),
-    ("codex", ["-c", "codex --full-auto"]),
-    ("antigravity", ["-c", "agy --yolo"]),
+    # `-c` + `-e PWD=` guard the session-cwd fix: the session must start in HOME
+    # AND carry PWD=HOME, or the harness (which chdir()s to $PWD, inherited as the
+    # s6 service scandir) writes its completion file where the driver never polls
+    # and every turn times out (turn=0).
+    ("claude", ["-c", "-e", "PWD=", "claude", "--session-id", "--permission-mode auto"]),
+    ("codex", ["-c", "-e", "PWD=", "codex --full-auto"]),
+    ("antigravity", ["-c", "-e", "PWD=", "agy --yolo"]),
 ])
 def test_per_agent_launch_profile(harness, agent, expected_tokens):
     # ensure_session dispatches on the `agent` field via the launch-profile


### PR DESCRIPTION
## Why a follow-up
#149 added `-c HOME` to `new-session`, which sets the **pane's** cwd. But the harness (claude) reads **$PWD** and `chdir()`s to it — and $PWD is inherited from the s6 `agent-session-server` longrun, whose PWD is the service scandir `/run/s6/legacy-services/agent-session-server`. So with `-c` alone the pane cwd is HOME, yet claude's **own** cwd is the scandir: it resolves the per-turn output-file path there, the completion JSON never lands at `OUT_DIR` (`HOME/.agent-session/out`), the driver's poll never sees it, and every turn **still** times out (`turn=0`).

## Fix
Add `-e PWD=HOME` to `new-session` so the session environment carries the right PWD; the harness then `chdir()`s to HOME.

## Verified live
On the node's default tmux socket, with $PWD polluted to the scandir exactly like the real server:
- `-c HOME` + `-e PWD=HOME` → claude cwd = HOME, completion file lands (`{"pwd":"/home/agent"}`) ✅
- `-c HOME` alone → claude cwd = scandir, file never appears ❌

Test guards both `-c` and `-e PWD=` for every launch profile.

> Alternative root fix considered: `cd $HOME` in the s6 run script (fixes the server's PWD for all children). The `-e PWD` approach is self-contained in the driver and directly test-covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)