### PR TITLE
fix(agent-session): run the server from HOME so tmux sessions land in HOME (root fix)

### DIFF
--- a/multi-agent-shell/rootfs/etc/services.d/agent-session-server/run
+++ b/multi-agent-shell/rootfs/etc/services.d/agent-session-server/run
@@ -13,6 +13,16 @@
 # Gated on AGENT_SESSION_SERVE=1 — DEFAULT OFF. A plain interactive shell is
 # unaffected; consumers (n8n, the alert-agent) opt in by setting the env var.
 if [ "${AGENT_SESSION_SERVE:-0}" = 1 ]; then
+  # Run the server from HOME, not the s6 service scandir it inherits as cwd
+  # (/run/s6/legacy-services/agent-session-server). The FIRST session the driver
+  # opens starts the tmux SERVER as a child of this process, so the tmux server —
+  # and hence the harness pane it spawns — inherits THIS cwd. Left at the scandir
+  # the harness (claude) runs there and resolves its per-turn output-file path
+  # against it, so the completion JSON never lands at OUT_DIR (HOME/.agent-session
+  # /out) and every turn times out. (new-session's -c/-e set the pane cwd/env but
+  # not the tmux server's, so they can't fix the first pane — the server cwd is
+  # the root.) cd HOME here fixes it for every session the server ever opens.
+  cd "$HOME" || cd / || true
   # Pre-trust the workspace in ~/.claude.json so claude never blocks on the
   # folder-trust gate before the session is driven (matches the driver's
   # pretrust(); belt-and-suspenders here, before serve binds).


### PR DESCRIPTION
## The actual root cause behind #149 and #150
Those addressed the tmux **pane** cwd (`-c HOME`) and **session** env (`-e PWD=HOME`) — but the **first pane inherits the tmux SERVER's** cwd/env, which neither touches.

The `agent-session-server` is an s6 longrun; its cwd is the service scandir `/run/s6/legacy-services/agent-session-server`. The first `/v1/session/send` opens a tmux session, which starts the **tmux server as a child of this process** — so the tmux server, and every harness pane it spawns, inherits the scandir cwd. The harness (claude) then runs in the scandir and resolves its per-turn output-file path there, so the completion JSON never lands at `OUT_DIR` (`HOME/.agent-session/out`) and **every turn times out** (`turn=0`).

## Fix
`cd "$HOME"` before `exec agent-session serve`, so the tmux server — and all harness panes — start in HOME.

## Verified live
- tmux server started from cwd HOME → claude cwd = HOME, completion file **lands** (`{"status":"done"}`).
- started from the scandir → file never appears, **regardless** of `-c`/`-e` on new-session (session PWD showed HOME via `-e`, but claude's own PWD/cwd stayed the scandir).

This supersedes the need for #149/#150 (harmless to keep as belt-and-suspenders). With this merged, agent-session turns complete end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)